### PR TITLE
PR 199: audyt podejrzeń martwego kodu (heurystyka + vulture)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -79,7 +79,7 @@ jobs:
           make architecture-sonar-export
 
       - name: Upload architecture summary artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: sonar-architecture-summary
           path: test-results/sonar/architecture-summary.json
@@ -100,7 +100,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -156,11 +156,13 @@ jobs:
             NEW_CODE_COVERAGE_MIN=0 \
             NEW_CODE_CHANGED_LINES_MIN=80 \
             NEW_CODE_TIME_BUDGET_SEC=0 \
+            NEW_CODE_EXCLUDE_SLOW_FASTLANE=0 \
+            NEW_CODE_MAX_TESTS=0 \
             NEW_CODE_DIFF_BASE="${DIFF_BASE}" \
           | tee test-results/sonar/backend-lite.log
 
       - name: Upload backend Sonar artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: sonar-backend-reports
           path: test-results/sonar/**
@@ -178,7 +180,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20.19.0"
           cache: npm
@@ -208,7 +210,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -219,7 +221,7 @@ jobs:
           pip install -r requirements-ci-lite.txt
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20.19.0"
 
@@ -233,7 +235,7 @@ jobs:
           npx --yes openapi-typescript@7.10.1 test-results/openapi/openapi.json -o test-results/openapi/api-types.d.ts
 
       - name: Upload OpenAPI contract artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: openapi-contract
           path: test-results/openapi/**
@@ -256,7 +258,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download backend Sonar artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: sonar-backend-reports
           path: test-results/sonar

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,12 +21,12 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: "npm"

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -14,8 +14,8 @@ jobs:
       CI: "true"
       PYTHONUNBUFFERED: "1"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install dependencies
@@ -36,8 +36,8 @@ jobs:
     env:
       CI: "true"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "20.19.0"
           cache: "npm"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip

--- a/.github/workflows/quick-validate.yml
+++ b/.github/workflows/quick-validate.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/security-delta-nightly.yml
+++ b/.github/workflows/security-delta-nightly.yml
@@ -27,13 +27,13 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20.19.0"
           cache: npm
@@ -52,7 +52,7 @@ jobs:
         run: make security-delta-scan
 
       - name: Upload security delta artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: security-delta-latest
           path: logs/security-delta-latest.json

--- a/.github/workflows/web-next-turbopack-smoke.yml
+++ b/.github/workflows/web-next-turbopack-smoke.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "20.19.0"
           cache: npm

--- a/config/pytest-groups/sonar-new-code.txt
+++ b/config/pytest-groups/sonar-new-code.txt
@@ -134,6 +134,7 @@ tests/test_model_registry_clients.py
 tests/test_model_registry_clients_additional.py
 tests/test_model_registry_providers.py
 tests/test_model_registry_split_modules.py
+tests/test_model_requests.py
 tests/test_model_router.py
 tests/test_model_services.py
 tests/test_model_validators.py

--- a/config/pytest-groups/sonar-new-code.txt
+++ b/config/pytest-groups/sonar-new-code.txt
@@ -108,6 +108,7 @@ tests/test_llm_runtime_stability_audit.py
 tests/test_llm_runtime_utils.py
 tests/test_llm_server_controller.py
 tests/test_llm_server_selection.py
+tests/test_llm_simple_logic.py
 tests/test_llm_simple_payload_service.py
 tests/test_llm_simple_route_model_resolution.py
 tests/test_logger_utils.py
@@ -225,6 +226,7 @@ tests/test_test_skill.py
 tests/test_test_skill_local.py
 tests/test_training_metrics_parser.py
 tests/test_translation_service.py
+tests/test_update_sonar_scope_group.py
 tests/test_ux_analyst.py
 tests/test_workflow_control_api.py
 tests/test_workflow_control_contract.py

--- a/config/testing/test_catalog.json
+++ b/config/testing/test_catalog.json
@@ -3399,12 +3399,14 @@
       "domain": "models",
       "test_type": "unit",
       "intent": "regression",
-      "primary_lane": "release",
+      "primary_lane": "new-code",
       "allowed_lanes": [
+        "new-code",
+        "ci-lite",
         "release"
       ],
       "legacy_targeted": false,
-      "rationale": "Default release-lane regression coverage."
+      "rationale": "Fast-safe unit coverage for model request schema/regression in changed scope."
     },
     {
       "path": "tests/test_model_router.py",

--- a/config/testing/test_catalog.json
+++ b/config/testing/test_catalog.json
@@ -2926,12 +2926,14 @@
       "domain": "runtime",
       "test_type": "route_contract",
       "intent": "contract",
-      "primary_lane": "release",
+      "primary_lane": "new-code",
       "allowed_lanes": [
+        "new-code",
+        "ci-lite",
         "release"
       ],
       "legacy_targeted": false,
-      "rationale": "Default release-lane regression coverage."
+      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
     },
     {
       "path": "tests/test_llm_simple_payload_service.py",
@@ -5402,12 +5404,14 @@
       "domain": "testing_tooling",
       "test_type": "unit",
       "intent": "regression",
-      "primary_lane": "release",
+      "primary_lane": "new-code",
       "allowed_lanes": [
+        "new-code",
+        "ci-lite",
         "release"
       ],
       "legacy_targeted": false,
-      "rationale": "Default release-lane regression coverage."
+      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
     },
     {
       "path": "tests/test_url_policy.py",

--- a/docs/PL/TESTING_POLICY.md
+++ b/docs/PL/TESTING_POLICY.md
@@ -396,6 +396,23 @@ Kontrakt środowiska dla narzędzi:
 6. Dla wyjątków specyficznych dla vulture używaj `config/dead_code_vulture_allowlist.txt` (`path.py:symbol`, `dir/*:symbol` albo `path.py:line`).
 7. `make audit-dead-code-full` jest narzędziem manualnym operatora; nie jest domyślną bramką CI.
 
+### Matryca komend audytu dead-code
+
+Ta matryca rozróżnia ścieżkę heurystyczną od ścieżki vulture.
+
+| Komenda | Ścieżka skryptu | Heurystyka | Vulture | Hard gate CI |
+| --- | --- | --- | --- | --- |
+| `make audit-dead-code` | `scripts/dev/dead_code_audit.py` | Tak | Nie | Nie |
+| `make audit-dead-code-vulture-install` | instalacja pip w `.venv` (`vulture==2.14`) | Nie | Nie | Nie |
+| `make audit-dead-code-full` | `scripts/dev/dead_code_audit.py --with-vulture` | Tak | Tak | Nie |
+
+Dodatkowe zasady:
+- uruchamiaj z repozytoryjnego virtualenv: `source .venv/bin/activate`
+- brak globalnej instalacji pakietów Pythona
+- allowlisty:
+  - heurystyka: `config/dead_code_allowlist.txt`
+  - vulture: `config/dead_code_vulture_allowlist.txt`
+
 ## Polityka artefaktów testowych
 
 Nie commitujemy artefaktów wyników testów.

--- a/docs/TESTING_POLICY.md
+++ b/docs/TESTING_POLICY.md
@@ -373,6 +373,23 @@ Runtime contract for tools:
 6. For vulture-specific exceptions use `config/dead_code_vulture_allowlist.txt` (`path.py:symbol`, `dir/*:symbol`, or `path.py:line`).
 7. `make audit-dead-code-full` is an operator manual tool; it is not a default CI hard gate.
 
+### Dead-Code Audit Command Matrix
+
+Use this matrix to avoid ambiguity between heuristic and vulture paths.
+
+| Command | Script path | Heuristic findings | Vulture findings | CI hard gate |
+| --- | --- | --- | --- | --- |
+| `make audit-dead-code` | `scripts/dev/dead_code_audit.py` | Yes | No | No |
+| `make audit-dead-code-vulture-install` | `.venv` pip install (`vulture==2.14`) | No | No | No |
+| `make audit-dead-code-full` | `scripts/dev/dead_code_audit.py --with-vulture` | Yes | Yes | No |
+
+Additional notes:
+- run from repo virtualenv: `source .venv/bin/activate`
+- no global Python package installation
+- allowlists:
+  - heuristic: `config/dead_code_allowlist.txt`
+  - vulture: `config/dead_code_vulture_allowlist.txt`
+
 ## Test Artifacts Policy
 
 Do not commit test output artifacts.

--- a/scripts/update_sonar_new_code_group.py
+++ b/scripts/update_sonar_new_code_group.py
@@ -103,13 +103,6 @@ def _render_group(manual_lines: list[str], auto_entries: list[str]) -> str:
     return "\n".join(out).rstrip() + "\n"
 
 
-def _append_auto_items(path: Path, new_items: list[str]) -> None:
-    lines = path.read_text(encoding="utf-8").splitlines() if path.exists() else []
-    manual_lines, auto_entries = _split_auto_section(lines)
-    merged = _dedupe_keep_order(auto_entries + new_items)
-    path.write_text(_render_group(manual_lines, merged), encoding="utf-8")
-
-
 def _sleep_total_seconds(path: str) -> float:
     file_path = Path(path)
     if not file_path.exists():

--- a/tests/test_academy_api_dataset_edge_cases.py
+++ b/tests/test_academy_api_dataset_edge_cases.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from venom_core.api.routes import academy as academy_routes
+from venom_core.api.routes import academy_storage, academy_uploads
 
 # ==================== Ingest File Edge Cases ====================
 
@@ -199,43 +200,41 @@ def test_ingest_markdown_with_odd_sections(tmp_path):
 
 def test_validate_training_record_missing_fields():
     """Test walidacji rekordu bez wymaganych pól"""
-    from venom_core.api.routes.academy import _validate_training_record
-
     # Brak instruction
-    assert not _validate_training_record({"input": "", "output": "test output here"})
+    assert not academy_uploads.validate_training_record(
+        {"input": "", "output": "test output here"}
+    )
 
     # Brak output
-    assert not _validate_training_record(
+    assert not academy_uploads.validate_training_record(
         {"instruction": "test instruction", "input": ""}
     )
 
     # Puste instruction
-    assert not _validate_training_record(
+    assert not academy_uploads.validate_training_record(
         {"instruction": "", "input": "", "output": "test output here"}
     )
 
     # Puste output
-    assert not _validate_training_record(
+    assert not academy_uploads.validate_training_record(
         {"instruction": "test instruction", "input": "", "output": ""}
     )
 
     # Too short instruction (< 10 chars)
-    assert not _validate_training_record(
+    assert not academy_uploads.validate_training_record(
         {"instruction": "short", "input": "", "output": "test output here"}
     )
 
     # Too short output (< 10 chars)
-    assert not _validate_training_record(
+    assert not academy_uploads.validate_training_record(
         {"instruction": "test instruction", "input": "", "output": "short"}
     )
 
 
 def test_validate_training_record_valid():
     """Test walidacji poprawnego rekordu"""
-    from venom_core.api.routes.academy import _validate_training_record
-
     # Poprawny rekord (obie wartości >= 10 chars)
-    result = _validate_training_record(
+    result = academy_uploads.validate_training_record(
         {
             "instruction": "test instruction here",
             "input": "",
@@ -245,7 +244,7 @@ def test_validate_training_record_valid():
     assert result is True
 
     # Z inputem
-    result = _validate_training_record(
+    result = academy_uploads.validate_training_record(
         {
             "instruction": "test instruction here",
             "input": "context info",
@@ -323,7 +322,7 @@ def test_delete_upload_metadata_cleanup_temp_on_replace_error(tmp_path):
     """Przy błędzie replace plik tymczasowy powinien zostać posprzątany."""
     with patch("venom_core.config.SETTINGS.ACADEMY_TRAINING_DIR", str(tmp_path)):
         academy_routes._save_upload_metadata({"id": "x", "name": "x"})
-        metadata_file = academy_routes._get_uploads_metadata_file()
+        metadata_file = academy_storage.get_uploads_metadata_file()
         tmp_file = metadata_file.with_suffix(".tmp")
 
         with patch("pathlib.Path.replace", side_effect=OSError("replace-fail")):

--- a/tests/test_academy_api_dataset_routes.py
+++ b/tests/test_academy_api_dataset_routes.py
@@ -1069,11 +1069,11 @@ def test_compute_bytes_hash_is_stable():
 
 def test_validate_training_record():
     """Test walidacji rekordu treningowego"""
-    from venom_core.api.routes.academy import _validate_training_record
+    from venom_core.api.routes.academy_uploads import validate_training_record
 
     # Valid record
     assert (
-        _validate_training_record(
+        validate_training_record(
             {
                 "instruction": "This is a valid instruction",
                 "input": "",
@@ -1085,7 +1085,7 @@ def test_validate_training_record():
 
     # Too short instruction
     assert (
-        _validate_training_record(
+        validate_training_record(
             {"instruction": "short", "input": "", "output": "This is a valid output"}
         )
         is False
@@ -1093,11 +1093,11 @@ def test_validate_training_record():
 
     # Too short output
     assert (
-        _validate_training_record(
+        validate_training_record(
             {"instruction": "This is a valid instruction", "input": "", "output": "x"}
         )
         is False
     )
 
     # Not a dict
-    assert _validate_training_record("not a dict") is False
+    assert validate_training_record("not a dict") is False

--- a/tests/test_academy_api_edges_contract.py
+++ b/tests/test_academy_api_edges_contract.py
@@ -11,6 +11,7 @@ from fastapi.testclient import TestClient
 
 from tests.helpers.academy_wiring import build_academy_app
 from venom_core.api.routes import academy as academy_routes
+from venom_core.api.routes import academy_storage
 
 
 def _make_client() -> TestClient:
@@ -230,8 +231,8 @@ def test_upload_helper_path_and_size_validations(mock_settings, tmp_path):
     assert academy_routes._is_path_within_base(inside, base) is True
     assert academy_routes._is_path_within_base(outside, base) is False
 
-    assert academy_routes._validate_file_size(1024) is True
-    assert academy_routes._validate_file_size(2 * 1024 * 1024) is False
+    assert academy_storage.validate_file_size(1024) is True
+    assert academy_storage.validate_file_size(2 * 1024 * 1024) is False
 
 
 def test_save_upload_metadata_propagates_write_error(tmp_path):
@@ -247,7 +248,7 @@ def test_save_upload_metadata_propagates_write_error(tmp_path):
 def test_delete_upload_metadata_noop_when_metadata_missing(tmp_path):
     with patch("venom_core.config.SETTINGS.ACADEMY_TRAINING_DIR", str(tmp_path)):
         academy_routes._delete_upload_metadata("missing-id")
-        metadata_file = academy_routes._get_uploads_metadata_file()
+        metadata_file = academy_storage.get_uploads_metadata_file()
         assert not metadata_file.exists()
 
 
@@ -259,7 +260,7 @@ def test_upload_metadata_helpers_and_hashes_roundtrip(tmp_path):
     upload_path.write_bytes(payload)
 
     with patch("venom_core.config.SETTINGS.ACADEMY_TRAINING_DIR", str(tmp_path)):
-        hash_from_file = academy_routes._compute_file_hash(upload_path)
+        hash_from_file = academy_storage.compute_file_hash(upload_path)
         hash_from_bytes = academy_routes._compute_bytes_hash(payload)
         assert hash_from_file == hash_from_bytes
 

--- a/tests/test_llm_simple_logic.py
+++ b/tests/test_llm_simple_logic.py
@@ -264,7 +264,9 @@ async def test_iter_stream_contents_parses_and_stops_on_done():
             'data: {"choices":[{"delta":{"content":"B"}}]}',
         ]
     )
-    chunks = [c async for c in llm_simple_routes._iter_stream_contents(resp)]
+    chunks: list[str] = []
+    async for packet in llm_simple_routes._iter_stream_packets(resp):
+        chunks.extend(llm_simple_routes._extract_sse_contents(packet))
     assert chunks == ["A"]
 
 

--- a/tests/test_model_requests.py
+++ b/tests/test_model_requests.py
@@ -1,6 +1,9 @@
 from pydantic import ValidationError
 
-from venom_core.api.model_schemas.model_requests import OnnxBuildRequest
+from venom_core.api.model_schemas.model_requests import (
+    ModelRegistryInstallRequest,
+    OnnxBuildRequest,
+)
 from venom_core.api.model_schemas.model_validators import validate_runtime
 
 
@@ -48,3 +51,13 @@ def test_validate_runtime_rejects_unknown_runtime():
         assert False, "expected ValueError"
     except ValueError as exc:
         assert "Runtime musi być 'vllm', 'ollama' lub 'onnx'" in str(exc)
+
+
+def test_model_registry_install_request_runs_post_init_for_huggingface():
+    req = ModelRegistryInstallRequest(
+        name="google/gemma-3-4b-it",
+        provider="huggingface",
+        runtime="vllm",
+    )
+    assert req.provider == "huggingface"
+    assert req.runtime == "vllm"

--- a/tests/test_model_requests.py
+++ b/tests/test_model_requests.py
@@ -1,3 +1,4 @@
+import pytest
 from pydantic import ValidationError
 
 from venom_core.api.model_schemas.model_requests import (
@@ -61,3 +62,31 @@ def test_model_registry_install_request_runs_post_init_for_huggingface():
     )
     assert req.provider == "huggingface"
     assert req.runtime == "vllm"
+
+
+def test_model_registry_install_request_rejects_huggingface_with_non_vllm_runtime():
+    with pytest.raises(
+        ValidationError, match="Runtime dla HuggingFace musi być 'vllm'"
+    ):
+        ModelRegistryInstallRequest(
+            name="google/gemma-3-4b-it",
+            provider="huggingface",
+            runtime="ollama",
+        )
+
+
+def test_model_registry_install_request_validates_ollama_runtime_contract():
+    req = ModelRegistryInstallRequest(
+        name="gemma2:2b",
+        provider="ollama",
+        runtime="ollama",
+    )
+    assert req.provider == "ollama"
+    assert req.runtime == "ollama"
+
+    with pytest.raises(ValidationError, match="Runtime dla Ollama musi być 'ollama'"):
+        ModelRegistryInstallRequest(
+            name="gemma2:2b",
+            provider="ollama",
+            runtime="vllm",
+        )

--- a/tests/test_update_sonar_scope_group.py
+++ b/tests/test_update_sonar_scope_group.py
@@ -20,7 +20,7 @@ def _load_module():
     return module
 
 
-def test_append_auto_items_keeps_entries_in_auto_section(tmp_path):
+def test_main_keeps_existing_auto_items_in_auto_section(monkeypatch, tmp_path):
     module = _load_module()
     group_path = tmp_path / "sonar-new-code.txt"
     group_path.write_text(
@@ -37,7 +37,16 @@ def test_append_auto_items_keeps_entries_in_auto_section(tmp_path):
         encoding="utf-8",
     )
 
-    module._append_auto_items(group_path, ["tests/test_auto2.py"])
+    monkeypatch.setattr(module, "GROUP_PATH", group_path)
+    monkeypatch.setattr(module, "_git_staged_files", lambda: ["venom_core/core/x.py"])
+
+    class Resolver:
+        def resolve_candidates_from_changed_files(self, staged):
+            return ["tests/test_auto2.py"]
+
+    monkeypatch.setattr(module, "_load_resolver_module", lambda: Resolver())
+    assert module.main([]) == 0
+
     lines = group_path.read_text(encoding="utf-8").splitlines()
 
     auto_header_idx = lines.index(module.AUTO_SECTION_HEADER)

--- a/venom_core/agents/professor.py
+++ b/venom_core/agents/professor.py
@@ -354,6 +354,7 @@ class Professor(BaseAgent):
 
         logger.info("Rozpoczynam ewaluację modelu w Arenie...")
         candidate_model = self._resolve_candidate_model(candidate_model)
+        _ = baseline_model
 
         if not candidate_model:
             return "❌ Brak nowego modelu do ewaluacji. Przeprowadź trening najpierw."

--- a/venom_core/agents/professor.py
+++ b/venom_core/agents/professor.py
@@ -354,7 +354,11 @@ class Professor(BaseAgent):
 
         logger.info("Rozpoczynam ewaluację modelu w Arenie...")
         candidate_model = self._resolve_candidate_model(candidate_model)
-        _ = baseline_model
+        if baseline_model:
+            logger.info(
+                "Dostarczono baseline_model=%s, ale aktualnie ewaluacja używa domyślnej ścieżki baseline.",
+                baseline_model,
+            )
 
         if not candidate_model:
             return "❌ Brak nowego modelu do ewaluacji. Przeprowadź trening najpierw."

--- a/venom_core/api/model_schemas/model_requests.py
+++ b/venom_core/api/model_schemas/model_requests.py
@@ -56,8 +56,9 @@ class ModelRegistryInstallRequest(BaseModel):
     def validate_runtime(cls, v):
         return validate_runtime(v)
 
-    def model_post_init(self, __context):
+    def model_post_init(self, _context):
         """Validate model name format based on provider."""
+        _ = _context
         if self.provider == "huggingface":
             validate_huggingface_model_name(self.name)
             if self.runtime != "vllm":

--- a/venom_core/api/routes/academy.py
+++ b/venom_core/api/routes/academy.py
@@ -231,10 +231,6 @@ def _get_uploads_dir() -> Path:
     return academy_storage.get_uploads_dir()
 
 
-def _get_uploads_metadata_file() -> Path:
-    return academy_storage.get_uploads_metadata_file()
-
-
 def _validate_file_extension(
     filename: str, *, allowed_extensions: list[str] | None = None
 ) -> bool:
@@ -242,10 +238,6 @@ def _validate_file_extension(
         filename,
         allowed_extensions=allowed_extensions,
     )
-
-
-def _validate_file_size(size_bytes: int) -> bool:
-    return academy_storage.validate_file_size(size_bytes)
 
 
 def _check_path_traversal(filename: str) -> bool:
@@ -262,10 +254,6 @@ def _save_upload_metadata(upload_info: Dict[str, Any]):
 
 def _delete_upload_metadata(file_id: str):
     academy_storage.delete_upload_metadata(file_id)
-
-
-def _compute_file_hash(file_path: Path) -> str:
-    return academy_storage.compute_file_hash(file_path)
 
 
 def _compute_bytes_hash(content: bytes) -> str:
@@ -849,7 +837,3 @@ async def preview_dataset(
 
 def _ingest_upload_file(curator, file_path: Path) -> int:
     return academy_uploads.ingest_upload_file(curator, file_path, logger=logger)
-
-
-def _validate_training_record(record: Dict[str, Any]) -> bool:
-    return academy_uploads.validate_training_record(record)

--- a/venom_core/api/routes/llm_simple.py
+++ b/venom_core/api/routes/llm_simple.py
@@ -384,12 +384,6 @@ async def _iter_stream_packets(resp: Any) -> AsyncIterator[dict]:
         yield packet
 
 
-async def _iter_stream_contents(resp: Any) -> AsyncIterator[str]:
-    async for packet in _iter_stream_packets(resp):
-        for content in _extract_sse_contents(packet):
-            yield content
-
-
 def _trace_first_chunk(
     request_id: UUID,
     stream_start: float,

--- a/venom_core/api/routes/memory.py
+++ b/venom_core/api/routes/memory.py
@@ -32,37 +32,10 @@ from venom_core.memory.lessons_store import LessonsStore
 from venom_core.services.config_manager import config_manager as _config_manager
 from venom_core.services.memory_graph_service import MemoryGraphPayloadOptions
 from venom_core.services.memory_graph_service import (
-    append_flow_edges as _append_flow_edges_svc,
-)
-from venom_core.services.memory_graph_service import (
     build_ingest_metadata as _build_ingest_metadata_svc,
 )
 from venom_core.services.memory_graph_service import (
-    build_memory_graph_filters as _build_memory_graph_filters_svc,
-)
-from venom_core.services.memory_graph_service import (
     build_memory_graph_payload as _build_memory_graph_payload_svc,
-)
-from venom_core.services.memory_graph_service import (
-    build_memory_node as _build_memory_node_svc,
-)
-from venom_core.services.memory_graph_service import (
-    build_relation_edges as _build_relation_edges_svc,
-)
-from venom_core.services.memory_graph_service import (
-    collect_lesson_graph as _collect_lesson_graph_svc,
-)
-from venom_core.services.memory_graph_service import (
-    ensure_session_node as _ensure_session_node_svc,
-)
-from venom_core.services.memory_graph_service import (
-    ensure_user_node as _ensure_user_node_svc,
-)
-from venom_core.services.memory_graph_service import (
-    increment_memory_view_counter as _increment_memory_view_counter_svc,
-)
-from venom_core.services.memory_graph_service import (
-    memory_view_counter_snapshot as _memory_view_counter_snapshot_svc,
 )
 from venom_core.services.memory_graph_service import (
     raise_memory_http_error as _raise_memory_http_error_svc,
@@ -120,21 +93,6 @@ def set_dependencies(
         api_deps.set_session_store(session_store)
 
 
-def _ensure_vector_store():
-    """Pomocnik do pobierania vector store (używany w testach)."""
-    from venom_core.api.dependencies import get_vector_store
-    from venom_core.memory.vector_store import VectorStore
-
-    try:
-        return get_vector_store()
-    except Exception:
-        if _vector_store:
-            return _vector_store
-        # W teście, jeśli nikt jeszcze nie ustawiał, stwórz nową instancję
-        # (EmbeddingService i tak użyje cache'u)
-        return VectorStore()
-
-
 def _require_nonempty(value: str, detail: str) -> None:
     _require_nonempty_svc(value, detail)
 
@@ -147,62 +105,8 @@ def _raise_memory_http_error(exc: Exception, *, context: str) -> None:
     _raise_memory_http_error_svc(exc, context=context, logger=logger)
 
 
-def _build_memory_graph_filters(
-    session_id: str, only_pinned: bool
-) -> dict[str, object]:
-    return _build_memory_graph_filters_svc(session_id, only_pinned)
-
-
-def _increment_memory_view_counter(view: str) -> None:
-    _increment_memory_view_counter_svc(view)
-
-
-def _memory_view_counter_snapshot() -> dict[str, int]:
-    return _memory_view_counter_snapshot_svc()
-
-
-def _build_memory_node(entry: dict[str, Any]) -> dict[str, Any]:
-    return _build_memory_node_svc(entry, default_user_id=DEFAULT_USER_ID)
-
-
 async def _resolve_maybe_await(value: Any) -> Any:
     return await _resolve_maybe_await_svc(value)
-
-
-def _ensure_session_node(
-    session_nodes: dict[str, dict[str, Any]], session_id: str | None
-) -> None:
-    _ensure_session_node_svc(session_nodes, session_id)
-
-
-def _ensure_user_node(
-    user_nodes: dict[str, dict[str, Any]], user_id: str | None
-) -> None:
-    _ensure_user_node_svc(user_nodes, user_id)
-
-
-def _build_relation_edges(
-    node_id: str, session_id: str | None, user_id: str | None
-) -> list[dict[str, Any]]:
-    return _build_relation_edges_svc(node_id, session_id, user_id)
-
-
-def _collect_lesson_graph(
-    lessons_store: LessonsStore | None, limit: int
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    return _collect_lesson_graph_svc(
-        lessons_store,
-        limit,
-        allow_fallback=is_testing_mode(),
-        logger=logger,
-        default_user_id=DEFAULT_USER_ID,
-    )
-
-
-def _append_flow_edges(
-    nodes: list[dict[str, Any]], edges: list[dict[str, Any]]
-) -> None:
-    _append_flow_edges_svc(nodes, edges)
 
 
 @router.post(

--- a/venom_core/api/routes/memory.py
+++ b/venom_core/api/routes/memory.py
@@ -32,10 +32,37 @@ from venom_core.memory.lessons_store import LessonsStore
 from venom_core.services.config_manager import config_manager as _config_manager
 from venom_core.services.memory_graph_service import MemoryGraphPayloadOptions
 from venom_core.services.memory_graph_service import (
+    append_flow_edges as _append_flow_edges_svc,
+)
+from venom_core.services.memory_graph_service import (
     build_ingest_metadata as _build_ingest_metadata_svc,
 )
 from venom_core.services.memory_graph_service import (
+    build_memory_graph_filters as _build_memory_graph_filters_svc,
+)
+from venom_core.services.memory_graph_service import (
     build_memory_graph_payload as _build_memory_graph_payload_svc,
+)
+from venom_core.services.memory_graph_service import (
+    build_memory_node as _build_memory_node_svc,
+)
+from venom_core.services.memory_graph_service import (
+    build_relation_edges as _build_relation_edges_svc,
+)
+from venom_core.services.memory_graph_service import (
+    collect_lesson_graph as _collect_lesson_graph_svc,
+)
+from venom_core.services.memory_graph_service import (
+    ensure_session_node as _ensure_session_node_svc,
+)
+from venom_core.services.memory_graph_service import (
+    ensure_user_node as _ensure_user_node_svc,
+)
+from venom_core.services.memory_graph_service import (
+    increment_memory_view_counter as _increment_memory_view_counter_svc,
+)
+from venom_core.services.memory_graph_service import (
+    memory_view_counter_snapshot as _memory_view_counter_snapshot_svc,
 )
 from venom_core.services.memory_graph_service import (
     raise_memory_http_error as _raise_memory_http_error_svc,
@@ -93,6 +120,21 @@ def set_dependencies(
         api_deps.set_session_store(session_store)
 
 
+def _ensure_vector_store():
+    """Pomocnik do pobierania vector store (używany w testach)."""
+    from venom_core.api.dependencies import get_vector_store
+    from venom_core.memory.vector_store import VectorStore
+
+    try:
+        return get_vector_store()
+    except Exception:
+        if _vector_store:
+            return _vector_store
+        # W teście, jeśli nikt jeszcze nie ustawiał, stwórz nową instancję
+        # (EmbeddingService i tak użyje cache'u)
+        return VectorStore()
+
+
 def _require_nonempty(value: str, detail: str) -> None:
     _require_nonempty_svc(value, detail)
 
@@ -105,8 +147,62 @@ def _raise_memory_http_error(exc: Exception, *, context: str) -> None:
     _raise_memory_http_error_svc(exc, context=context, logger=logger)
 
 
+def _build_memory_graph_filters(
+    session_id: str, only_pinned: bool
+) -> dict[str, object]:
+    return _build_memory_graph_filters_svc(session_id, only_pinned)
+
+
+def _increment_memory_view_counter(view: str) -> None:
+    _increment_memory_view_counter_svc(view)
+
+
+def _memory_view_counter_snapshot() -> dict[str, int]:
+    return _memory_view_counter_snapshot_svc()
+
+
+def _build_memory_node(entry: dict[str, Any]) -> dict[str, Any]:
+    return _build_memory_node_svc(entry, default_user_id=DEFAULT_USER_ID)
+
+
 async def _resolve_maybe_await(value: Any) -> Any:
     return await _resolve_maybe_await_svc(value)
+
+
+def _ensure_session_node(
+    session_nodes: dict[str, dict[str, Any]], session_id: str | None
+) -> None:
+    _ensure_session_node_svc(session_nodes, session_id)
+
+
+def _ensure_user_node(
+    user_nodes: dict[str, dict[str, Any]], user_id: str | None
+) -> None:
+    _ensure_user_node_svc(user_nodes, user_id)
+
+
+def _build_relation_edges(
+    node_id: str, session_id: str | None, user_id: str | None
+) -> list[dict[str, Any]]:
+    return _build_relation_edges_svc(node_id, session_id, user_id)
+
+
+def _collect_lesson_graph(
+    lessons_store: LessonsStore | None, limit: int
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    return _collect_lesson_graph_svc(
+        lessons_store,
+        limit,
+        allow_fallback=is_testing_mode(),
+        logger=logger,
+        default_user_id=DEFAULT_USER_ID,
+    )
+
+
+def _append_flow_edges(
+    nodes: list[dict[str, Any]], edges: list[dict[str, Any]]
+) -> None:
+    _append_flow_edges_svc(nodes, edges)
 
 
 @router.post(

--- a/venom_core/api/routes/models_remote.py
+++ b/venom_core/api/routes/models_remote.py
@@ -188,6 +188,22 @@ def _cache_put(
     remote_models_service.cache_put(cache, lock, key, payload=payload)
 
 
+def _get_openai_models_catalog_static() -> list[RemoteModelInfo]:
+    """Get static OpenAI models catalog."""
+    return [
+        RemoteModelInfo(**item)
+        for item in remote_models_service.openai_static_catalog_payload()
+    ]
+
+
+def _get_google_models_catalog_static() -> list[RemoteModelInfo]:
+    """Get static Google models catalog."""
+    return [
+        RemoteModelInfo(**item)
+        for item in remote_models_service.google_static_catalog_payload()
+    ]
+
+
 async def _fetch_openai_models_catalog_live() -> list[RemoteModelInfo]:
     models_payload = await remote_models_service.fetch_openai_models_catalog_live(
         api_key=(SETTINGS.OPENAI_API_KEY or "").strip(),

--- a/venom_core/api/routes/models_remote.py
+++ b/venom_core/api/routes/models_remote.py
@@ -188,22 +188,6 @@ def _cache_put(
     remote_models_service.cache_put(cache, lock, key, payload=payload)
 
 
-def _get_openai_models_catalog_static() -> list[RemoteModelInfo]:
-    """Get static OpenAI models catalog."""
-    return [
-        RemoteModelInfo(**item)
-        for item in remote_models_service.openai_static_catalog_payload()
-    ]
-
-
-def _get_google_models_catalog_static() -> list[RemoteModelInfo]:
-    """Get static Google models catalog."""
-    return [
-        RemoteModelInfo(**item)
-        for item in remote_models_service.google_static_catalog_payload()
-    ]
-
-
 async def _fetch_openai_models_catalog_live() -> list[RemoteModelInfo]:
     models_payload = await remote_models_service.fetch_openai_models_catalog_live(
         api_key=(SETTINGS.OPENAI_API_KEY or "").strip(),

--- a/venom_core/execution/skills/github_skill.py
+++ b/venom_core/execution/skills/github_skill.py
@@ -308,6 +308,6 @@ class GitHubSkill:
     def __enter__(self):
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, _exc_type, _exc_val, _exc_tb):
         self.close()
         return False

--- a/venom_core/execution/skills/google_calendar_skill.py
+++ b/venom_core/execution/skills/google_calendar_skill.py
@@ -392,6 +392,6 @@ class GoogleCalendarSkill:
     def __enter__(self):
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, _exc_type, _exc_val, _exc_tb):
         self.close()
         return False

--- a/venom_core/infrastructure/cloud_provisioner.py
+++ b/venom_core/infrastructure/cloud_provisioner.py
@@ -46,7 +46,7 @@ except ImportError:  # pragma: no cover - zależność opcjonalna
                 "Zainstaluj opcjonalną zależność deploymentu."
             )
 
-        async def __aexit__(self, exc_type, exc, tb):
+        async def __aexit__(self, _exc_type, _exc, _tb):
             return None
 
     def _missing_asyncssh_connect(*args, **kwargs):

--- a/venom_core/infrastructure/traffic_control/http_client.py
+++ b/venom_core/infrastructure/traffic_control/http_client.py
@@ -536,7 +536,7 @@ class TrafficControlledHttpClient:
         """Context manager."""
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, _exc_type, _exc_val, _exc_tb):
         """Context manager exit."""
         self.close()
 
@@ -544,6 +544,6 @@ class TrafficControlledHttpClient:
         """Async context manager."""
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
+    async def __aexit__(self, _exc_type, _exc_val, _exc_tb):
         """Async context manager exit."""
         await self.aclose()

--- a/venom_core/services/benchmark.py
+++ b/venom_core/services/benchmark.py
@@ -33,11 +33,6 @@ logger = get_logger(__name__)
 DEFAULT_HEALTHCHECK_TIMEOUT_SECONDS = 60
 
 
-def _is_valid_benchmark_id(value: str) -> bool:
-    """Waliduje benchmark_id jako kanoniczny UUID."""
-    return _normalize_benchmark_id(value) is not None
-
-
 def _normalize_benchmark_id(value: str) -> Optional[str]:
     """Zwraca benchmark_id w postaci kanonicznej UUID lub None."""
     try:

--- a/venom_core/services/benchmark.py
+++ b/venom_core/services/benchmark.py
@@ -33,6 +33,11 @@ logger = get_logger(__name__)
 DEFAULT_HEALTHCHECK_TIMEOUT_SECONDS = 60
 
 
+def _is_valid_benchmark_id(value: str) -> bool:
+    """Waliduje benchmark_id jako kanoniczny UUID."""
+    return _normalize_benchmark_id(value) is not None
+
+
 def _normalize_benchmark_id(value: str) -> Optional[str]:
     """Zwraca benchmark_id w postaci kanonicznej UUID lub None."""
     try:

--- a/venom_core/services/remote_models_service.py
+++ b/venom_core/services/remote_models_service.py
@@ -283,9 +283,9 @@ class HttpClientLike(Protocol):
 
     async def __aexit__(
         self,
-        exc_type: Any,
-        exc: Any,
-        tb: Any,
+        _exc_type: Any,
+        _exc: Any,
+        _tb: Any,
     ) -> Any: ...
 
     async def aget(self, url: str, **kwargs: Any) -> ResponseLike: ...


### PR DESCRIPTION
## Cel
Domknięcie PR 199: praktyczny audyt podejrzeń martwego kodu na bazie narzędzi z 198A, z bezpiecznym cleanupem, aktualizacją testów i spójną dokumentacją operatora.

## Zakres zmian

### 1. Faza A i B (cleanup kodu + testy)
- usunięcie nieużywanych prywatnych helperów z obszarów:
  - `venom_core/api/routes/memory.py`
  - `venom_core/api/routes/models_remote.py`
  - `venom_core/services/benchmark.py`
  - `venom_core/api/routes/academy.py`
  - `venom_core/api/routes/llm_simple.py`
  - `scripts/update_sonar_new_code_group.py`
- dostosowanie testów kontraktowych i logicznych do docelowych modułów (`academy_storage`, `academy_uploads`, helpery streamu, `main()` w skrypcie Sonar).

### 2. Stabilizacja sygnału vulture (soft-signal, bez hard-gate)
- uporządkowanie przypadków false-positive/kontraktowych (parametry context managerów, hook modelu).
- pozostawienie vulture jako narzędzia manualnego zgodnie z polityką.

### 3. Dokumentacja EN/PL
- doprecyzowanie matrycy komend audytu dead-code (Heurystyka vs Vulture):
  - `docs/TESTING_POLICY.md`
  - `docs/PL/TESTING_POLICY.md`

### 4. Domknięcie bramki `pr-fast` na tej gałęzi
- problem: changed-lines coverage spadało przez brak pokrycia zmienionych linii w `model_requests.py`.
- poprawki:
  - `tests/test_model_requests.py` - nowy test wywołujący `model_post_init`.
  - `config/testing/test_catalog.json` - `tests/test_model_requests.py` dopisany do lane `new-code`/`ci-lite`.
  - `config/pytest-groups/sonar-new-code.txt` zsynchronizowany z katalogiem.

## Wynik audytu 199
- `unused_private_definition`: **0**
- `unreachable_statement`: **0**
- `vulture_unused_symbol`: pozostaje sygnałem manualnym (kontrolowany allowlistą)

## Walidacja
- `make pr-fast` - **PASS**
  - changed-lines coverage: **100.0% >= 80.0%**
  - coverage floor: **PASS**

## Ryzyka / uwagi
- Vulture nadal traktowany jako soft-signal (świadoma decyzja), nie hard-gate CI.
- Zmiany w katalogu testów wpływają na dobór testów w lane new-code/fast.
