### PR TITLE
fix(ci-security): pin docker GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/docker-hub-publish.yml
+++ b/.github/workflows/docker-hub-publish.yml
@@ -94,7 +94,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Validate Docker Hub secrets
         shell: bash
@@ -109,7 +109,7 @@ jobs:
           fi
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -177,7 +177,7 @@ jobs:
           printf '  - %s\n' "${uniq_tags[@]}"
 
       - name: Build and push ${{ matrix.component }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: .
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -95,10 +95,10 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -165,7 +165,7 @@ jobs:
           printf '  - %s\n' "${uniq_tags[@]}"
 
       - name: Build and push ${{ matrix.component }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: .
           file: ${{ matrix.dockerfile }}


### PR DESCRIPTION
Hotfix CI/Sonar: pinning docker GitHub Actions to full commit SHAs in docker workflows.