### PR TITLE
feat(voice/orb): audio-reactive voice orb with WOW visual effects (PR 206)

### DIFF
--- a/tests/test_operator_agent.py
+++ b/tests/test_operator_agent.py
@@ -2,9 +2,18 @@
 
 from unittest.mock import AsyncMock, MagicMock
 
+import httpx
 import pytest
+from semantic_kernel.contents.chat_history import ChatHistory
 
-from venom_core.agents.operator import OperatorAgent, _coerce_float, _coerce_int
+import venom_core.agents.operator as op_module
+from venom_core.agents.operator import (
+    OperatorAgent,
+    _coerce_float,
+    _coerce_int,
+    _ollama_extra_body,
+    _ollama_native_call,
+)
 from venom_core.infrastructure.hardware_pi import HardwareBridge
 
 
@@ -299,3 +308,279 @@ class TestOperatorAgent:
         assert captured["tokens"] == 100
         assert captured["temperature"] == pytest.approx(0.5)
         assert captured["messages"].count("system") == 2
+
+
+class TestOllamaExtraBody:
+    """Tests for the _ollama_extra_body() helper."""
+
+    def test_returns_think_false_when_local_and_think_disabled(self, monkeypatch):
+        mock_settings = MagicMock()
+        mock_settings.LLM_SERVICE_TYPE = "local"
+        mock_settings.OLLAMA_ENABLE_THINK = False
+        monkeypatch.setattr(op_module, "SETTINGS", mock_settings)
+
+        result = _ollama_extra_body()
+
+        assert result == {"think": False}
+
+    def test_returns_none_when_not_local(self, monkeypatch):
+        mock_settings = MagicMock()
+        mock_settings.LLM_SERVICE_TYPE = "openai"
+        mock_settings.OLLAMA_ENABLE_THINK = False
+        monkeypatch.setattr(op_module, "SETTINGS", mock_settings)
+
+        result = _ollama_extra_body()
+
+        assert result is None
+
+    def test_returns_none_when_think_enabled(self, monkeypatch):
+        mock_settings = MagicMock()
+        mock_settings.LLM_SERVICE_TYPE = "local"
+        mock_settings.OLLAMA_ENABLE_THINK = True
+        monkeypatch.setattr(op_module, "SETTINGS", mock_settings)
+
+        result = _ollama_extra_body()
+
+        assert result is None
+
+
+class TestOllamaNativeCall:
+    """Tests for the _ollama_native_call() async helper."""
+
+    def _make_settings(self, endpoint="http://localhost:11434/v1", model="test-model"):
+        mock_settings = MagicMock()
+        mock_settings.LLM_LOCAL_ENDPOINT = endpoint
+        mock_settings.LLM_MODEL_NAME = model
+        return mock_settings
+
+    def _make_mock_client_cls(self, response_data):
+        """Build an async context manager mock for httpx.AsyncClient."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json = MagicMock(return_value=response_data)
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        mock_client_cls = MagicMock()
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        return mock_client_cls, mock_client
+
+    @pytest.mark.asyncio
+    async def test_success_returns_content(self, monkeypatch):
+        monkeypatch.setattr(op_module, "SETTINGS", self._make_settings())
+        mock_client_cls, _ = self._make_mock_client_cls(
+            {"message": {"content": "answer"}}
+        )
+        monkeypatch.setattr(httpx, "AsyncClient", mock_client_cls)
+
+        chat_history = ChatHistory()
+        chat_history.add_user_message("hello")
+
+        result = await _ollama_native_call(
+            chat_history, max_tokens=150, temperature=0.7
+        )
+
+        assert result == "answer"
+
+    @pytest.mark.asyncio
+    async def test_strips_v1_from_endpoint(self, monkeypatch):
+        monkeypatch.setattr(
+            op_module,
+            "SETTINGS",
+            self._make_settings(endpoint="http://localhost:11434/v1"),
+        )
+        captured_urls = []
+
+        async def fake_post(url, **kwargs):
+            captured_urls.append(url)
+            mock_resp = MagicMock()
+            mock_resp.raise_for_status = MagicMock()
+            mock_resp.json = MagicMock(return_value={"message": {"content": "ok"}})
+            return mock_resp
+
+        mock_client = AsyncMock()
+        mock_client.post = fake_post
+
+        mock_client_cls = MagicMock()
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr(httpx, "AsyncClient", mock_client_cls)
+
+        chat_history = ChatHistory()
+        chat_history.add_user_message("test")
+
+        await _ollama_native_call(chat_history, max_tokens=100, temperature=0.5)
+
+        assert len(captured_urls) == 1
+        assert captured_urls[0] == "http://localhost:11434/api/chat"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_http_error(self, monkeypatch):
+        monkeypatch.setattr(op_module, "SETTINGS", self._make_settings())
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "500", request=MagicMock(), response=MagicMock()
+            )
+        )
+
+        mock_client_cls = MagicMock()
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr(httpx, "AsyncClient", mock_client_cls)
+
+        chat_history = ChatHistory()
+        chat_history.add_user_message("test")
+
+        result = await _ollama_native_call(
+            chat_history, max_tokens=100, temperature=0.5
+        )
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_connection_error(self, monkeypatch):
+        monkeypatch.setattr(op_module, "SETTINGS", self._make_settings())
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(
+            side_effect=httpx.ConnectError("Connection refused")
+        )
+
+        mock_client_cls = MagicMock()
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr(httpx, "AsyncClient", mock_client_cls)
+
+        chat_history = ChatHistory()
+        chat_history.add_user_message("test")
+
+        result = await _ollama_native_call(
+            chat_history, max_tokens=100, temperature=0.5
+        )
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_payload_has_think_false(self, monkeypatch):
+        monkeypatch.setattr(op_module, "SETTINGS", self._make_settings())
+        captured_payloads = []
+
+        async def fake_post(url, **kwargs):
+            captured_payloads.append(kwargs.get("json", {}))
+            mock_resp = MagicMock()
+            mock_resp.raise_for_status = MagicMock()
+            mock_resp.json = MagicMock(return_value={"message": {"content": "ok"}})
+            return mock_resp
+
+        mock_client = AsyncMock()
+        mock_client.post = fake_post
+
+        mock_client_cls = MagicMock()
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr(httpx, "AsyncClient", mock_client_cls)
+
+        chat_history = ChatHistory()
+        chat_history.add_user_message("test payload")
+
+        await _ollama_native_call(chat_history, max_tokens=200, temperature=0.8)
+
+        assert len(captured_payloads) == 1
+        assert captured_payloads[0]["think"] is False
+
+
+class TestGenerateVoiceResponseGuards:
+    """Tests for the None/empty-list guard and Ollama fallback in _generate_voice_response."""
+
+    @pytest.fixture
+    def mock_kernel(self):
+        kernel = MagicMock()
+        kernel.get_service = MagicMock(return_value=MagicMock())
+        kernel.services = {"chat": MagicMock()}
+        return kernel
+
+    def _make_settings(self, service_type="openai"):
+        mock_settings = MagicMock()
+        mock_settings.LLM_SERVICE_TYPE = service_type
+        mock_settings.OLLAMA_ENABLE_THINK = False
+        mock_settings.LLM_LOCAL_ENDPOINT = "http://localhost:11434/v1"
+        mock_settings.LLM_MODEL_NAME = "test-model"
+        return mock_settings
+
+    @pytest.mark.asyncio
+    async def test_none_response_triggers_fallback_message(
+        self, mock_kernel, monkeypatch
+    ):
+        monkeypatch.setattr(op_module, "SETTINGS", self._make_settings("openai"))
+        agent = OperatorAgent(kernel=mock_kernel)
+        agent._invoke_chat_with_fallbacks = AsyncMock(return_value=None)
+
+        response = await agent._generate_voice_response("test input")
+
+        assert (
+            response == "Przepraszam, model nie zwrócił odpowiedzi. Spróbuj ponownie."
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_list_response_triggers_fallback_message(
+        self, mock_kernel, monkeypatch
+    ):
+        monkeypatch.setattr(op_module, "SETTINGS", self._make_settings("openai"))
+        agent = OperatorAgent(kernel=mock_kernel)
+        agent._invoke_chat_with_fallbacks = AsyncMock(return_value=[])
+
+        response = await agent._generate_voice_response("test input")
+
+        assert (
+            response == "Przepraszam, model nie zwrócił odpowiedzi. Spróbuj ponownie."
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_response_uses_first_item(self, mock_kernel, monkeypatch):
+        monkeypatch.setattr(op_module, "SETTINGS", self._make_settings("openai"))
+        agent = OperatorAgent(kernel=mock_kernel)
+
+        mock_item = MagicMock()
+        mock_item.__str__ = lambda self: "answer"
+        agent._invoke_chat_with_fallbacks = AsyncMock(return_value=[mock_item])
+
+        response = await agent._generate_voice_response("test input")
+
+        assert response == "answer"
+
+    @pytest.mark.asyncio
+    async def test_empty_sk_with_local_service_calls_ollama_native(
+        self, mock_kernel, monkeypatch
+    ):
+        monkeypatch.setattr(op_module, "SETTINGS", self._make_settings("local"))
+        agent = OperatorAgent(kernel=mock_kernel)
+        agent._invoke_chat_with_fallbacks = AsyncMock(return_value="")
+        monkeypatch.setattr(
+            op_module, "_ollama_native_call", AsyncMock(return_value="native answer")
+        )
+
+        response = await agent._generate_voice_response("test input")
+
+        assert response == "native answer"
+
+    @pytest.mark.asyncio
+    async def test_empty_sk_non_local_no_ollama_fallback(
+        self, mock_kernel, monkeypatch
+    ):
+        monkeypatch.setattr(op_module, "SETTINGS", self._make_settings("openai"))
+        agent = OperatorAgent(kernel=mock_kernel)
+        agent._invoke_chat_with_fallbacks = AsyncMock(return_value="")
+
+        native_mock = AsyncMock(return_value="should not be called")
+        monkeypatch.setattr(op_module, "_ollama_native_call", native_mock)
+
+        response = await agent._generate_voice_response("test input")
+
+        assert (
+            response == "Przepraszam, model nie zwrócił odpowiedzi. Spróbuj ponownie."
+        )
+        native_mock.assert_not_called()

--- a/venom_core/agents/operator.py
+++ b/venom_core/agents/operator.py
@@ -359,7 +359,13 @@ PAMIĘTAJ: Twoim celem jest być jak Jarvis - pomocny, zwięzły i profesjonalny
                 enable_functions=False,
             )
 
-            assistant_message = str(response).strip()
+            # Guard against None or empty list before str() — str(None) → 'None'
+            # and str([]) → '[]' are both truthy and would bypass the empty check.
+            if not response or (isinstance(response, list) and not response):
+                assistant_message = ""
+            else:
+                item = response[0] if isinstance(response, list) else response
+                assistant_message = str(item).strip()
             if not assistant_message and SETTINGS.LLM_SERVICE_TYPE == "local":
                 # Ollama's OpenAI-compat endpoint ignores think:false for some
                 # thinking models (gemma4, qwen3, deepseek-r1). Fall back to the

--- a/venom_core/agents/operator.py
+++ b/venom_core/agents/operator.py
@@ -298,7 +298,12 @@ PAMIĘTAJ: Twoim celem jest być jak Jarvis - pomocny, zwięzły i profesjonalny
                 enable_functions=False,
             )
 
-            assistant_message = str(response)
+            assistant_message = str(response).strip()
+            if not assistant_message:
+                logger.warning(
+                    "LLM zwrócił pustą odpowiedź dla input: %s", input_text[:80]
+                )
+                return "Przepraszam, model nie zwrócił odpowiedzi. Spróbuj ponownie."
 
             # Dodaj do historii
             self.chat_history.add_user_message(input_text)

--- a/venom_core/agents/operator.py
+++ b/venom_core/agents/operator.py
@@ -3,11 +3,13 @@
 import re
 from typing import Any, Optional
 
+import httpx
 from semantic_kernel import Kernel
 from semantic_kernel.connectors.ai.open_ai import OpenAIChatPromptExecutionSettings
 from semantic_kernel.contents import ChatHistory
 
 from venom_core.agents.base import BaseAgent
+from venom_core.config import SETTINGS
 from venom_core.infrastructure.hardware_pi import HardwareBridge
 from venom_core.utils.logger import get_logger
 
@@ -53,6 +55,64 @@ def _coerce_float(value: Any, default: float) -> float:
         return float(value)
     except (TypeError, ValueError):
         return default
+
+
+def _ollama_extra_body() -> dict[str, Any] | None:
+    """Returns extra_body to disable thinking for Ollama models (e.g. gemma4).
+
+    Thinking models (gemma4, deepseek-r1, qwen3 etc.) served via Ollama return
+    an empty `content` field and put the answer in `thinking`/`reasoning` when
+    thinking is enabled.  Passing `think: false` forces the regular response path.
+    """
+    if SETTINGS.LLM_SERVICE_TYPE == "local" and not SETTINGS.OLLAMA_ENABLE_THINK:
+        return {"think": False}
+    return None
+
+
+async def _ollama_native_call(
+    chat_history: ChatHistory,
+    max_tokens: int,
+    temperature: float,
+) -> str:
+    """Call Ollama native API (/api/chat) with think:false.
+
+    Fallback for thinking models (gemma4, qwen3, deepseek-r1) where Ollama's
+    OpenAI-compat endpoint (/v1/chat/completions) ignores the `think` flag and
+    returns an empty `content` with the answer placed in `reasoning`/`thinking`.
+    The native endpoint reliably respects `think: false`.
+    """
+    base_url = SETTINGS.LLM_LOCAL_ENDPOINT.rstrip("/")
+    if base_url.endswith("/v1"):
+        base_url = base_url[:-3]
+    native_url = f"{base_url}/api/chat"
+
+    messages = []
+    for msg in chat_history.messages:
+        role_raw = str(getattr(msg, "role", "user")).lower()
+        if "system" in role_raw:
+            role = "system"
+        elif "assistant" in role_raw:
+            role = "assistant"
+        else:
+            role = "user"
+        messages.append({"role": role, "content": str(msg.content or "")})
+
+    payload: dict[str, Any] = {
+        "model": SETTINGS.LLM_MODEL_NAME,
+        "messages": messages,
+        "stream": False,
+        "think": False,
+        "options": {"num_predict": max_tokens, "temperature": temperature},
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            resp = await client.post(native_url, json=payload)
+            resp.raise_for_status()
+            return resp.json().get("message", {}).get("content", "") or ""
+    except Exception as exc:
+        logger.error("Ollama native fallback failed: %s", exc)
+        return ""
 
 
 class OperatorAgent(BaseAgent):
@@ -285,6 +345,7 @@ PAMIĘTAJ: Twoim celem jest być jak Jarvis - pomocny, zwięzły i profesjonalny
                 service_id=service_id,
                 max_tokens=_coerce_int(mode_prompt["max_tokens"], 0),
                 temperature=_coerce_float(mode_prompt["temperature"], 0.7),
+                extra_body=_ollama_extra_body(),
             )
 
             # Pobierz usługę czatu
@@ -299,6 +360,21 @@ PAMIĘTAJ: Twoim celem jest być jak Jarvis - pomocny, zwięzły i profesjonalny
             )
 
             assistant_message = str(response).strip()
+            if not assistant_message and SETTINGS.LLM_SERVICE_TYPE == "local":
+                # Ollama's OpenAI-compat endpoint ignores think:false for some
+                # thinking models (gemma4, qwen3, deepseek-r1). Fall back to the
+                # native /api/chat endpoint which reliably disables thinking.
+                logger.warning(
+                    "SK returned empty content (thinking model?), falling back to "
+                    "native Ollama API for input: %s",
+                    input_text[:80],
+                )
+                assistant_message = await _ollama_native_call(
+                    chat_history=temp_history,
+                    max_tokens=_coerce_int(mode_prompt["max_tokens"], 150),
+                    temperature=_coerce_float(mode_prompt["temperature"], 0.7),
+                )
+
             if not assistant_message:
                 logger.warning(
                     "LLM zwrócił pustą odpowiedź dla input: %s", input_text[:80]
@@ -366,6 +442,7 @@ Streszczenie:"""
                 service_id=service_id,
                 max_tokens=100,
                 temperature=0.5,
+                extra_body=_ollama_extra_body(),
             )
 
             chat_service: Any = self.kernel.get_service(service_id=service_id)

--- a/venom_core/agents/operator.py
+++ b/venom_core/agents/operator.py
@@ -106,7 +106,7 @@ async def _ollama_native_call(
     }
 
     try:
-        async with httpx.AsyncClient(timeout=60.0) as client:
+        async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.post(native_url, json=payload)
             resp.raise_for_status()
             return resp.json().get("message", {}).get("content", "") or ""

--- a/venom_core/api/audio_stream.py
+++ b/venom_core/api/audio_stream.py
@@ -655,6 +655,20 @@ class AudioStreamHandler:
                     },
                 )
 
+                if not response_text:
+                    logger.warning(
+                        "Agent zwrócił pustą odpowiedź dla connection_id=%s",
+                        connection_id,
+                    )
+                    await self._send_json(
+                        connection_id,
+                        {
+                            "type": "error",
+                            "message": "Model nie zwrócił odpowiedzi. Sprawdź status runtime.",
+                        },
+                    )
+                    return
+
                 # Wyślij tekst odpowiedzi
                 await self._send_json(
                     connection_id, {"type": "response_text", "text": response_text}
@@ -789,6 +803,20 @@ class AudioStreamHandler:
                         "timings_ms": timings_ms,
                     },
                 )
+                if not response_text:
+                    logger.warning(
+                        "Agent zwrócił pustą odpowiedź dla connection_id=%s (encoded)",
+                        connection_id,
+                    )
+                    await self._send_json(
+                        connection_id,
+                        {
+                            "type": "error",
+                            "message": "Model nie zwrócił odpowiedzi. Sprawdź status runtime.",
+                        },
+                    )
+                    return
+
                 await self._send_json(
                     connection_id, {"type": "response_text", "text": response_text}
                 )

--- a/venom_core/api/audio_stream.py
+++ b/venom_core/api/audio_stream.py
@@ -664,7 +664,7 @@ class AudioStreamHandler:
                         connection_id,
                         {
                             "type": "error",
-                            "message": "Model nie zwrócił odpowiedzi. Sprawdź status runtime.",
+                            "message": "Agent returned empty response. Check runtime status.",
                         },
                     )
                     return
@@ -812,7 +812,7 @@ class AudioStreamHandler:
                         connection_id,
                         {
                             "type": "error",
-                            "message": "Model nie zwrócił odpowiedzi. Sprawdź status runtime.",
+                            "message": "Agent returned empty response. Check runtime status.",
                         },
                     )
                     return

--- a/web-next/app/globals.css
+++ b/web-next/app/globals.css
@@ -886,3 +886,51 @@ html[data-theme="venom-light"] body::before {
 html[data-theme="venom-light"] body::after {
   background: radial-gradient(circle at center, transparent 30%, rgba(71, 85, 105, 0.22) 130%);
 }
+
+/* ── Voice Orb WOW effects ──────────────────────────────────────────── */
+
+@keyframes orb-ripple {
+  0%   { transform: scale(1);   opacity: 0.55; }
+  100% { transform: scale(2.6); opacity: 0; }
+}
+
+@keyframes orb-blob {
+  0%,  100% { border-radius: 60% 40% 70% 30% / 50% 60% 40% 70%; }
+  25%        { border-radius: 40% 60% 30% 70% / 65% 35% 70% 45%; }
+  50%        { border-radius: 70% 30% 55% 45% / 40% 70% 55% 60%; }
+  75%        { border-radius: 35% 65% 45% 55% / 70% 45% 60% 40%; }
+}
+
+@keyframes orb-particle-rise {
+  0%   { transform: translateY(0)     scale(1);   opacity: 0.65; }
+  100% { transform: translateY(-56px) scale(0.2); opacity: 0; }
+}
+
+@keyframes orb-flash {
+  0%   { opacity: 0; }
+  25%  { opacity: 0.55; }
+  100% { opacity: 0; }
+}
+
+@keyframes orb-burst {
+  0%   { transform: scale(1);   opacity: 0.75; }
+  100% { transform: scale(2.4); opacity: 0; }
+}
+
+@keyframes orb-plasma-slow {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+@keyframes orb-plasma-fast {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(-360deg); }
+}
+
+.animate-orb-ripple        { animation: orb-ripple        1.9s ease-out infinite; }
+.animate-orb-blob          { animation: orb-blob           3.2s ease-in-out infinite; }
+.animate-orb-particle-rise { animation: orb-particle-rise  2.1s ease-out forwards; }
+.animate-orb-flash         { animation: orb-flash          0.32s ease-out forwards; }
+.animate-orb-burst         { animation: orb-burst          0.58s ease-out forwards; }
+.animate-orb-plasma-slow   { animation: orb-plasma-slow    9s   linear infinite; }
+.animate-orb-plasma-fast   { animation: orb-plasma-fast    5.5s linear infinite; }

--- a/web-next/app/globals.css
+++ b/web-next/app/globals.css
@@ -888,33 +888,14 @@ html[data-theme="venom-light"] body::after {
 }
 
 /* ── Voice Orb WOW effects ──────────────────────────────────────────── */
-
-@keyframes orb-ripple {
-  0%   { transform: scale(1);   opacity: 0.55; }
-  100% { transform: scale(2.6); opacity: 0; }
-}
-
-@keyframes orb-blob {
-  0%,  100% { border-radius: 60% 40% 70% 30% / 50% 60% 40% 70%; }
-  25%        { border-radius: 40% 60% 30% 70% / 65% 35% 70% 45%; }
-  50%        { border-radius: 70% 30% 55% 45% / 40% 70% 55% 60%; }
-  75%        { border-radius: 35% 65% 45% 55% / 70% 45% 60% 40%; }
-}
+/* orb-ripple / orb-blob / orb-flash / orb-burst are defined in            */
+/* tailwind.config.ts (keyframes + animation utilities). Only the three    */
+/* effects NOT representable in Tailwind (plasma rotations, particle-rise) */
+/* live here as plain CSS classes.                                         */
 
 @keyframes orb-particle-rise {
   0%   { transform: translateY(0)     scale(1);   opacity: 0.65; }
   100% { transform: translateY(-56px) scale(0.2); opacity: 0; }
-}
-
-@keyframes orb-flash {
-  0%   { opacity: 0; }
-  25%  { opacity: 0.55; }
-  100% { opacity: 0; }
-}
-
-@keyframes orb-burst {
-  0%   { transform: scale(1);   opacity: 0.75; }
-  100% { transform: scale(2.4); opacity: 0; }
 }
 
 @keyframes orb-plasma-slow {
@@ -927,10 +908,6 @@ html[data-theme="venom-light"] body::after {
   to   { transform: rotate(-360deg); }
 }
 
-.animate-orb-ripple        { animation: orb-ripple        1.9s ease-out infinite; }
-.animate-orb-blob          { animation: orb-blob           3.2s ease-in-out infinite; }
 .animate-orb-particle-rise { animation: orb-particle-rise  2.1s ease-out forwards; }
-.animate-orb-flash         { animation: orb-flash          0.32s ease-out forwards; }
-.animate-orb-burst         { animation: orb-burst          0.58s ease-out forwards; }
 .animate-orb-plasma-slow   { animation: orb-plasma-slow    9s   linear infinite; }
 .animate-orb-plasma-fast   { animation: orb-plasma-fast    5.5s linear infinite; }

--- a/web-next/components/voice/orb-frequency-ring.tsx
+++ b/web-next/components/voice/orb-frequency-ring.tsx
@@ -12,7 +12,7 @@ type OrbFrequencyRingProps = Readonly<{
 export function OrbFrequencyRing({ analyserRef, active, color, size }: OrbFrequencyRingProps) {
   const pathRef = useRef<SVGPathElement | null>(null);
   const rafRef = useRef<number | null>(null);
-  const bufferRef = useRef<Uint8Array<ArrayBuffer> | null>(null);
+  const bufferRef = useRef<Uint8Array | null>(null);
 
   useEffect(() => {
     if (!active) {

--- a/web-next/components/voice/orb-frequency-ring.tsx
+++ b/web-next/components/voice/orb-frequency-ring.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { RefObject, useEffect, useRef } from "react";
+
+type OrbFrequencyRingProps = Readonly<{
+  analyserRef: RefObject<AnalyserNode | null>;
+  active: boolean;
+  color: string;
+  size: number;
+}>;
+
+export function OrbFrequencyRing({ analyserRef, active, color, size }: OrbFrequencyRingProps) {
+  const pathRef = useRef<SVGPathElement | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const bufferRef = useRef<Uint8Array<ArrayBuffer> | null>(null);
+
+  useEffect(() => {
+    if (!active) {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+      if (pathRef.current) pathRef.current.setAttribute("d", "");
+      return;
+    }
+
+    const N = 48;
+    const cx = size / 2;
+    const cy = size / 2;
+    const baseR = size * 0.415;
+    const maxDisp = size * 0.095;
+
+    const draw = () => {
+      const analyser = analyserRef.current;
+
+      if (!analyser) {
+        rafRef.current = requestAnimationFrame(draw);
+        return;
+      }
+
+      const binCount = analyser.frequencyBinCount;
+      if (!bufferRef.current || bufferRef.current.length !== binCount) {
+        bufferRef.current = new Uint8Array(binCount);
+      }
+      analyser.getByteFrequencyData(bufferRef.current);
+      const data = bufferRef.current;
+      const step = Math.max(1, Math.floor(binCount / N));
+
+      let d = "";
+      for (let i = 0; i < N; i++) {
+        const angle = (2 * Math.PI * i) / N - Math.PI / 2;
+        const val = data[Math.min(i * step, binCount - 1)] / 255;
+        const r = baseR + val * maxDisp;
+        const x = (cx + r * Math.cos(angle)).toFixed(2);
+        const y = (cy + r * Math.sin(angle)).toFixed(2);
+        d += i === 0 ? `M ${x} ${y}` : ` L ${x} ${y}`;
+      }
+      d += " Z";
+
+      if (pathRef.current) pathRef.current.setAttribute("d", d);
+      rafRef.current = requestAnimationFrame(draw);
+    };
+
+    rafRef.current = requestAnimationFrame(draw);
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [active, analyserRef, size]);
+
+  if (!active) return null;
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      className="pointer-events-none absolute inset-0"
+      aria-hidden="true"
+    >
+      <path
+        ref={pathRef}
+        fill="none"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+        opacity="0.75"
+      />
+    </svg>
+  );
+}

--- a/web-next/components/voice/use-audio-level.ts
+++ b/web-next/components/voice/use-audio-level.ts
@@ -7,8 +7,8 @@ const computeRms = (analyser: AnalyserNode): number => {
   const buffer = new Float32Array(analyser.fftSize);
   analyser.getFloatTimeDomainData(buffer);
   let sum = 0;
-  for (let i = 0; i < buffer.length; i++) {
-    sum += (buffer[i] ?? 0) ** 2;
+  for (const sample of buffer) {
+    sum += sample ** 2;
   }
   return Math.sqrt(sum / buffer.length);
 };

--- a/web-next/components/voice/use-audio-level.ts
+++ b/web-next/components/voice/use-audio-level.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+
+const computeRms = (analyser: AnalyserNode): number => {
+  const buffer = new Float32Array(analyser.fftSize);
+  analyser.getFloatTimeDomainData(buffer);
+  let sum = 0;
+  for (let i = 0; i < buffer.length; i++) {
+    sum += (buffer[i] ?? 0) ** 2;
+  }
+  return Math.sqrt(sum / buffer.length);
+};
+
+export const useAudioLevel = (
+  analyserRef: RefObject<AnalyserNode | null>,
+  active: boolean,
+): number => {
+  const [level, setLevel] = useState(0);
+  const decayRef = useRef(0);
+
+  useEffect(() => {
+    if (!active) {
+      decayRef.current = 0;
+      setLevel(0);
+      return;
+    }
+
+    let frameId: number | null = null;
+
+    const tick = () => {
+      const analyser = analyserRef.current;
+      if (analyser) {
+        const rms = computeRms(analyser);
+        decayRef.current = Math.max(rms, decayRef.current * 0.85);
+      } else {
+        decayRef.current *= 0.85;
+      }
+      setLevel(Math.min(1, decayRef.current * 4));
+      frameId = requestAnimationFrame(tick);
+    };
+
+    frameId = requestAnimationFrame(tick);
+    return () => {
+      if (frameId !== null) cancelAnimationFrame(frameId);
+    };
+    // analyserRef is a stable RefObject — intentionally excluded from deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active]);
+
+  return level;
+};

--- a/web-next/components/voice/use-audio-level.ts
+++ b/web-next/components/voice/use-audio-level.ts
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import type { RefObject } from "react";
 
 const computeRms = (analyser: AnalyserNode, bufferRef: RefObject<Float32Array | null>): number => {
-  if (!bufferRef.current || bufferRef.current.length !== analyser.fftSize) {
+  if (bufferRef.current?.length !== analyser.fftSize) {
     bufferRef.current = new Float32Array(analyser.fftSize);
   }
 

--- a/web-next/components/voice/use-audio-level.ts
+++ b/web-next/components/voice/use-audio-level.ts
@@ -3,8 +3,16 @@
 import { useEffect, useRef, useState } from "react";
 import type { RefObject } from "react";
 
-const computeRms = (analyser: AnalyserNode): number => {
-  const buffer = new Float32Array(analyser.fftSize);
+const computeRms = (analyser: AnalyserNode, bufferRef: RefObject<Float32Array | null>): number => {
+  if (!bufferRef.current || bufferRef.current.length !== analyser.fftSize) {
+    bufferRef.current = new Float32Array(analyser.fftSize);
+  }
+
+  const buffer = bufferRef.current;
+  if (!buffer) {
+    return 0;
+  }
+
   analyser.getFloatTimeDomainData(buffer);
   let sum = 0;
   for (const sample of buffer) {
@@ -19,6 +27,7 @@ export const useAudioLevel = (
 ): number => {
   const [level, setLevel] = useState(0);
   const decayRef = useRef(0);
+  const bufferRef = useRef<Float32Array | null>(null);
 
   useEffect(() => {
     if (!active) {
@@ -32,7 +41,7 @@ export const useAudioLevel = (
     const tick = () => {
       const analyser = analyserRef.current;
       if (analyser) {
-        const rms = computeRms(analyser);
+        const rms = computeRms(analyser, bufferRef);
         decayRef.current = Math.max(rms, decayRef.current * 0.85);
       } else {
         decayRef.current *= 0.85;

--- a/web-next/components/voice/use-orb-effects-config.ts
+++ b/web-next/components/voice/use-orb-effects-config.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useMemo } from "react";
+
+export type OrbEffectsConfig = {
+  ripple: boolean;
+  blob: boolean;
+  glow: boolean;
+  transitions: boolean;
+  frequencyRing: boolean;
+  coreTexture: boolean;
+  particles: boolean;
+  stateLabel: boolean;
+};
+
+const ALL_OFF: OrbEffectsConfig = {
+  ripple: false,
+  blob: false,
+  glow: false,
+  transitions: false,
+  frequencyRing: false,
+  coreTexture: false,
+  particles: false,
+  stateLabel: false,
+};
+
+function readFlag(key: string): boolean {
+  const v = process.env[key];
+  return v !== "false" && v !== "0";
+}
+
+export function useOrbEffectsConfig(): OrbEffectsConfig {
+  return useMemo(() => {
+    if (process.env.NEXT_PUBLIC_ORB_EFFECTS === "off") return ALL_OFF;
+    return {
+      ripple: readFlag("NEXT_PUBLIC_ORB_RIPPLE"),
+      blob: readFlag("NEXT_PUBLIC_ORB_BLOB"),
+      glow: readFlag("NEXT_PUBLIC_ORB_GLOW"),
+      transitions: readFlag("NEXT_PUBLIC_ORB_TRANSITIONS"),
+      frequencyRing: readFlag("NEXT_PUBLIC_ORB_FREQUENCY_RING"),
+      coreTexture: readFlag("NEXT_PUBLIC_ORB_CORE_TEXTURE"),
+      particles: readFlag("NEXT_PUBLIC_ORB_PARTICLES"),
+      stateLabel: readFlag("NEXT_PUBLIC_ORB_STATE_LABEL"),
+    };
+  }, []);
+}

--- a/web-next/components/voice/use-orb-effects-config.ts
+++ b/web-next/components/voice/use-orb-effects-config.ts
@@ -24,23 +24,25 @@ const ALL_OFF: OrbEffectsConfig = {
   stateLabel: false,
 };
 
-function readFlag(key: string): boolean {
-  const v = process.env[key];
-  return v !== "false" && v !== "0";
+// Next.js replaces NEXT_PUBLIC_* vars at build time only when referenced by
+// their full literal name — dynamic process.env[key] is not replaced in the
+// browser bundle. Each flag is therefore read with a static reference.
+function isOff(v: string | undefined): boolean {
+  return v === "false" || v === "0";
 }
 
 export function useOrbEffectsConfig(): OrbEffectsConfig {
   return useMemo(() => {
     if (process.env.NEXT_PUBLIC_ORB_EFFECTS === "off") return ALL_OFF;
     return {
-      ripple: readFlag("NEXT_PUBLIC_ORB_RIPPLE"),
-      blob: readFlag("NEXT_PUBLIC_ORB_BLOB"),
-      glow: readFlag("NEXT_PUBLIC_ORB_GLOW"),
-      transitions: readFlag("NEXT_PUBLIC_ORB_TRANSITIONS"),
-      frequencyRing: readFlag("NEXT_PUBLIC_ORB_FREQUENCY_RING"),
-      coreTexture: readFlag("NEXT_PUBLIC_ORB_CORE_TEXTURE"),
-      particles: readFlag("NEXT_PUBLIC_ORB_PARTICLES"),
-      stateLabel: readFlag("NEXT_PUBLIC_ORB_STATE_LABEL"),
+      ripple:       !isOff(process.env.NEXT_PUBLIC_ORB_RIPPLE),
+      blob:         !isOff(process.env.NEXT_PUBLIC_ORB_BLOB),
+      glow:         !isOff(process.env.NEXT_PUBLIC_ORB_GLOW),
+      transitions:  !isOff(process.env.NEXT_PUBLIC_ORB_TRANSITIONS),
+      frequencyRing:!isOff(process.env.NEXT_PUBLIC_ORB_FREQUENCY_RING),
+      coreTexture:  !isOff(process.env.NEXT_PUBLIC_ORB_CORE_TEXTURE),
+      particles:    !isOff(process.env.NEXT_PUBLIC_ORB_PARTICLES),
+      stateLabel:   !isOff(process.env.NEXT_PUBLIC_ORB_STATE_LABEL),
     };
   }, []);
 }

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -1254,7 +1254,7 @@ export function VoiceCommandCenter({
   }, []);
 
   useEffect(() => {
-    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const mq = globalThis.matchMedia("(prefers-reduced-motion: reduce)");
     setReducedMotion(mq.matches);
     const handler = (e: MediaQueryListEvent) => setReducedMotion(e.matches);
     mq.addEventListener("change", handler);

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -9,6 +9,7 @@ import { getAudioWsUrl } from "@/lib/env";
 import { useTranslation } from "@/lib/i18n";
 import { VoiceOrb, type VoiceOrbState } from "@/components/voice/voice-orb";
 import { useAudioLevel } from "@/components/voice/use-audio-level";
+import { useOrbEffectsConfig, type OrbEffectsConfig } from "@/components/voice/use-orb-effects-config";
 
 type AudioStatus = {
   enabled: boolean;
@@ -1079,6 +1080,9 @@ type VoiceCommandCenterStatusSidebarProps = Readonly<{
   reducedMotion: boolean;
   isVoiceModeEnabled: boolean;
   audioEnabled: boolean;
+  effectsConfig: OrbEffectsConfig;
+  micAnalyserRef: RefObject<AnalyserNode | null>;
+  ttsAnalyserRef: RefObject<AnalyserNode | null>;
 }>;
 
 function VoiceCommandCenterStatusSidebar({
@@ -1097,11 +1101,14 @@ function VoiceCommandCenterStatusSidebar({
   reducedMotion,
   isVoiceModeEnabled,
   audioEnabled,
+  effectsConfig,
+  micAnalyserRef,
+  ttsAnalyserRef,
 }: VoiceCommandCenterStatusSidebarProps) {
   return (
     <div className="space-y-3">
       {isVoiceModeEnabled ? (
-        <div className="flex justify-center rounded-2xl box-muted py-4">
+        <div className="flex justify-center rounded-2xl box-muted py-6">
           <VoiceOrb
             state={orbState}
             inputLevel={inputLevel}
@@ -1109,6 +1116,9 @@ function VoiceCommandCenterStatusSidebar({
             disabled={!audioEnabled}
             reducedMotion={reducedMotion}
             label={t(`voice.orb.stateLabel.${orbState}`)}
+            effectsConfig={effectsConfig}
+            micAnalyserRef={micAnalyserRef}
+            ttsAnalyserRef={ttsAnalyserRef}
           />
         </div>
       ) : null}
@@ -1622,6 +1632,7 @@ export function VoiceCommandCenter({
   );
 
   const orbState = deriveOrbState(connected, recording, processingStatus, playbackState, lastAudioSignal);
+  const effectsConfig = useOrbEffectsConfig();
 
   const recordingButtonClass = getRecordingButtonClass(
     audioEnabled,
@@ -1793,6 +1804,9 @@ export function VoiceCommandCenter({
           reducedMotion={reducedMotion}
           isVoiceModeEnabled={isVoiceModeEnabled}
           audioEnabled={audioEnabled}
+          effectsConfig={effectsConfig}
+          micAnalyserRef={analyserRef}
+          ttsAnalyserRef={ttsAnalyserRef}
         />
       </div>
     </Panel>

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -449,8 +449,6 @@ type VoiceControlDeps = {
   analyserRef?: RefObject<AnalyserNode | null>;
   mediaRecorderRef?: RefObject<MediaRecorder | null>;
   mediaStreamRef?: RefObject<MediaStream | null>;
-  canvasRef?: RefObject<HTMLCanvasElement | null>;
-  visualizerFrameRef: RefObject<number | null>;
   recordingRef: RefObject<boolean>;
   recordingStartPendingRef: RefObject<boolean>;
   stopRequestedRef: RefObject<boolean>;
@@ -462,7 +460,6 @@ type VoiceControlDeps = {
   setStatusMessage: (value: string | null) => void;
   setAudioChunkCount: (value: number | ((current: number) => number)) => void;
   setLastAudioSignal: (value: string) => void;
-  clearVisualizer?: () => void;
   releaseAudioResources: () => void;
   releasePlaybackResources: () => void;
   refreshAudioStatus: () => Promise<void>;
@@ -470,10 +467,6 @@ type VoiceControlDeps = {
   sendControlMessage: (payload: Record<string, unknown>) => boolean;
   getMediaRecorderMimeType: () => string;
   ensurePlaybackContext: () => Promise<AudioContext | null>;
-  drawVisualizer?: (samples: Float32Array) => void;
-  scaleAudioChunkForDisplay: (
-    samples: Float32Array,
-  ) => { normalized: Float32Array; peak: number; gain: number };
   activeWindow?: Window;
 };
 
@@ -856,35 +849,6 @@ const createVoiceCaptureEnvironment = async (
   return { mediaStream, audioContext, source, analyser, recorder, mimeType };
 };
 
-const startAnalyserLoop = (deps: VoiceControlDeps, analyser: AnalyserNode) => {
-  const {
-    recordingRef,
-    visualizerFrameRef,
-    activeWindow,
-    scaleAudioChunkForDisplay,
-    drawVisualizer,
-    setLastAudioSignal,
-  } = deps;
-  const timeDomain = new Uint8Array(analyser.fftSize);
-  const drawFromAnalyser = () => {
-    if (!recordingRef.current) {
-      return;
-    }
-    analyser.getByteTimeDomainData(timeDomain);
-    const samples = new Float32Array(timeDomain.length);
-    for (let index = 0; index < timeDomain.length; index += 1) {
-      samples[index] = ((timeDomain[index] ?? 128) - 128) / 128;
-    }
-    const { normalized, peak } = scaleAudioChunkForDisplay(samples);
-    if (peak > 0) {
-      setLastAudioSignal(`media:peak ${peak.toFixed(3)}`);
-    }
-    drawVisualizer?.(normalized);
-    visualizerFrameRef.current = activeWindow?.requestAnimationFrame(drawFromAnalyser) ?? null;
-  };
-  visualizerFrameRef.current = activeWindow?.requestAnimationFrame(drawFromAnalyser) ?? null;
-};
-
 const sendRecordingStartMessages = (
   deps: Pick<VoiceControlDeps, "sendControlMessage" | "setStatusMessage" | "setAudioChunkCount" | "setLastAudioSignal">,
   audioContext: AudioContext,
@@ -1034,7 +998,6 @@ const startVoiceCapture = async (deps: VoiceControlDeps): Promise<void> => {
       return;
     }
     environment.recorder.start(250);
-    startAnalyserLoop(deps, environment.analyser);
   } catch (error) {
     console.error("recording error", error);
     releaseAudioResources();
@@ -1237,21 +1200,11 @@ export function VoiceCommandCenter({
   const analyserRef = useRef<AnalyserNode | null>(null);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const mediaStreamRef = useRef<MediaStream | null>(null);
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const visualizerFrameRef = useRef<number | null>(null);
   const recordingRef = useRef(false);
   const recordingStartPendingRef = useRef(false);
   const stopRequestedRef = useRef(false);
   const lastAudioResponseRef = useRef<{ audio: string; sampleRate: number } | null>(null);
   const lastVoiceModeSentRef = useRef<string | null>(null);
-
-  const clearVisualizer = useCallback(() => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-  }, []);
 
   useEffect(() => {
     const mq = globalThis.matchMedia("(prefers-reduced-motion: reduce)");
@@ -1272,31 +1225,6 @@ export function VoiceCommandCenter({
       setStatusMessage,
     });
   }, [audioEnabled, connected, t, voiceModePreset]);
-
-  const drawVisualizer = useCallback((samples: Float32Array) => {
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) return;
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    ctx.fillStyle = "rgba(15,23,42,0.9)";
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
-    ctx.strokeStyle = "#34d399";
-    ctx.lineWidth = 2;
-    ctx.beginPath();
-    const sliceWidth = canvas.width / Math.max(samples.length, 1);
-    let x = 0;
-    for (const [index, value] of samples.entries()) {
-      const y = (0.5 + value / 2) * canvas.height;
-      if (index === 0) {
-        ctx.moveTo(x, y);
-      } else {
-        ctx.lineTo(x, y);
-      }
-      x += sliceWidth;
-    }
-    ctx.stroke();
-  }, []);
 
   const refreshAudioStatus = useCallback(async () => {
     try {
@@ -1326,24 +1254,6 @@ export function VoiceCommandCenter({
     ttsSourceRef.current = null;
     ttsAnalyserRef.current?.disconnect();
     ttsAnalyserRef.current = null;
-  }, []);
-
-  const scaleAudioChunkForDisplay = useCallback((samples: Float32Array) => {
-    let peak = 0;
-    for (const sample of samples) {
-      const value = Math.abs(sample);
-      if (value > peak) {
-        peak = value;
-      }
-    }
-    const targetPeak = 0.6;
-    const gain = peak > 0 ? Math.min(24, Math.max(1, targetPeak / peak)) : 1;
-    const normalized = new Float32Array(samples.length);
-    for (let index = 0; index < samples.length; index += 1) {
-      const value = (samples[index] ?? 0) * gain;
-      normalized[index] = Math.max(-1, Math.min(1, value));
-    }
-    return { normalized, peak, gain };
   }, []);
 
   const getMediaRecorderMimeType = useCallback(() => {
@@ -1478,11 +1388,6 @@ export function VoiceCommandCenter({
   );
 
   const releaseAudioResources = useCallback(() => {
-    const browserWindow = getBrowserWindow();
-    if (visualizerFrameRef.current !== null) {
-      browserWindow?.cancelAnimationFrame(visualizerFrameRef.current);
-      visualizerFrameRef.current = null;
-    }
     if (mediaRecorderRef.current?.state === "recording") {
       try {
         mediaRecorderRef.current.stop();
@@ -1570,7 +1475,6 @@ export function VoiceCommandCenter({
     stopRequestedRef.current = false;
     setRecording(false);
     setLastAudioSignal("recording:stop");
-    clearVisualizer();
     setStatusMessage(t("voice.status.recordingEnded"));
     const recorder = mediaRecorderRef.current;
     if (recorder?.state === "recording") {
@@ -1579,7 +1483,7 @@ export function VoiceCommandCenter({
       sendControlMessage({ command: "stop_recording" });
       releaseAudioResources();
     }
-  }, [clearVisualizer, releaseAudioResources, sendControlMessage, t]);
+  }, [releaseAudioResources, sendControlMessage, t]);
 
   const startRecording = useCallback(
     async () =>
@@ -1593,7 +1497,6 @@ export function VoiceCommandCenter({
         analyserRef,
         mediaRecorderRef,
         mediaStreamRef,
-        visualizerFrameRef,
         recordingRef,
         recordingStartPendingRef,
         stopRequestedRef,
@@ -1605,19 +1508,15 @@ export function VoiceCommandCenter({
         sendControlMessage,
         getMediaRecorderMimeType,
         ensurePlaybackContext,
-        drawVisualizer,
-        scaleAudioChunkForDisplay,
         stopRecording,
         activeWindow: getBrowserWindow(),
       }),
     [
-      drawVisualizer,
       ensurePlaybackContext,
       getMediaRecorderMimeType,
       audioEnabled,
       isVoiceModeEnabled,
       releaseAudioResources,
-      scaleAudioChunkForDisplay,
       sendControlMessage,
       stopRecording,
       t,
@@ -1766,7 +1665,6 @@ export function VoiceCommandCenter({
             runtimeSnapshot={runtimeSnapshot}
             runtimeSnapshotSummary={runtimeSnapshotSummary}
           />
-          <canvas ref={canvasRef} width={320} height={80} className="hidden" />
           <p className="text-hint">{statusMessage ?? t("voice.status.channelReady")}</p>
           <div className="rounded-2xl box-muted p-3 text-xs text-zinc-300">
             <div className="grid grid-cols-2 gap-2">

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -1073,6 +1073,12 @@ type VoiceCommandCenterStatusSidebarProps = Readonly<{
   runtimeSummary: string;
   transcription: string;
   response: string;
+  orbState: VoiceOrbState;
+  inputLevel: number;
+  outputLevel: number;
+  reducedMotion: boolean;
+  isVoiceModeEnabled: boolean;
+  audioEnabled: boolean;
 }>;
 
 function VoiceCommandCenterStatusSidebar({
@@ -1085,9 +1091,27 @@ function VoiceCommandCenterStatusSidebar({
   runtimeSummary,
   transcription,
   response,
+  orbState,
+  inputLevel,
+  outputLevel,
+  reducedMotion,
+  isVoiceModeEnabled,
+  audioEnabled,
 }: VoiceCommandCenterStatusSidebarProps) {
   return (
     <div className="space-y-3">
+      {isVoiceModeEnabled ? (
+        <div className="flex justify-center rounded-2xl box-muted py-4">
+          <VoiceOrb
+            state={orbState}
+            inputLevel={inputLevel}
+            outputLevel={outputLevel}
+            disabled={!audioEnabled}
+            reducedMotion={reducedMotion}
+            label={t(`voice.orb.stateLabel.${orbState}`)}
+          />
+        </div>
+      ) : null}
       <div className="rounded-2xl box-muted p-4">
         <p className="eyebrow">{t("voice.controls.audioWs")}</p>
         {audioStatus ? (
@@ -1738,18 +1762,6 @@ export function VoiceCommandCenter({
             runtimeSnapshot={runtimeSnapshot}
             runtimeSnapshotSummary={runtimeSnapshotSummary}
           />
-          {isVoiceModeEnabled ? (
-            <div className="flex justify-center rounded-2xl box-muted py-4">
-              <VoiceOrb
-                state={orbState}
-                inputLevel={inputLevel}
-                outputLevel={outputLevel}
-                disabled={!audioEnabled}
-                reducedMotion={reducedMotion}
-                label={t(`voice.orb.stateLabel.${orbState}`)}
-              />
-            </div>
-          ) : null}
           <canvas ref={canvasRef} width={320} height={80} className="hidden" />
           <p className="text-hint">{statusMessage ?? t("voice.status.channelReady")}</p>
           <div className="rounded-2xl box-muted p-3 text-xs text-zinc-300">
@@ -1775,6 +1787,12 @@ export function VoiceCommandCenter({
           runtimeSummary={runtimeSummary}
           transcription={transcription}
           response={response}
+          orbState={orbState}
+          inputLevel={inputLevel}
+          outputLevel={outputLevel}
+          reducedMotion={reducedMotion}
+          isVoiceModeEnabled={isVoiceModeEnabled}
+          audioEnabled={audioEnabled}
         />
       </div>
     </Panel>

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -8,7 +8,6 @@ import { Badge } from "@/components/ui/badge";
 import { getAudioWsUrl } from "@/lib/env";
 import { useTranslation } from "@/lib/i18n";
 import { VoiceOrb, type VoiceOrbState } from "@/components/voice/voice-orb";
-import { useAudioLevel } from "@/components/voice/use-audio-level";
 import { useOrbEffectsConfig, type OrbEffectsConfig } from "@/components/voice/use-orb-effects-config";
 
 type AudioStatus = {
@@ -1075,8 +1074,6 @@ type VoiceCommandCenterStatusSidebarProps = Readonly<{
   transcription: string;
   response: string;
   orbState: VoiceOrbState;
-  inputLevel: number;
-  outputLevel: number;
   reducedMotion: boolean;
   isVoiceModeEnabled: boolean;
   audioEnabled: boolean;
@@ -1096,8 +1093,6 @@ function VoiceCommandCenterStatusSidebar({
   transcription,
   response,
   orbState,
-  inputLevel,
-  outputLevel,
   reducedMotion,
   isVoiceModeEnabled,
   audioEnabled,
@@ -1111,8 +1106,6 @@ function VoiceCommandCenterStatusSidebar({
         <div className="flex justify-center rounded-2xl box-muted py-6">
           <VoiceOrb
             state={orbState}
-            inputLevel={inputLevel}
-            outputLevel={outputLevel}
             disabled={!audioEnabled}
             reducedMotion={reducedMotion}
             label={t(`voice.orb.stateLabel.${orbState}`)}
@@ -1266,9 +1259,6 @@ export function VoiceCommandCenter({
     mq.addEventListener("change", handler);
     return () => mq.removeEventListener("change", handler);
   }, []);
-
-  const inputLevel = useAudioLevel(analyserRef, recording);
-  const outputLevel = useAudioLevel(ttsAnalyserRef, playbackState === "playing");
 
   useEffect(() => {
     syncVoiceModeSelection({
@@ -1799,8 +1789,6 @@ export function VoiceCommandCenter({
           transcription={transcription}
           response={response}
           orbState={orbState}
-          inputLevel={inputLevel}
-          outputLevel={outputLevel}
           reducedMotion={reducedMotion}
           isVoiceModeEnabled={isVoiceModeEnabled}
           audioEnabled={audioEnabled}

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -7,6 +7,8 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { getAudioWsUrl } from "@/lib/env";
 import { useTranslation } from "@/lib/i18n";
+import { VoiceOrb, type VoiceOrbState } from "@/components/voice/voice-orb";
+import { useAudioLevel } from "@/components/voice/use-audio-level";
 
 type AudioStatus = {
   enabled: boolean;
@@ -620,13 +622,35 @@ const getPlaybackStateLabel = (
   return t("voice.status.playbackIdleShort");
 };
 
+const deriveOrbState = (
+  connected: boolean,
+  recording: boolean,
+  processingStatus: string | null,
+  playbackState: PlaybackState,
+  lastAudioSignal: string,
+): VoiceOrbState => {
+  if (!connected) return "offline";
+  if (recording) return "recording";
+  if (processingStatus) {
+    const s = processingStatus.toLowerCase();
+    if (s.includes("stt") || s.includes("transcri") || s.includes("whisper")) return "stt";
+    return "thinking";
+  }
+  if (playbackState === "playing") return "tts";
+  if (playbackState === "error") return "error";
+  if (lastAudioSignal === "complete") return "complete";
+  return "ready";
+};
+
 const handleVoiceRecordingStarted = (
   t: Translator,
   setStatusMessage: (value: string | null) => void,
   setLastAudioSignal: (value: string) => void,
+  setProcessingStatus?: (value: string | null) => void,
 ) => {
   setStatusMessage(t("voice.status.recordingStarted"));
   setLastAudioSignal("recording:started");
+  setProcessingStatus?.(null);
 };
 
 const handleVoiceProcessing = (
@@ -634,10 +658,12 @@ const handleVoiceProcessing = (
   data: Record<string, unknown>,
   setStatusMessage: (value: string | null) => void,
   setLastAudioSignal: (value: string) => void,
+  setProcessingStatus?: (value: string | null) => void,
 ) => {
   const status = toPrimitiveString(data.status) ?? "unknown";
   setStatusMessage(t("voice.status.processing", { status }));
   setLastAudioSignal(`processing:${status}`);
+  setProcessingStatus?.(status);
 };
 
 const handleVoiceTranscript = (
@@ -683,9 +709,11 @@ const handleVoiceCompletion = (
   t: Translator,
   setStatusMessage: (value: string | null) => void,
   setLastAudioSignal: (value: string) => void,
+  setProcessingStatus?: (value: string | null) => void,
 ) => {
   setStatusMessage(t("voice.status.complete"));
   setLastAudioSignal("complete");
+  setProcessingStatus?.(null);
 };
 
 const handleVoiceError = (
@@ -1168,12 +1196,15 @@ export function VoiceCommandCenter({
   const [ttsMuted, setTtsMuted] = useState(false);
   const [audioChunkCount, setAudioChunkCount] = useState(0);
   const [lastAudioSignal, setLastAudioSignal] = useState("idle");
+  const [processingStatus, setProcessingStatus] = useState<string | null>(null);
+  const [reducedMotion, setReducedMotion] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectAttemptsRef = useRef(0);
   const reconnectTimeoutRef = useRef<number | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
   const ttsAudioContextRef = useRef<AudioContext | null>(null);
   const ttsSourceRef = useRef<AudioBufferSourceNode | null>(null);
+  const ttsAnalyserRef = useRef<AnalyserNode | null>(null);
   const sourceNodeRef = useRef<MediaStreamAudioSourceNode | null>(null);
   const analyserRef = useRef<AnalyserNode | null>(null);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
@@ -1193,6 +1224,17 @@ export function VoiceCommandCenter({
     if (!ctx) return;
     ctx.clearRect(0, 0, canvas.width, canvas.height);
   }, []);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReducedMotion(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setReducedMotion(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  const inputLevel = useAudioLevel(analyserRef, recording);
+  const outputLevel = useAudioLevel(ttsAnalyserRef, playbackState === "playing");
 
   useEffect(() => {
     syncVoiceModeSelection({
@@ -1257,6 +1299,7 @@ export function VoiceCommandCenter({
     }
     ttsSourceRef.current?.disconnect();
     ttsSourceRef.current = null;
+    ttsAnalyserRef.current = null;
   }, []);
 
   const scaleAudioChunkForDisplay = useCallback((samples: Float32Array) => {
@@ -1340,11 +1383,16 @@ export function VoiceCommandCenter({
         }
         const source = ctx.createBufferSource();
         source.buffer = audioBuffer;
-        source.connect(ctx.destination);
+        const ttsAnalyser = ctx.createAnalyser();
+        ttsAnalyser.fftSize = 512;
+        source.connect(ttsAnalyser);
+        ttsAnalyser.connect(ctx.destination);
+        ttsAnalyserRef.current = ttsAnalyser;
         source.onended = () => {
           if (ttsSourceRef.current === source) {
             setPlaybackState("idle");
             ttsSourceRef.current = null;
+            ttsAnalyserRef.current = null;
           }
         };
         ttsSourceRef.current = source;
@@ -1372,11 +1420,11 @@ export function VoiceCommandCenter({
     (data: Record<string, unknown>) => {
       const messageType = toPrimitiveString(data.type) ?? "";
       if (messageType === "recording_started") {
-        handleVoiceRecordingStarted(t, setStatusMessage, setLastAudioSignal);
+        handleVoiceRecordingStarted(t, setStatusMessage, setLastAudioSignal, setProcessingStatus);
         return;
       }
       if (messageType === "processing") {
-        handleVoiceProcessing(t, data, setStatusMessage, setLastAudioSignal);
+        handleVoiceProcessing(t, data, setStatusMessage, setLastAudioSignal, setProcessingStatus);
         return;
       }
       if (messageType === "transcription") {
@@ -1392,7 +1440,7 @@ export function VoiceCommandCenter({
         return;
       }
       if (messageType === "complete") {
-        handleVoiceCompletion(t, setStatusMessage, setLastAudioSignal);
+        handleVoiceCompletion(t, setStatusMessage, setLastAudioSignal, setProcessingStatus);
         return;
       }
       if (messageType === "error") {
@@ -1549,6 +1597,8 @@ export function VoiceCommandCenter({
     ],
   );
 
+  const orbState = deriveOrbState(connected, recording, processingStatus, playbackState, lastAudioSignal);
+
   const recordingButtonClass = getRecordingButtonClass(
     audioEnabled,
     isVoiceModeEnabled,
@@ -1688,7 +1738,19 @@ export function VoiceCommandCenter({
             runtimeSnapshot={runtimeSnapshot}
             runtimeSnapshotSummary={runtimeSnapshotSummary}
           />
-          <canvas ref={canvasRef} width={320} height={80} className="w-full rounded-2xl box-muted" />
+          {isVoiceModeEnabled ? (
+            <div className="flex justify-center rounded-2xl box-muted py-4">
+              <VoiceOrb
+                state={orbState}
+                inputLevel={inputLevel}
+                outputLevel={outputLevel}
+                disabled={!audioEnabled}
+                reducedMotion={reducedMotion}
+                label={t(`voice.orb.stateLabel.${orbState}`)}
+              />
+            </div>
+          ) : null}
+          <canvas ref={canvasRef} width={320} height={80} className="hidden" />
           <p className="text-hint">{statusMessage ?? t("voice.status.channelReady")}</p>
           <div className="rounded-2xl box-muted p-3 text-xs text-zinc-300">
             <div className="grid grid-cols-2 gap-2">

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -634,6 +634,7 @@ const deriveOrbState = (
   if (processingStatus) {
     const s = processingStatus.toLowerCase();
     if (s.includes("stt") || s.includes("transcri") || s.includes("whisper")) return "stt";
+    if (s.includes("tts") || s.includes("speak")) return "tts";
     return "thinking";
   }
   if (playbackState === "playing") return "tts";
@@ -1323,6 +1324,7 @@ export function VoiceCommandCenter({
     }
     ttsSourceRef.current?.disconnect();
     ttsSourceRef.current = null;
+    ttsAnalyserRef.current?.disconnect();
     ttsAnalyserRef.current = null;
   }, []);
 
@@ -1416,6 +1418,7 @@ export function VoiceCommandCenter({
           if (ttsSourceRef.current === source) {
             setPlaybackState("idle");
             ttsSourceRef.current = null;
+            ttsAnalyser.disconnect();
             ttsAnalyserRef.current = null;
           }
         };

--- a/web-next/components/voice/voice-orb.tsx
+++ b/web-next/components/voice/voice-orb.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { RefObject, useEffect, useMemo, useRef, useState } from "react";
+import { RefObject, useEffect, useRef, useState } from "react";
 
+import { useAudioLevel } from "@/components/voice/use-audio-level";
 import { OrbFrequencyRing } from "@/components/voice/orb-frequency-ring";
 import type { OrbEffectsConfig } from "@/components/voice/use-orb-effects-config";
 
@@ -79,8 +80,9 @@ const CORE_SIZE = 72;
 
 type VoiceOrbProps = Readonly<{
   state: VoiceOrbState;
-  inputLevel: number;
-  outputLevel: number;
+  /** Override audio level — used in tests; omit in production (computed internally). */
+  inputLevel?: number;
+  outputLevel?: number;
   disabled?: boolean;
   reducedMotion?: boolean;
   label?: string;
@@ -91,8 +93,8 @@ type VoiceOrbProps = Readonly<{
 
 export function VoiceOrb({
   state,
-  inputLevel,
-  outputLevel,
+  inputLevel: inputLevelProp,
+  outputLevel: outputLevelProp,
   disabled = false,
   reducedMotion = false,
   label,
@@ -105,7 +107,15 @@ export function VoiceOrb({
   const visual = ORB_VISUALS[effectiveState];
   const noAnim = reducedMotion;
 
-  // ── Audio level for active state ─────────────────────────────────────
+  // ── Audio level (computed here to avoid 60fps re-renders in parent) ──
+  // inputLevelProp / outputLevelProp are accepted as test overrides; in
+  // production the parent passes analyserRefs instead and omits these.
+  const fallbackRef = useRef<AnalyserNode | null>(null);
+  const inputLevelHook  = useAudioLevel(micAnalyserRef ?? fallbackRef, effectiveState === "recording");
+  const outputLevelHook = useAudioLevel(ttsAnalyserRef ?? fallbackRef, effectiveState === "tts");
+  const inputLevel  = inputLevelProp  ?? inputLevelHook;
+  const outputLevel = outputLevelProp ?? outputLevelHook;
+
   const audioLevel =
     effectiveState === "recording" ? inputLevel
     : effectiveState === "tts"     ? outputLevel
@@ -195,15 +205,17 @@ export function VoiceOrb({
   const hasMotion = coreScale !== 1;
 
   // ── Ambient glow box-shadow (3 layers, audio-reactive) ───────────────
-  const glowShadow = useMemo(() => {
-    if (!cfg.glow || noAnim || effectiveState === "offline") return undefined;
+  // Not memoized: depends on audioLevel which updates every animation frame,
+  // so memo overhead exceeds any benefit.
+  let glowShadow: string | undefined;
+  if (cfg.glow && !noAnim && effectiveState !== "offline") {
     const [c1, c2, c3] = ORB_GLOW[effectiveState];
     const l = Math.min(1, audioLevel);
     const r1 = (16 + l * 18).toFixed(0);
     const r2 = (30 + l * 32).toFixed(0);
     const r3 = (52 + l * 62).toFixed(0);
-    return `0 0 ${r1}px ${c1}, 0 0 ${r2}px ${c2}, 0 0 ${r3}px ${c3}`;
-  }, [cfg.glow, noAnim, effectiveState, audioLevel]);
+    glowShadow = `0 0 ${r1}px ${c1}, 0 0 ${r2}px ${c2}, 0 0 ${r3}px ${c3}`;
+  }
 
   const ringAnimation = noAnim ? "" : visual.ringAnimation;
   const coreAnimation = noAnim ? "" : visual.coreAnimation;

--- a/web-next/components/voice/voice-orb.tsx
+++ b/web-next/components/voice/voice-orb.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { useMemo } from "react";
+import { RefObject, useEffect, useMemo, useRef, useState } from "react";
+
+import { OrbFrequencyRing } from "@/components/voice/orb-frequency-ring";
+import type { OrbEffectsConfig } from "@/components/voice/use-orb-effects-config";
 
 export type VoiceOrbState =
   | "offline"
@@ -20,55 +23,59 @@ type OrbVisual = {
 };
 
 const ORB_VISUALS: Record<VoiceOrbState, OrbVisual> = {
-  offline: {
-    coreColor: "bg-zinc-700",
-    glowColor: "bg-zinc-600/20",
-    ringAnimation: "",
-    coreAnimation: "",
-  },
-  ready: {
-    coreColor: "bg-indigo-600",
-    glowColor: "bg-indigo-500/20",
-    ringAnimation: "animate-pulse-signal",
-    coreAnimation: "",
-  },
-  recording: {
-    coreColor: "bg-emerald-500",
-    glowColor: "bg-emerald-400/30",
-    ringAnimation: "",
-    coreAnimation: "",
-  },
-  stt: {
-    coreColor: "bg-amber-500",
-    glowColor: "bg-amber-400/25",
-    ringAnimation: "animate-spin",
-    coreAnimation: "animate-pulse",
-  },
-  thinking: {
-    coreColor: "bg-violet-600",
-    glowColor: "bg-violet-500/25",
-    ringAnimation: "animate-orb-thinking",
-    coreAnimation: "",
-  },
-  tts: {
-    coreColor: "bg-cyan-500",
-    glowColor: "bg-cyan-400/30",
-    ringAnimation: "",
-    coreAnimation: "",
-  },
-  complete: {
-    coreColor: "bg-teal-500",
-    glowColor: "bg-teal-400/20",
-    ringAnimation: "animate-pulse",
-    coreAnimation: "",
-  },
-  error: {
-    coreColor: "bg-rose-600",
-    glowColor: "bg-rose-500/20",
-    ringAnimation: "",
-    coreAnimation: "",
-  },
+  offline:   { coreColor: "bg-zinc-700",    glowColor: "bg-zinc-600/20",    ringAnimation: "",                    coreAnimation: "" },
+  ready:     { coreColor: "bg-indigo-600",  glowColor: "bg-indigo-500/20",  ringAnimation: "animate-pulse-signal", coreAnimation: "" },
+  recording: { coreColor: "bg-emerald-500", glowColor: "bg-emerald-400/30", ringAnimation: "",                    coreAnimation: "" },
+  stt:       { coreColor: "bg-amber-500",   glowColor: "bg-amber-400/25",   ringAnimation: "animate-spin",        coreAnimation: "animate-pulse" },
+  thinking:  { coreColor: "bg-violet-600",  glowColor: "bg-violet-500/25",  ringAnimation: "animate-orb-thinking", coreAnimation: "" },
+  tts:       { coreColor: "bg-cyan-500",    glowColor: "bg-cyan-400/30",    ringAnimation: "",                    coreAnimation: "" },
+  complete:  { coreColor: "bg-teal-500",    glowColor: "bg-teal-400/20",    ringAnimation: "animate-pulse",       coreAnimation: "" },
+  error:     { coreColor: "bg-rose-600",    glowColor: "bg-rose-500/20",    ringAnimation: "",                    coreAnimation: "" },
 };
+
+// Three-layer ambient glow: [inner, mid, outer] RGBA strings
+const ORB_GLOW: Record<VoiceOrbState, [string, string, string]> = {
+  offline:   ["rgba(113,113,122,0.08)", "rgba(113,113,122,0.03)", "transparent"],
+  ready:     ["rgba(99,102,241,0.38)",  "rgba(99,102,241,0.13)", "rgba(99,102,241,0.04)"],
+  recording: ["rgba(52,211,153,0.48)",  "rgba(52,211,153,0.18)", "rgba(52,211,153,0.06)"],
+  stt:       ["rgba(251,191,36,0.38)",  "rgba(251,191,36,0.13)", "rgba(251,191,36,0.04)"],
+  thinking:  ["rgba(139,92,246,0.48)",  "rgba(139,92,246,0.18)", "rgba(139,92,246,0.06)"],
+  tts:       ["rgba(34,211,238,0.48)",  "rgba(34,211,238,0.18)", "rgba(34,211,238,0.06)"],
+  complete:  ["rgba(20,184,166,0.38)",  "rgba(20,184,166,0.13)", "rgba(20,184,166,0.04)"],
+  error:     ["rgba(225,29,72,0.38)",   "rgba(225,29,72,0.13)",  "rgba(225,29,72,0.04)"],
+};
+
+const FFT_RING_COLOR: Partial<Record<VoiceOrbState, string>> = {
+  recording: "rgba(52,211,153,0.8)",
+  tts:       "rgba(34,211,238,0.8)",
+};
+
+const RIPPLE_COLORS: Partial<Record<VoiceOrbState, [string, string, string]>> = {
+  recording: ["bg-emerald-400/25", "bg-emerald-400/18", "bg-emerald-400/10"],
+  tts:       ["bg-cyan-400/25",    "bg-cyan-400/18",    "bg-cyan-400/10"],
+};
+
+const PARTICLE_COLORS: Partial<Record<VoiceOrbState, string>> = {
+  recording: "rgba(52,211,153,0.72)",
+  tts:       "rgba(34,211,238,0.72)",
+};
+
+type Particle = {
+  id: number;
+  angle: number;
+  duration: number;
+  delay: number;
+  offset: number;
+  size: number;
+};
+
+const DEFAULT_EFFECTS: OrbEffectsConfig = {
+  ripple: true, blob: true, glow: true, transitions: true,
+  frequencyRing: true, coreTexture: true, particles: true, stateLabel: true,
+};
+
+const ORB_SIZE = 120;
+const CORE_SIZE = 72;
 
 type VoiceOrbProps = Readonly<{
   state: VoiceOrbState;
@@ -77,6 +84,9 @@ type VoiceOrbProps = Readonly<{
   disabled?: boolean;
   reducedMotion?: boolean;
   label?: string;
+  effectsConfig?: OrbEffectsConfig;
+  micAnalyserRef?: RefObject<AnalyserNode | null>;
+  ttsAnalyserRef?: RefObject<AnalyserNode | null>;
 }>;
 
 export function VoiceOrb({
@@ -86,20 +96,112 @@ export function VoiceOrb({
   disabled = false,
   reducedMotion = false,
   label,
+  effectsConfig,
+  micAnalyserRef,
+  ttsAnalyserRef,
 }: VoiceOrbProps) {
+  const cfg = effectsConfig ?? DEFAULT_EFFECTS;
   const effectiveState: VoiceOrbState = disabled ? "offline" : state;
   const visual = ORB_VISUALS[effectiveState];
+  const noAnim = reducedMotion;
 
-  const coreScale = useMemo(() => {
-    if (reducedMotion) return 1;
-    if (effectiveState === "recording") return 1 + Math.min(1, inputLevel) * 0.35;
-    if (effectiveState === "tts") return 1 + Math.min(1, outputLevel) * 0.35;
-    return 1;
-  }, [effectiveState, inputLevel, outputLevel, reducedMotion]);
+  // ── Audio level for active state ─────────────────────────────────────
+  const audioLevel =
+    effectiveState === "recording" ? inputLevel
+    : effectiveState === "tts"     ? outputLevel
+    : 0;
 
-  const ringAnimation = reducedMotion ? "" : visual.ringAnimation;
-  const coreAnimation = reducedMotion ? "" : visual.coreAnimation;
+  // ── Transition flash on state change ─────────────────────────────────
+  const [flashClass, setFlashClass] = useState("");
+  const prevStateRef = useRef<VoiceOrbState>(effectiveState);
+
+  useEffect(() => {
+    if (!cfg.transitions || noAnim) return;
+    if (prevStateRef.current === effectiveState) return;
+    prevStateRef.current = effectiveState;
+
+    const cls =
+      effectiveState === "recording" || effectiveState === "complete"
+        ? "animate-orb-flash"
+        : "";
+    if (!cls) return;
+
+    setFlashClass(cls);
+    const id = setTimeout(() => setFlashClass(""), 350);
+    return () => clearTimeout(id);
+  }, [effectiveState, cfg.transitions, noAnim]);
+
+  // ── Complete burst (one-shot ring that expands then vanishes) ─────────
+  const [showBurst, setShowBurst] = useState(false);
+  const burstKeyRef = useRef(0);
+
+  useEffect(() => {
+    if (!cfg.transitions || noAnim || effectiveState !== "complete") return;
+    burstKeyRef.current += 1;
+    setShowBurst(true);
+    const id = setTimeout(() => setShowBurst(false), 650);
+    return () => clearTimeout(id);
+  }, [effectiveState, cfg.transitions, noAnim]);
+
+  // ── Particles (generated client-side to avoid SSR mismatch) ──────────
+  const [particles, setParticles] = useState<Particle[]>([]);
+
+  useEffect(() => {
+    setParticles(
+      Array.from({ length: 9 }, (_, i) => ({
+        id: i,
+        angle: (360 / 9) * i + Math.random() * 20 - 10,
+        duration: 1.6 + Math.random() * 0.9,
+        delay: Math.random() * 1.1,
+        offset: 30 + Math.random() * 8,
+        size: 2 + Math.random() * 2,
+      }))
+    );
+  }, []);
+
+  const showParticles =
+    !noAnim && cfg.particles &&
+    (effectiveState === "recording" || effectiveState === "tts");
+
+  // ── Derived booleans ─────────────────────────────────────────────────
+  const showRipple =
+    !noAnim && cfg.ripple &&
+    (effectiveState === "recording" || effectiveState === "tts");
+
+  const showBlob =
+    !noAnim && cfg.blob &&
+    (effectiveState === "recording" || effectiveState === "tts");
+
+  const activeAnalyser =
+    effectiveState === "recording" ? micAnalyserRef
+    : effectiveState === "tts"     ? ttsAnalyserRef
+    : undefined;
+
+  const showFreqRing =
+    !noAnim && cfg.frequencyRing && !!activeAnalyser &&
+    (effectiveState === "recording" || effectiveState === "tts");
+
+  // ── Core scale ───────────────────────────────────────────────────────
+  const coreScale = noAnim ? 1 : 1 + Math.min(1, audioLevel) * 0.35;
   const hasMotion = coreScale !== 1;
+
+  // ── Ambient glow box-shadow (3 layers, audio-reactive) ───────────────
+  const glowShadow = useMemo(() => {
+    if (!cfg.glow || noAnim || effectiveState === "offline") return undefined;
+    const [c1, c2, c3] = ORB_GLOW[effectiveState];
+    const l = Math.min(1, audioLevel);
+    const r1 = (16 + l * 18).toFixed(0);
+    const r2 = (30 + l * 32).toFixed(0);
+    const r3 = (52 + l * 62).toFixed(0);
+    return `0 0 ${r1}px ${c1}, 0 0 ${r2}px ${c2}, 0 0 ${r3}px ${c3}`;
+  }, [cfg.glow, noAnim, effectiveState, audioLevel]);
+
+  const ringAnimation = noAnim ? "" : visual.ringAnimation;
+  const coreAnimation = noAnim ? "" : visual.coreAnimation;
+  const blobClass     = showBlob ? "animate-orb-blob" : "";
+  const rippleColors  = RIPPLE_COLORS[effectiveState];
+  const particleColor = PARTICLE_COLORS[effectiveState] ?? "rgba(255,255,255,0.5)";
+  const fftColor      = FFT_RING_COLOR[effectiveState] ?? "transparent";
 
   return (
     <div
@@ -109,34 +211,134 @@ export function VoiceOrb({
       className="flex flex-col items-center gap-3 py-2"
       style={{ minHeight: "160px" }}
     >
+      {/* ── Container ── */}
       <div
         className="relative flex items-center justify-center"
-        style={{ width: 120, height: 120 }}
+        style={{
+          width: ORB_SIZE,
+          height: ORB_SIZE,
+          borderRadius: "50%",
+          boxShadow: glowShadow,
+          transition: "box-shadow 220ms ease",
+        }}
       >
-        {/* Outer glow ring */}
+        {/* ── Ripple rings ── */}
+        {showRipple && rippleColors && (
+          <>
+            <div className={`absolute inset-0 rounded-full ${rippleColors[0]} animate-orb-ripple`} style={{ animationDelay: "0s" }} />
+            <div className={`absolute inset-0 rounded-full ${rippleColors[1]} animate-orb-ripple`} style={{ animationDelay: "0.48s" }} />
+            <div className={`absolute inset-0 rounded-full ${rippleColors[2]} animate-orb-ripple`} style={{ animationDelay: "0.96s" }} />
+          </>
+        )}
+
+        {/* ── Base glow ring ── */}
         <div
           className={`absolute inset-0 rounded-full blur-2xl transition-colors duration-500 ${visual.glowColor} ${ringAnimation}`}
         />
-        {/* Secondary ring for stt spin indicator */}
-        {effectiveState === "stt" && !reducedMotion && (
+
+        {/* ── FFT frequency ring ── */}
+        {showFreqRing && activeAnalyser && (
+          <OrbFrequencyRing
+            analyserRef={activeAnalyser}
+            active={showFreqRing}
+            color={fftColor}
+            size={ORB_SIZE}
+          />
+        )}
+
+        {/* ── STT spinning border ── */}
+        {effectiveState === "stt" && !noAnim && (
           <div className="absolute inset-4 rounded-full border-2 border-amber-400/40 border-t-amber-400 animate-spin" />
         )}
-        {/* Core orb */}
+
+        {/* ── Complete burst ring (one-shot) ── */}
+        {showBurst && (
+          <div
+            key={burstKeyRef.current}
+            className="absolute inset-0 rounded-full border-2 border-teal-400/70 animate-orb-burst"
+            style={{ pointerEvents: "none" }}
+          />
+        )}
+
+        {/* ── Core orb ── */}
         <div
           data-testid="voice-orb-core"
-          className={`relative rounded-full shadow-lg transition-colors duration-300 ${visual.coreColor} ${coreAnimation}`}
+          className={`relative overflow-hidden rounded-full shadow-lg transition-colors duration-300 ${visual.coreColor} ${coreAnimation} ${blobClass} ${flashClass}`}
           style={{
-            width: 72,
-            height: 72,
-            transform: `scale(${coreScale})`,
+            width: CORE_SIZE,
+            height: CORE_SIZE,
+            transform: `scale(${coreScale.toFixed(4)})`,
             willChange: hasMotion ? "transform" : undefined,
-            transition: reducedMotion
-              ? "background-color 300ms"
-              : `transform 80ms linear, background-color 300ms`,
+            transition: noAnim
+              ? "background-color 300ms, border-radius 400ms"
+              : "transform 80ms linear, background-color 300ms, border-radius 400ms ease-in-out",
           }}
-        />
+        >
+          {/* Specular highlight (3D gloss effect) */}
+          {cfg.coreTexture && (
+            <div
+              className="pointer-events-none absolute inset-0"
+              style={{
+                background:
+                  "radial-gradient(circle at 33% 28%, rgba(255,255,255,0.22) 0%, transparent 58%)",
+              }}
+            />
+          )}
+          {/* Plasma inner rings */}
+          {cfg.coreTexture && !noAnim && (
+            <>
+              <div
+                className="animate-orb-plasma-slow pointer-events-none absolute rounded-full opacity-[0.18]"
+                style={{
+                  width: "58%", height: "58%",
+                  top: "21%", left: "21%",
+                  border: "1px solid rgba(255,255,255,0.5)",
+                }}
+              />
+              <div
+                className="animate-orb-plasma-fast pointer-events-none absolute rounded-full opacity-[0.13]"
+                style={{
+                  width: "80%", height: "80%",
+                  top: "10%", left: "10%",
+                  border: "1px solid rgba(255,255,255,0.3)",
+                }}
+              />
+            </>
+          )}
+        </div>
+
+        {/* ── Particles ── */}
+        {showParticles && particles.map((p) => {
+          const rad = (p.angle * Math.PI) / 180;
+          const x = ORB_SIZE / 2 + p.offset * Math.cos(rad);
+          const y = ORB_SIZE / 2 + p.offset * Math.sin(rad);
+          return (
+            <div
+              key={p.id}
+              className="pointer-events-none absolute rounded-full animate-orb-particle-rise"
+              style={{
+                width: p.size,
+                height: p.size,
+                left: x - p.size / 2,
+                top: y - p.size / 2,
+                backgroundColor: particleColor,
+                animationDuration: `${p.duration.toFixed(2)}s`,
+                animationDelay: `${p.delay.toFixed(2)}s`,
+              }}
+            />
+          );
+        })}
       </div>
-      <p className="text-xs text-zinc-400 tabular-nums">{label ?? effectiveState}</p>
+
+      {/* ── State label ── */}
+      {cfg.stateLabel && (
+        <p
+          key={effectiveState}
+          className="animate-fade-in text-xs text-zinc-400 tabular-nums transition-opacity duration-300"
+        >
+          {label ?? effectiveState}
+        </p>
+      )}
     </div>
   );
 }

--- a/web-next/components/voice/voice-orb.tsx
+++ b/web-next/components/voice/voice-orb.tsx
@@ -288,7 +288,7 @@ export function VoiceOrb({
           style={{
             width: CORE_SIZE,
             height: CORE_SIZE,
-            transform: `scale(${parseFloat(coreScale.toFixed(4))})`,
+            transform: `scale(${coreScale === 1 ? 1 : coreScale.toFixed(4)})`,
             willChange: hasMotion ? "transform" : undefined,
             transition: noAnim
               ? "background-color 300ms, border-radius 400ms"

--- a/web-next/components/voice/voice-orb.tsx
+++ b/web-next/components/voice/voice-orb.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useMemo } from "react";
+
+export type VoiceOrbState =
+  | "offline"
+  | "ready"
+  | "recording"
+  | "stt"
+  | "thinking"
+  | "tts"
+  | "complete"
+  | "error";
+
+type OrbVisual = {
+  coreColor: string;
+  glowColor: string;
+  ringAnimation: string;
+  coreAnimation: string;
+};
+
+const ORB_VISUALS: Record<VoiceOrbState, OrbVisual> = {
+  offline: {
+    coreColor: "bg-zinc-700",
+    glowColor: "bg-zinc-600/20",
+    ringAnimation: "",
+    coreAnimation: "",
+  },
+  ready: {
+    coreColor: "bg-indigo-600",
+    glowColor: "bg-indigo-500/20",
+    ringAnimation: "animate-pulse-signal",
+    coreAnimation: "",
+  },
+  recording: {
+    coreColor: "bg-emerald-500",
+    glowColor: "bg-emerald-400/30",
+    ringAnimation: "",
+    coreAnimation: "",
+  },
+  stt: {
+    coreColor: "bg-amber-500",
+    glowColor: "bg-amber-400/25",
+    ringAnimation: "animate-spin",
+    coreAnimation: "animate-pulse",
+  },
+  thinking: {
+    coreColor: "bg-violet-600",
+    glowColor: "bg-violet-500/25",
+    ringAnimation: "animate-orb-thinking",
+    coreAnimation: "",
+  },
+  tts: {
+    coreColor: "bg-cyan-500",
+    glowColor: "bg-cyan-400/30",
+    ringAnimation: "",
+    coreAnimation: "",
+  },
+  complete: {
+    coreColor: "bg-teal-500",
+    glowColor: "bg-teal-400/20",
+    ringAnimation: "animate-pulse",
+    coreAnimation: "",
+  },
+  error: {
+    coreColor: "bg-rose-600",
+    glowColor: "bg-rose-500/20",
+    ringAnimation: "",
+    coreAnimation: "",
+  },
+};
+
+type VoiceOrbProps = Readonly<{
+  state: VoiceOrbState;
+  inputLevel: number;
+  outputLevel: number;
+  disabled?: boolean;
+  reducedMotion?: boolean;
+  label?: string;
+}>;
+
+export function VoiceOrb({
+  state,
+  inputLevel,
+  outputLevel,
+  disabled = false,
+  reducedMotion = false,
+  label,
+}: VoiceOrbProps) {
+  const effectiveState: VoiceOrbState = disabled ? "offline" : state;
+  const visual = ORB_VISUALS[effectiveState];
+
+  const coreScale = useMemo(() => {
+    if (reducedMotion) return 1;
+    if (effectiveState === "recording") return 1 + Math.min(1, inputLevel) * 0.35;
+    if (effectiveState === "tts") return 1 + Math.min(1, outputLevel) * 0.35;
+    return 1;
+  }, [effectiveState, inputLevel, outputLevel, reducedMotion]);
+
+  const ringAnimation = reducedMotion ? "" : visual.ringAnimation;
+  const coreAnimation = reducedMotion ? "" : visual.coreAnimation;
+  const hasMotion = coreScale !== 1;
+
+  return (
+    <div
+      role="img"
+      aria-label={label ?? effectiveState}
+      data-orb-state={effectiveState}
+      className="flex flex-col items-center gap-3 py-2"
+      style={{ minHeight: "160px" }}
+    >
+      <div
+        className="relative flex items-center justify-center"
+        style={{ width: 120, height: 120 }}
+      >
+        {/* Outer glow ring */}
+        <div
+          className={`absolute inset-0 rounded-full blur-2xl transition-colors duration-500 ${visual.glowColor} ${ringAnimation}`}
+        />
+        {/* Secondary ring for stt spin indicator */}
+        {effectiveState === "stt" && !reducedMotion && (
+          <div className="absolute inset-4 rounded-full border-2 border-amber-400/40 border-t-amber-400 animate-spin" />
+        )}
+        {/* Core orb */}
+        <div
+          data-testid="voice-orb-core"
+          className={`relative rounded-full shadow-lg transition-colors duration-300 ${visual.coreColor} ${coreAnimation}`}
+          style={{
+            width: 72,
+            height: 72,
+            transform: `scale(${coreScale})`,
+            willChange: hasMotion ? "transform" : undefined,
+            transition: reducedMotion
+              ? "background-color 300ms"
+              : `transform 80ms linear, background-color 300ms`,
+          }}
+        />
+      </div>
+      <p className="text-xs text-zinc-400 tabular-nums">{label ?? effectiveState}</p>
+    </div>
+  );
+}

--- a/web-next/components/voice/voice-orb.tsx
+++ b/web-next/components/voice/voice-orb.tsx
@@ -78,6 +78,10 @@ const DEFAULT_EFFECTS: OrbEffectsConfig = {
 const ORB_SIZE = 120;
 const CORE_SIZE = 72;
 
+function getFlashClass(state: VoiceOrbState): string {
+  return state === "recording" || state === "complete" ? "animate-orb-flash" : "";
+}
+
 type VoiceOrbProps = Readonly<{
   state: VoiceOrbState;
   /** Override audio level — used in tests; omit in production (computed internally). */
@@ -98,11 +102,11 @@ export function VoiceOrb({
   disabled = false,
   reducedMotion = false,
   label,
-  effectsConfig,
+  effectsConfig = DEFAULT_EFFECTS,
   micAnalyserRef,
   ttsAnalyserRef,
 }: VoiceOrbProps) {
-  const cfg = effectsConfig ?? DEFAULT_EFFECTS;
+  const cfg = effectsConfig;
   const effectiveState: VoiceOrbState = disabled ? "offline" : state;
   const visual = ORB_VISUALS[effectiveState];
   const noAnim = reducedMotion;
@@ -116,10 +120,9 @@ export function VoiceOrb({
   const inputLevel  = inputLevelProp  ?? inputLevelHook;
   const outputLevel = outputLevelProp ?? outputLevelHook;
 
-  const audioLevel =
-    effectiveState === "recording" ? inputLevel
-    : effectiveState === "tts"     ? outputLevel
-    : 0;
+  let audioLevel = 0;
+  if (effectiveState === "recording") audioLevel = inputLevel;
+  else if (effectiveState === "tts") audioLevel = outputLevel;
 
   // ── Transition flash on state change ─────────────────────────────────
   const [flashClass, setFlashClass] = useState("");
@@ -130,10 +133,7 @@ export function VoiceOrb({
     if (prevStateRef.current === effectiveState) return;
     prevStateRef.current = effectiveState;
 
-    const cls =
-      effectiveState === "recording" || effectiveState === "complete"
-        ? "animate-orb-flash"
-        : "";
+    const cls = getFlashClass(effectiveState);
     if (!cls) return;
 
     let clearId: ReturnType<typeof setTimeout>;
@@ -191,10 +191,9 @@ export function VoiceOrb({
     !noAnim && cfg.blob &&
     (effectiveState === "recording" || effectiveState === "tts");
 
-  const activeAnalyser =
-    effectiveState === "recording" ? micAnalyserRef
-    : effectiveState === "tts"     ? ttsAnalyserRef
-    : undefined;
+  let activeAnalyser: RefObject<AnalyserNode | null> | undefined;
+  if (effectiveState === "recording") activeAnalyser = micAnalyserRef;
+  else if (effectiveState === "tts") activeAnalyser = ttsAnalyserRef;
 
   const showFreqRing =
     !noAnim && cfg.frequencyRing && !!activeAnalyser &&

--- a/web-next/components/voice/voice-orb.tsx
+++ b/web-next/components/voice/voice-orb.tsx
@@ -178,26 +178,18 @@ export function VoiceOrb({
     return () => clearTimeout(id);
   }, []);
 
-  const showParticles =
-    !noAnim && cfg.particles &&
-    (effectiveState === "recording" || effectiveState === "tts");
-
   // ── Derived booleans ─────────────────────────────────────────────────
-  const showRipple =
-    !noAnim && cfg.ripple &&
-    (effectiveState === "recording" || effectiveState === "tts");
+  const isActive = effectiveState === "recording" || effectiveState === "tts";
 
-  const showBlob =
-    !noAnim && cfg.blob &&
-    (effectiveState === "recording" || effectiveState === "tts");
+  const showParticles = !noAnim && cfg.particles && isActive;
+  const showRipple    = !noAnim && cfg.ripple    && isActive;
+  const showBlob      = !noAnim && cfg.blob      && isActive;
 
   let activeAnalyser: RefObject<AnalyserNode | null> | undefined;
   if (effectiveState === "recording") activeAnalyser = micAnalyserRef;
   else if (effectiveState === "tts") activeAnalyser = ttsAnalyserRef;
 
-  const showFreqRing =
-    !noAnim && cfg.frequencyRing && !!activeAnalyser &&
-    (effectiveState === "recording" || effectiveState === "tts");
+  const showFreqRing = !noAnim && cfg.frequencyRing && !!activeAnalyser && isActive;
 
   // ── Core scale ───────────────────────────────────────────────────────
   const coreScale = noAnim ? 1 : 1 + Math.min(1, audioLevel) * 0.35;

--- a/web-next/components/voice/voice-orb.tsx
+++ b/web-next/components/voice/voice-orb.tsx
@@ -288,7 +288,7 @@ export function VoiceOrb({
           style={{
             width: CORE_SIZE,
             height: CORE_SIZE,
-            transform: `scale(${coreScale.toFixed(4)})`,
+            transform: `scale(${parseFloat(coreScale.toFixed(4))})`,
             willChange: hasMotion ? "transform" : undefined,
             transition: noAnim
               ? "background-color 300ms, border-radius 400ms"

--- a/web-next/components/voice/voice-orb.tsx
+++ b/web-next/components/voice/voice-orb.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { RefObject, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type RefObject } from "react";
 
-import { useAudioLevel } from "@/components/voice/use-audio-level";
 import { OrbFrequencyRing } from "@/components/voice/orb-frequency-ring";
+import { useAudioLevel } from "@/components/voice/use-audio-level";
 import type { OrbEffectsConfig } from "@/components/voice/use-orb-effects-config";
 
 export type VoiceOrbState =
@@ -24,42 +24,50 @@ type OrbVisual = {
 };
 
 const ORB_VISUALS: Record<VoiceOrbState, OrbVisual> = {
-  offline:   { coreColor: "bg-zinc-700",    glowColor: "bg-zinc-600/20",    ringAnimation: "",                    coreAnimation: "" },
-  ready:     { coreColor: "bg-indigo-600",  glowColor: "bg-indigo-500/20",  ringAnimation: "animate-pulse-signal", coreAnimation: "" },
-  recording: { coreColor: "bg-emerald-500", glowColor: "bg-emerald-400/30", ringAnimation: "",                    coreAnimation: "" },
-  stt:       { coreColor: "bg-amber-500",   glowColor: "bg-amber-400/25",   ringAnimation: "animate-spin",        coreAnimation: "animate-pulse" },
-  thinking:  { coreColor: "bg-violet-600",  glowColor: "bg-violet-500/25",  ringAnimation: "animate-orb-thinking", coreAnimation: "" },
-  tts:       { coreColor: "bg-cyan-500",    glowColor: "bg-cyan-400/30",    ringAnimation: "",                    coreAnimation: "" },
-  complete:  { coreColor: "bg-teal-500",    glowColor: "bg-teal-400/20",    ringAnimation: "animate-pulse",       coreAnimation: "" },
-  error:     { coreColor: "bg-rose-600",    glowColor: "bg-rose-500/20",    ringAnimation: "",                    coreAnimation: "" },
+  offline: { coreColor: "bg-zinc-700", glowColor: "bg-zinc-600/20", ringAnimation: "", coreAnimation: "" },
+  ready: { coreColor: "bg-indigo-600", glowColor: "bg-indigo-500/20", ringAnimation: "animate-pulse-signal", coreAnimation: "" },
+  recording: { coreColor: "bg-emerald-500", glowColor: "bg-emerald-400/30", ringAnimation: "", coreAnimation: "" },
+  stt: { coreColor: "bg-amber-500", glowColor: "bg-amber-400/25", ringAnimation: "animate-spin", coreAnimation: "animate-pulse" },
+  thinking: { coreColor: "bg-violet-600", glowColor: "bg-violet-500/25", ringAnimation: "animate-orb-thinking", coreAnimation: "" },
+  tts: { coreColor: "bg-cyan-500", glowColor: "bg-cyan-400/30", ringAnimation: "", coreAnimation: "" },
+  complete: { coreColor: "bg-teal-500", glowColor: "bg-teal-400/20", ringAnimation: "animate-pulse", coreAnimation: "" },
+  error: { coreColor: "bg-rose-600", glowColor: "bg-rose-500/20", ringAnimation: "", coreAnimation: "" },
 };
 
-// Three-layer ambient glow: [inner, mid, outer] RGBA strings
+// Three-layer ambient glow: [inner, mid, outer] RGBA strings.
 const ORB_GLOW: Record<VoiceOrbState, [string, string, string]> = {
-  offline:   ["rgba(113,113,122,0.08)", "rgba(113,113,122,0.03)", "transparent"],
-  ready:     ["rgba(99,102,241,0.38)",  "rgba(99,102,241,0.13)", "rgba(99,102,241,0.04)"],
-  recording: ["rgba(52,211,153,0.48)",  "rgba(52,211,153,0.18)", "rgba(52,211,153,0.06)"],
-  stt:       ["rgba(251,191,36,0.38)",  "rgba(251,191,36,0.13)", "rgba(251,191,36,0.04)"],
-  thinking:  ["rgba(139,92,246,0.48)",  "rgba(139,92,246,0.18)", "rgba(139,92,246,0.06)"],
-  tts:       ["rgba(34,211,238,0.48)",  "rgba(34,211,238,0.18)", "rgba(34,211,238,0.06)"],
-  complete:  ["rgba(20,184,166,0.38)",  "rgba(20,184,166,0.13)", "rgba(20,184,166,0.04)"],
-  error:     ["rgba(225,29,72,0.38)",   "rgba(225,29,72,0.13)",  "rgba(225,29,72,0.04)"],
+  offline: ["rgba(113,113,122,0.08)", "rgba(113,113,122,0.03)", "transparent"],
+  ready: ["rgba(99,102,241,0.38)", "rgba(99,102,241,0.13)", "rgba(99,102,241,0.04)"],
+  recording: ["rgba(52,211,153,0.48)", "rgba(52,211,153,0.18)", "rgba(52,211,153,0.06)"],
+  stt: ["rgba(251,191,36,0.38)", "rgba(251,191,36,0.13)", "rgba(251,191,36,0.04)"],
+  thinking: ["rgba(139,92,246,0.48)", "rgba(139,92,246,0.18)", "rgba(139,92,246,0.06)"],
+  tts: ["rgba(34,211,238,0.48)", "rgba(34,211,238,0.18)", "rgba(34,211,238,0.06)"],
+  complete: ["rgba(20,184,166,0.38)", "rgba(20,184,166,0.13)", "rgba(20,184,166,0.04)"],
+  error: ["rgba(225,29,72,0.38)", "rgba(225,29,72,0.13)", "rgba(225,29,72,0.04)"],
 };
 
 const FFT_RING_COLOR: Partial<Record<VoiceOrbState, string>> = {
   recording: "rgba(52,211,153,0.8)",
-  tts:       "rgba(34,211,238,0.8)",
+  tts: "rgba(34,211,238,0.8)",
 };
 
 const RIPPLE_COLORS: Partial<Record<VoiceOrbState, [string, string, string]>> = {
   recording: ["bg-emerald-400/25", "bg-emerald-400/18", "bg-emerald-400/10"],
-  tts:       ["bg-cyan-400/25",    "bg-cyan-400/18",    "bg-cyan-400/10"],
+  tts: ["bg-cyan-400/25", "bg-cyan-400/18", "bg-cyan-400/10"],
 };
 
 const PARTICLE_COLORS: Partial<Record<VoiceOrbState, string>> = {
   recording: "rgba(52,211,153,0.72)",
-  tts:       "rgba(34,211,238,0.72)",
+  tts: "rgba(34,211,238,0.72)",
 };
+
+const ORB_PARTICLE_COUNT = 9;
+const ORB_PARTICLE_RANDOMS_PER_PARTICLE = 5;
+const ORB_PARTICLE_RANDOM_FALLBACK = 0x80000000;
+const ORB_PARTICLE_RANDOM_DENOMINATOR = 0x100000000;
+
+const ORB_SIZE = 120;
+const CORE_SIZE = 72;
 
 type Particle = {
   id: number;
@@ -70,21 +78,158 @@ type Particle = {
   size: number;
 };
 
-const DEFAULT_EFFECTS: OrbEffectsConfig = {
-  ripple: true, blob: true, glow: true, transitions: true,
-  frequencyRing: true, coreTexture: true, particles: true, stateLabel: true,
-};
-
-const ORB_SIZE = 120;
-const CORE_SIZE = 72;
-
 function getFlashClass(state: VoiceOrbState): string {
   return state === "recording" || state === "complete" ? "animate-orb-flash" : "";
 }
 
+function isOrbActive(state: VoiceOrbState): boolean {
+  return state === "recording" || state === "tts";
+}
+
+function getOrbAudioLevel(state: VoiceOrbState, inputLevel: number, outputLevel: number): number {
+  if (state === "recording") return inputLevel;
+  if (state === "tts") return outputLevel;
+  return 0;
+}
+
+function getOrbAnalyser(
+  state: VoiceOrbState,
+  micAnalyserRef: RefObject<AnalyserNode | null> | undefined,
+  ttsAnalyserRef: RefObject<AnalyserNode | null> | undefined,
+): RefObject<AnalyserNode | null> | undefined {
+  if (state === "recording") return micAnalyserRef;
+  if (state === "tts") return ttsAnalyserRef;
+  return undefined;
+}
+
+function getOrbGlowShadow(
+  enabled: boolean,
+  noAnim: boolean,
+  state: VoiceOrbState,
+  audioLevel: number,
+): string | undefined {
+  if (!enabled || noAnim || state === "offline") return undefined;
+
+  const [c1, c2, c3] = ORB_GLOW[state];
+  const level = Math.min(1, audioLevel);
+  const r1 = (16 + level * 18).toFixed(0);
+  const r2 = (30 + level * 32).toFixed(0);
+  const r3 = (52 + level * 62).toFixed(0);
+  return `0 0 ${r1}px ${c1}, 0 0 ${r2}px ${c2}, 0 0 ${r3}px ${c3}`;
+}
+
+function shouldShowOrbEffect(enabled: boolean, noAnim: boolean, active: boolean): boolean {
+  return enabled && !noAnim && active;
+}
+
+function getMotionClass(noAnim: boolean, className: string): string {
+  return noAnim ? "" : className;
+}
+
+function formatCoreScale(scale: number): string {
+  return scale === 1 ? "1" : scale.toFixed(4);
+}
+
+function randomUnitValues(count: number): number[] {
+  const values = new Uint32Array(count);
+  const crypto = globalThis.crypto;
+
+  if (crypto) {
+    crypto.getRandomValues(values);
+  } else {
+    values.fill(ORB_PARTICLE_RANDOM_FALLBACK);
+  }
+
+  return Array.from(values, (value) => value / ORB_PARTICLE_RANDOM_DENOMINATOR);
+}
+
+function createOrbParticles(): Particle[] {
+  const randomValues = randomUnitValues(ORB_PARTICLE_COUNT * ORB_PARTICLE_RANDOMS_PER_PARTICLE);
+
+  return Array.from({ length: ORB_PARTICLE_COUNT }, (_, index) => {
+    const base = index * ORB_PARTICLE_RANDOMS_PER_PARTICLE;
+    const angleJitter = randomValues[base] ?? 0.5;
+    const durationJitter = randomValues[base + 1] ?? 0.5;
+    const delayJitter = randomValues[base + 2] ?? 0.5;
+    const offsetJitter = randomValues[base + 3] ?? 0.5;
+    const sizeJitter = randomValues[base + 4] ?? 0.5;
+
+    return {
+      id: index,
+      angle: (360 / ORB_PARTICLE_COUNT) * index + angleJitter * 20 - 10,
+      duration: 1.6 + durationJitter * 0.9,
+      delay: delayJitter * 1.1,
+      offset: 30 + offsetJitter * 8,
+      size: 2 + sizeJitter * 2,
+    };
+  });
+}
+
+function useOrbTransitionEffects(state: VoiceOrbState, enabled: boolean, noAnim: boolean) {
+  const [flashClass, setFlashClass] = useState("");
+  const [showBurst, setShowBurst] = useState(false);
+  const [burstKey, setBurstKey] = useState(0);
+  const prevStateRef = useRef<VoiceOrbState>(state);
+
+  useEffect(() => {
+    if (!enabled || noAnim || prevStateRef.current === state) return;
+
+    prevStateRef.current = state;
+    const cls = getFlashClass(state);
+    if (!cls) return;
+
+    let clearId: ReturnType<typeof setTimeout> | undefined;
+    const startId = setTimeout(() => {
+      setFlashClass(cls);
+      clearId = setTimeout(() => setFlashClass(""), 350);
+    }, 0);
+
+    return () => {
+      clearTimeout(startId);
+      if (clearId !== undefined) {
+        clearTimeout(clearId);
+      }
+    };
+  }, [enabled, noAnim, state]);
+
+  useEffect(() => {
+    if (!enabled || noAnim || state !== "complete") return;
+
+    let hideId: ReturnType<typeof setTimeout> | undefined;
+    const startId = setTimeout(() => {
+      setBurstKey((current) => current + 1);
+      setShowBurst(true);
+      hideId = setTimeout(() => setShowBurst(false), 650);
+    }, 0);
+
+    return () => {
+      clearTimeout(startId);
+      if (hideId !== undefined) {
+        clearTimeout(hideId);
+      }
+    };
+  }, [enabled, noAnim, state]);
+
+  return { flashClass, showBurst, burstKey };
+}
+
+function useOrbParticles() {
+  const [particles, setParticles] = useState<Particle[]>([]);
+
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setParticles(createOrbParticles());
+    }, 0);
+
+    return () => clearTimeout(id);
+  }, []);
+
+  return particles;
+}
+
 type VoiceOrbProps = Readonly<{
   state: VoiceOrbState;
-  /** Override audio level — used in tests; omit in production (computed internally). */
+  /** Override audio level - used in tests; omit in production (computed internally). */
   inputLevel?: number;
   outputLevel?: number;
   disabled?: boolean;
@@ -102,118 +247,49 @@ export function VoiceOrb({
   disabled = false,
   reducedMotion = false,
   label,
-  effectsConfig = DEFAULT_EFFECTS,
+  effectsConfig,
   micAnalyserRef,
   ttsAnalyserRef,
 }: VoiceOrbProps) {
-  const cfg = effectsConfig;
   const effectiveState: VoiceOrbState = disabled ? "offline" : state;
   const visual = ORB_VISUALS[effectiveState];
   const noAnim = reducedMotion;
+  const cfg = effectsConfig ?? {
+    ripple: true,
+    blob: true,
+    glow: true,
+    transitions: true,
+    frequencyRing: true,
+    coreTexture: true,
+    particles: true,
+    stateLabel: true,
+  };
 
-  // ── Audio level (computed here to avoid 60fps re-renders in parent) ──
-  // inputLevelProp / outputLevelProp are accepted as test overrides; in
-  // production the parent passes analyserRefs instead and omits these.
+  // Audio level is computed here so the parent does not re-render at 60fps.
   const fallbackRef = useRef<AnalyserNode | null>(null);
-  const inputLevelHook  = useAudioLevel(micAnalyserRef ?? fallbackRef, effectiveState === "recording");
+  const inputLevelHook = useAudioLevel(micAnalyserRef ?? fallbackRef, effectiveState === "recording");
   const outputLevelHook = useAudioLevel(ttsAnalyserRef ?? fallbackRef, effectiveState === "tts");
-  const inputLevel  = inputLevelProp  ?? inputLevelHook;
+  const inputLevel = inputLevelProp ?? inputLevelHook;
   const outputLevel = outputLevelProp ?? outputLevelHook;
 
-  let audioLevel = 0;
-  if (effectiveState === "recording") audioLevel = inputLevel;
-  else if (effectiveState === "tts") audioLevel = outputLevel;
+  const audioLevel = getOrbAudioLevel(effectiveState, inputLevel, outputLevel);
+  const activeAnalyser = getOrbAnalyser(effectiveState, micAnalyserRef, ttsAnalyserRef);
+  const showParticles = shouldShowOrbEffect(cfg.particles, noAnim, isOrbActive(effectiveState));
+  const showRipple = shouldShowOrbEffect(cfg.ripple, noAnim, isOrbActive(effectiveState));
+  const showBlob = shouldShowOrbEffect(cfg.blob, noAnim, isOrbActive(effectiveState));
+  const showFreqRing = shouldShowOrbEffect(cfg.frequencyRing, noAnim, activeAnalyser !== undefined);
+  const particles = useOrbParticles();
+  const { flashClass, showBurst, burstKey } = useOrbTransitionEffects(effectiveState, cfg.transitions, noAnim);
 
-  // ── Transition flash on state change ─────────────────────────────────
-  const [flashClass, setFlashClass] = useState("");
-  const prevStateRef = useRef<VoiceOrbState>(effectiveState);
-
-  useEffect(() => {
-    if (!cfg.transitions || noAnim) return;
-    if (prevStateRef.current === effectiveState) return;
-    prevStateRef.current = effectiveState;
-
-    const cls = getFlashClass(effectiveState);
-    if (!cls) return;
-
-    let clearId: ReturnType<typeof setTimeout>;
-    const startId = setTimeout(() => {
-      setFlashClass(cls);
-      clearId = setTimeout(() => setFlashClass(""), 350);
-    }, 0);
-    return () => { clearTimeout(startId); clearTimeout(clearId); };
-  }, [effectiveState, cfg.transitions, noAnim]);
-
-  // ── Complete burst (one-shot ring that expands then vanishes) ─────────
-  const [showBurst, setShowBurst] = useState(false);
-  const [burstKey, setBurstKey] = useState(0);
-
-  useEffect(() => {
-    if (!cfg.transitions || noAnim || effectiveState !== "complete") return;
-    let hideId: ReturnType<typeof setTimeout>;
-    const startId = setTimeout(() => {
-      setBurstKey((k) => k + 1);
-      setShowBurst(true);
-      hideId = setTimeout(() => setShowBurst(false), 650);
-    }, 0);
-    return () => { clearTimeout(startId); clearTimeout(hideId); };
-  }, [effectiveState, cfg.transitions, noAnim]);
-
-  // ── Particles (generated client-side to avoid SSR mismatch) ──────────
-  const [particles, setParticles] = useState<Particle[]>([]);
-
-  useEffect(() => {
-    const id = setTimeout(() => {
-      setParticles(
-        Array.from({ length: 9 }, (_, i) => ({
-          id: i,
-          angle: (360 / 9) * i + Math.random() * 20 - 10,
-          duration: 1.6 + Math.random() * 0.9,
-          delay: Math.random() * 1.1,
-          offset: 30 + Math.random() * 8,
-          size: 2 + Math.random() * 2,
-        }))
-      );
-    }, 0);
-    return () => clearTimeout(id);
-  }, []);
-
-  // ── Derived booleans ─────────────────────────────────────────────────
-  const isActive = effectiveState === "recording" || effectiveState === "tts";
-
-  const showParticles = !noAnim && cfg.particles && isActive;
-  const showRipple    = !noAnim && cfg.ripple    && isActive;
-  const showBlob      = !noAnim && cfg.blob      && isActive;
-
-  let activeAnalyser: RefObject<AnalyserNode | null> | undefined;
-  if (effectiveState === "recording") activeAnalyser = micAnalyserRef;
-  else if (effectiveState === "tts") activeAnalyser = ttsAnalyserRef;
-
-  const showFreqRing = !noAnim && cfg.frequencyRing && !!activeAnalyser && isActive;
-
-  // ── Core scale ───────────────────────────────────────────────────────
   const coreScale = noAnim ? 1 : 1 + Math.min(1, audioLevel) * 0.35;
   const hasMotion = coreScale !== 1;
-
-  // ── Ambient glow box-shadow (3 layers, audio-reactive) ───────────────
-  // Not memoized: depends on audioLevel which updates every animation frame,
-  // so memo overhead exceeds any benefit.
-  let glowShadow: string | undefined;
-  if (cfg.glow && !noAnim && effectiveState !== "offline") {
-    const [c1, c2, c3] = ORB_GLOW[effectiveState];
-    const l = Math.min(1, audioLevel);
-    const r1 = (16 + l * 18).toFixed(0);
-    const r2 = (30 + l * 32).toFixed(0);
-    const r3 = (52 + l * 62).toFixed(0);
-    glowShadow = `0 0 ${r1}px ${c1}, 0 0 ${r2}px ${c2}, 0 0 ${r3}px ${c3}`;
-  }
-
-  const ringAnimation = noAnim ? "" : visual.ringAnimation;
-  const coreAnimation = noAnim ? "" : visual.coreAnimation;
-  const blobClass     = showBlob ? "animate-orb-blob" : "";
-  const rippleColors  = RIPPLE_COLORS[effectiveState];
+  const glowShadow = getOrbGlowShadow(cfg.glow, noAnim, effectiveState, audioLevel);
+  const ringAnimation = getMotionClass(noAnim, visual.ringAnimation);
+  const coreAnimation = getMotionClass(noAnim, visual.coreAnimation);
+  const blobClass = showBlob ? "animate-orb-blob" : "";
+  const rippleColors = RIPPLE_COLORS[effectiveState];
   const particleColor = PARTICLE_COLORS[effectiveState] ?? "rgba(255,255,255,0.5)";
-  const fftColor      = FFT_RING_COLOR[effectiveState] ?? "transparent";
+  const fftColor = FFT_RING_COLOR[effectiveState] ?? "transparent";
 
   return (
     <div
@@ -223,7 +299,6 @@ export function VoiceOrb({
       className="flex flex-col items-center gap-3 py-2"
       style={{ minHeight: "160px" }}
     >
-      {/* ── Container ── */}
       <div
         className="relative flex items-center justify-center"
         style={{
@@ -234,7 +309,6 @@ export function VoiceOrb({
           transition: "box-shadow 220ms ease",
         }}
       >
-        {/* ── Ripple rings ── */}
         {showRipple && rippleColors && (
           <>
             <div className={`absolute inset-0 rounded-full ${rippleColors[0]} animate-orb-ripple`} style={{ animationDelay: "0s" }} />
@@ -243,27 +317,16 @@ export function VoiceOrb({
           </>
         )}
 
-        {/* ── Base glow ring ── */}
-        <div
-          className={`absolute inset-0 rounded-full blur-2xl transition-colors duration-500 ${visual.glowColor} ${ringAnimation}`}
-        />
+        <div className={`absolute inset-0 rounded-full blur-2xl transition-colors duration-500 ${visual.glowColor} ${ringAnimation}`} />
 
-        {/* ── FFT frequency ring ── */}
         {showFreqRing && activeAnalyser && (
-          <OrbFrequencyRing
-            analyserRef={activeAnalyser}
-            active={showFreqRing}
-            color={fftColor}
-            size={ORB_SIZE}
-          />
+          <OrbFrequencyRing analyserRef={activeAnalyser} active={showFreqRing} color={fftColor} size={ORB_SIZE} />
         )}
 
-        {/* ── STT spinning border ── */}
         {effectiveState === "stt" && !noAnim && (
           <div className="absolute inset-4 rounded-full border-2 border-amber-400/40 border-t-amber-400 animate-spin" />
         )}
 
-        {/* ── Complete burst ring (one-shot) ── */}
         {showBurst && (
           <div
             key={burstKey}
@@ -272,46 +335,47 @@ export function VoiceOrb({
           />
         )}
 
-        {/* ── Core orb ── */}
         <div
           data-testid="voice-orb-core"
           className={`relative overflow-hidden rounded-full shadow-lg transition-colors duration-300 ${visual.coreColor} ${coreAnimation} ${blobClass} ${flashClass}`}
           style={{
             width: CORE_SIZE,
             height: CORE_SIZE,
-            transform: `scale(${coreScale === 1 ? 1 : coreScale.toFixed(4)})`,
+            transform: `scale(${formatCoreScale(coreScale)})`,
             willChange: hasMotion ? "transform" : undefined,
             transition: noAnim
               ? "background-color 300ms, border-radius 400ms"
               : "transform 80ms linear, background-color 300ms, border-radius 400ms ease-in-out",
           }}
         >
-          {/* Specular highlight (3D gloss effect) */}
           {cfg.coreTexture && (
             <div
               className="pointer-events-none absolute inset-0"
               style={{
-                background:
-                  "radial-gradient(circle at 33% 28%, rgba(255,255,255,0.22) 0%, transparent 58%)",
+                background: "radial-gradient(circle at 33% 28%, rgba(255,255,255,0.22) 0%, transparent 58%)",
               }}
             />
           )}
-          {/* Plasma inner rings */}
+
           {cfg.coreTexture && !noAnim && (
             <>
               <div
                 className="animate-orb-plasma-slow pointer-events-none absolute rounded-full opacity-[0.18]"
                 style={{
-                  width: "58%", height: "58%",
-                  top: "21%", left: "21%",
+                  width: "58%",
+                  height: "58%",
+                  top: "21%",
+                  left: "21%",
                   border: "1px solid rgba(255,255,255,0.5)",
                 }}
               />
               <div
                 className="animate-orb-plasma-fast pointer-events-none absolute rounded-full opacity-[0.13]"
                 style={{
-                  width: "80%", height: "80%",
-                  top: "10%", left: "10%",
+                  width: "80%",
+                  height: "80%",
+                  top: "10%",
+                  left: "10%",
                   border: "1px solid rgba(255,255,255,0.3)",
                 }}
               />
@@ -319,30 +383,29 @@ export function VoiceOrb({
           )}
         </div>
 
-        {/* ── Particles ── */}
-        {showParticles && particles.map((p) => {
-          const rad = (p.angle * Math.PI) / 180;
-          const x = ORB_SIZE / 2 + p.offset * Math.cos(rad);
-          const y = ORB_SIZE / 2 + p.offset * Math.sin(rad);
-          return (
-            <div
-              key={p.id}
-              className="pointer-events-none absolute rounded-full animate-orb-particle-rise"
-              style={{
-                width: p.size,
-                height: p.size,
-                left: x - p.size / 2,
-                top: y - p.size / 2,
-                backgroundColor: particleColor,
-                animationDuration: `${p.duration.toFixed(2)}s`,
-                animationDelay: `${p.delay.toFixed(2)}s`,
-              }}
-            />
-          );
-        })}
+        {showParticles &&
+          particles.map((particle) => {
+            const rad = (particle.angle * Math.PI) / 180;
+            const x = ORB_SIZE / 2 + particle.offset * Math.cos(rad);
+            const y = ORB_SIZE / 2 + particle.offset * Math.sin(rad);
+            return (
+              <div
+                key={particle.id}
+                className="pointer-events-none absolute rounded-full animate-orb-particle-rise"
+                style={{
+                  width: particle.size,
+                  height: particle.size,
+                  left: x - particle.size / 2,
+                  top: y - particle.size / 2,
+                  backgroundColor: particleColor,
+                  animationDuration: `${particle.duration.toFixed(2)}s`,
+                  animationDelay: `${particle.delay.toFixed(2)}s`,
+                }}
+              />
+            );
+          })}
       </div>
 
-      {/* ── State label ── */}
       {cfg.stateLabel && (
         <p
           key={effectiveState}

--- a/web-next/components/voice/voice-orb.tsx
+++ b/web-next/components/voice/voice-orb.tsx
@@ -126,37 +126,46 @@ export function VoiceOrb({
         : "";
     if (!cls) return;
 
-    setFlashClass(cls);
-    const id = setTimeout(() => setFlashClass(""), 350);
-    return () => clearTimeout(id);
+    let clearId: ReturnType<typeof setTimeout>;
+    const startId = setTimeout(() => {
+      setFlashClass(cls);
+      clearId = setTimeout(() => setFlashClass(""), 350);
+    }, 0);
+    return () => { clearTimeout(startId); clearTimeout(clearId); };
   }, [effectiveState, cfg.transitions, noAnim]);
 
   // ── Complete burst (one-shot ring that expands then vanishes) ─────────
   const [showBurst, setShowBurst] = useState(false);
-  const burstKeyRef = useRef(0);
+  const [burstKey, setBurstKey] = useState(0);
 
   useEffect(() => {
     if (!cfg.transitions || noAnim || effectiveState !== "complete") return;
-    burstKeyRef.current += 1;
-    setShowBurst(true);
-    const id = setTimeout(() => setShowBurst(false), 650);
-    return () => clearTimeout(id);
+    let hideId: ReturnType<typeof setTimeout>;
+    const startId = setTimeout(() => {
+      setBurstKey((k) => k + 1);
+      setShowBurst(true);
+      hideId = setTimeout(() => setShowBurst(false), 650);
+    }, 0);
+    return () => { clearTimeout(startId); clearTimeout(hideId); };
   }, [effectiveState, cfg.transitions, noAnim]);
 
   // ── Particles (generated client-side to avoid SSR mismatch) ──────────
   const [particles, setParticles] = useState<Particle[]>([]);
 
   useEffect(() => {
-    setParticles(
-      Array.from({ length: 9 }, (_, i) => ({
-        id: i,
-        angle: (360 / 9) * i + Math.random() * 20 - 10,
-        duration: 1.6 + Math.random() * 0.9,
-        delay: Math.random() * 1.1,
-        offset: 30 + Math.random() * 8,
-        size: 2 + Math.random() * 2,
-      }))
-    );
+    const id = setTimeout(() => {
+      setParticles(
+        Array.from({ length: 9 }, (_, i) => ({
+          id: i,
+          angle: (360 / 9) * i + Math.random() * 20 - 10,
+          duration: 1.6 + Math.random() * 0.9,
+          delay: Math.random() * 1.1,
+          offset: 30 + Math.random() * 8,
+          size: 2 + Math.random() * 2,
+        }))
+      );
+    }, 0);
+    return () => clearTimeout(id);
   }, []);
 
   const showParticles =
@@ -254,7 +263,7 @@ export function VoiceOrb({
         {/* ── Complete burst ring (one-shot) ── */}
         {showBurst && (
           <div
-            key={burstKeyRef.current}
+            key={burstKey}
             className="absolute inset-0 rounded-full border-2 border-teal-400/70 animate-orb-burst"
             style={{ pointerEvents: "none" }}
           />

--- a/web-next/lib/i18n/locales/voice/de.ts
+++ b/web-next/lib/i18n/locales/voice/de.ts
@@ -82,6 +82,18 @@ export const voice = {
     playbackIdleShort: "Bereit",
     replayUnavailable: "Keine vorherige Audioantwort zum Wiederholen.",
   },
+  orb: {
+    stateLabel: {
+      offline: "Offline",
+      ready: "Bereit",
+      recording: "Aufnahme…",
+      stt: "Transkribiere…",
+      thinking: "Denke…",
+      tts: "Spreche…",
+      complete: "Fertig",
+      error: "Fehler",
+    },
+  },
   modes: {
     title: "Voice-Modi",
     description: "Wähle, wie die nächste Äußerung verarbeitet werden soll.",

--- a/web-next/lib/i18n/locales/voice/de.ts
+++ b/web-next/lib/i18n/locales/voice/de.ts
@@ -81,6 +81,7 @@ export const voice = {
     playbackErrorShort: "Fehler",
     playbackIdleShort: "Bereit",
     replayUnavailable: "Keine vorherige Audioantwort zum Wiederholen.",
+    complete: "Antwort bereit.",
   },
   orb: {
     stateLabel: {

--- a/web-next/lib/i18n/locales/voice/en.ts
+++ b/web-next/lib/i18n/locales/voice/en.ts
@@ -81,6 +81,7 @@ export const voice = {
     playbackErrorShort: "Error",
     playbackIdleShort: "Idle",
     replayUnavailable: "No previous audio response to replay.",
+    complete: "Response ready.",
   },
   orb: {
     stateLabel: {

--- a/web-next/lib/i18n/locales/voice/en.ts
+++ b/web-next/lib/i18n/locales/voice/en.ts
@@ -82,6 +82,18 @@ export const voice = {
     playbackIdleShort: "Idle",
     replayUnavailable: "No previous audio response to replay.",
   },
+  orb: {
+    stateLabel: {
+      offline: "Offline",
+      ready: "Ready",
+      recording: "Listening…",
+      stt: "Transcribing…",
+      thinking: "Thinking…",
+      tts: "Speaking…",
+      complete: "Done",
+      error: "Error",
+    },
+  },
   modes: {
     title: "Voice modes",
     description: "Choose how the next utterance should be handled.",

--- a/web-next/lib/i18n/locales/voice/pl.ts
+++ b/web-next/lib/i18n/locales/voice/pl.ts
@@ -81,6 +81,7 @@ export const voice = {
     playbackErrorShort: "Błąd",
     playbackIdleShort: "Gotowy",
     replayUnavailable: "Brak ostatniej odpowiedzi audio do odtworzenia.",
+    complete: "Odpowiedź gotowa.",
   },
   orb: {
     stateLabel: {

--- a/web-next/lib/i18n/locales/voice/pl.ts
+++ b/web-next/lib/i18n/locales/voice/pl.ts
@@ -82,6 +82,18 @@ export const voice = {
     playbackIdleShort: "Gotowy",
     replayUnavailable: "Brak ostatniej odpowiedzi audio do odtworzenia.",
   },
+  orb: {
+    stateLabel: {
+      offline: "Offline",
+      ready: "Gotowy",
+      recording: "Słucham…",
+      stt: "Transkrybuję…",
+      thinking: "Myślę…",
+      tts: "Mówię…",
+      complete: "Gotowe",
+      error: "Błąd",
+    },
+  },
   modes: {
     title: "Tryby voice",
     description: "Wybierz jak ma być traktowana kolejna wypowiedź.",

--- a/web-next/tailwind.config.ts
+++ b/web-next/tailwind.config.ts
@@ -39,6 +39,10 @@ const config: Config = {
           "0%, 100%": { opacity: "0.4", transform: "scale(1)" },
           "50%": { opacity: "1", transform: "scale(1.2)" },
         },
+        "orb-thinking": {
+          "0%, 100%": { opacity: "0.6", transform: "scale(1)" },
+          "50%": { opacity: "1", transform: "scale(1.15)" },
+        },
         "accordion-down": {
           from: { height: "0" },
           to: { height: "var(--radix-accordion-content-height)" },
@@ -50,6 +54,7 @@ const config: Config = {
       },
       animation: {
         "pulse-signal": "pulse-signal 1.6s ease-in-out infinite",
+        "orb-thinking": "orb-thinking 2.4s ease-in-out infinite",
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
       },

--- a/web-next/tailwind.config.ts
+++ b/web-next/tailwind.config.ts
@@ -43,6 +43,25 @@ const config: Config = {
           "0%, 100%": { opacity: "0.6", transform: "scale(1)" },
           "50%": { opacity: "1", transform: "scale(1.15)" },
         },
+        "orb-ripple": {
+          "0%": { transform: "scale(1)", opacity: "0.55" },
+          "100%": { transform: "scale(2.6)", opacity: "0" },
+        },
+        "orb-blob": {
+          "0%, 100%": { borderRadius: "60% 40% 70% 30% / 50% 60% 40% 70%" },
+          "25%": { borderRadius: "40% 60% 30% 70% / 65% 35% 70% 45%" },
+          "50%": { borderRadius: "70% 30% 55% 45% / 40% 70% 55% 60%" },
+          "75%": { borderRadius: "35% 65% 45% 55% / 70% 45% 60% 40%" },
+        },
+        "orb-flash": {
+          "0%": { opacity: "0" },
+          "25%": { opacity: "0.55" },
+          "100%": { opacity: "0" },
+        },
+        "orb-burst": {
+          "0%": { transform: "scale(1)", opacity: "0.75" },
+          "100%": { transform: "scale(2.4)", opacity: "0" },
+        },
         "accordion-down": {
           from: { height: "0" },
           to: { height: "var(--radix-accordion-content-height)" },
@@ -55,6 +74,10 @@ const config: Config = {
       animation: {
         "pulse-signal": "pulse-signal 1.6s ease-in-out infinite",
         "orb-thinking": "orb-thinking 2.4s ease-in-out infinite",
+        "orb-ripple": "orb-ripple 1.9s ease-out infinite",
+        "orb-blob": "orb-blob 3.2s ease-in-out infinite",
+        "orb-flash": "orb-flash 0.32s ease-out forwards",
+        "orb-burst": "orb-burst 0.58s ease-out forwards",
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
       },

--- a/web-next/tests/voice-orb.component.test.tsx
+++ b/web-next/tests/voice-orb.component.test.tsx
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { cleanup, render } from "@testing-library/react";
+import { VoiceOrb, type VoiceOrbState } from "../components/voice/voice-orb";
+
+afterEach(() => cleanup());
+
+const ALL_STATES: VoiceOrbState[] = [
+  "offline",
+  "ready",
+  "recording",
+  "stt",
+  "thinking",
+  "tts",
+  "complete",
+  "error",
+];
+
+describe("VoiceOrb", () => {
+  for (const state of ALL_STATES) {
+    it(`renders state=${state} without crashing`, () => {
+      const { container } = render(
+        <VoiceOrb state={state} inputLevel={0} outputLevel={0} />,
+      );
+      assert.ok(container.firstChild, `VoiceOrb state=${state} should render`);
+    });
+  }
+
+  it("exposes data-orb-state attribute reflecting active state", () => {
+    const { getByRole } = render(
+      <VoiceOrb state="recording" inputLevel={0.5} outputLevel={0} />,
+    );
+    const orb = getByRole("img");
+    assert.equal(orb.getAttribute("data-orb-state"), "recording");
+  });
+
+  it("overrides state to offline when disabled=true", () => {
+    const { getByRole } = render(
+      <VoiceOrb state="recording" inputLevel={0.8} outputLevel={0} disabled />,
+    );
+    assert.equal(getByRole("img").getAttribute("data-orb-state"), "offline");
+  });
+
+  it("uses the label prop as aria-label", () => {
+    const { getByRole } = render(
+      <VoiceOrb state="ready" inputLevel={0} outputLevel={0} label="Gotowy" />,
+    );
+    assert.equal(getByRole("img").getAttribute("aria-label"), "Gotowy");
+  });
+
+  it("falls back to state name when no label provided", () => {
+    const { getByRole } = render(
+      <VoiceOrb state="thinking" inputLevel={0} outputLevel={0} />,
+    );
+    assert.equal(getByRole("img").getAttribute("aria-label"), "thinking");
+  });
+
+  describe("inputLevel → core scale (recording state)", () => {
+    it("applies scale > 1 when inputLevel > 0 in recording state", () => {
+      const { getByTestId } = render(
+        <VoiceOrb state="recording" inputLevel={0.5} outputLevel={0} />,
+      );
+      const core = getByTestId("voice-orb-core");
+      const transform = (core as HTMLElement).style.transform;
+      const scaleValue = parseFloat(transform.replace("scale(", "").replace(")", ""));
+      assert.ok(scaleValue > 1, `expected scale > 1, got ${scaleValue}`);
+    });
+
+    it("keeps scale=1 when inputLevel=0 in recording state", () => {
+      const { getByTestId } = render(
+        <VoiceOrb state="recording" inputLevel={0} outputLevel={0} />,
+      );
+      const core = getByTestId("voice-orb-core");
+      assert.equal((core as HTMLElement).style.transform, "scale(1)");
+    });
+  });
+
+  describe("outputLevel → core scale (tts state)", () => {
+    it("applies scale > 1 when outputLevel > 0 in tts state", () => {
+      const { getByTestId } = render(
+        <VoiceOrb state="tts" inputLevel={0} outputLevel={0.7} />,
+      );
+      const core = getByTestId("voice-orb-core");
+      const scaleValue = parseFloat(
+        (core as HTMLElement).style.transform.replace("scale(", "").replace(")", ""),
+      );
+      assert.ok(scaleValue > 1, `expected scale > 1, got ${scaleValue}`);
+    });
+
+    it("does NOT use outputLevel when state is not tts", () => {
+      const { getByTestId } = render(
+        <VoiceOrb state="ready" inputLevel={0} outputLevel={0.9} />,
+      );
+      const core = getByTestId("voice-orb-core");
+      assert.equal((core as HTMLElement).style.transform, "scale(1)");
+    });
+  });
+
+  describe("reducedMotion", () => {
+    it("keeps scale=1 even with high inputLevel when reducedMotion=true", () => {
+      const { getByTestId } = render(
+        <VoiceOrb state="recording" inputLevel={1} outputLevel={0} reducedMotion />,
+      );
+      const core = getByTestId("voice-orb-core");
+      assert.equal((core as HTMLElement).style.transform, "scale(1)");
+    });
+
+    it("removes ring animation classes when reducedMotion=true", () => {
+      const { container } = render(
+        <VoiceOrb state="thinking" inputLevel={0} outputLevel={0} reducedMotion />,
+      );
+      assert.ok(
+        !container.innerHTML.includes("animate-orb-thinking"),
+        "should not include animate-orb-thinking when reducedMotion=true",
+      );
+    });
+  });
+
+  describe("container dimensions", () => {
+    it("sets minHeight on the container for layout stability", () => {
+      const { getByRole } = render(
+        <VoiceOrb state="ready" inputLevel={0} outputLevel={0} />,
+      );
+      const orb = getByRole("img");
+      assert.ok(
+        (orb as HTMLElement).style.minHeight,
+        "container should have minHeight for layout stability",
+      );
+    });
+  });
+});

--- a/web-next/tests/voice-orb.spec.ts
+++ b/web-next/tests/voice-orb.spec.ts
@@ -63,11 +63,9 @@ test.describe("VoiceOrb smoke", () => {
     await page.setViewportSize({ width: 1280, height: 800 });
     await page.goto("/voice", { waitUntil: "domcontentloaded" });
 
-    await page.getByRole("button", { name: /Hold to talk|Przytrzymaj|Gedrückt/i }).waitFor({
-      state: "visible",
-      timeout: 10000,
-    });
-
+    const pttButton = page.getByRole("button", { name: /Hold to talk|Przytrzymaj|Gedrückt/i });
+    await pttButton.waitFor({ state: "visible", timeout: 10000 });
+    await expect(pttButton).toBeVisible();
     await page.screenshot({ path: "test-results/voice-orb-desktop.png", fullPage: false });
   });
 
@@ -75,11 +73,9 @@ test.describe("VoiceOrb smoke", () => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.goto("/voice", { waitUntil: "domcontentloaded" });
 
-    await page.getByRole("button", { name: /Hold to talk|Przytrzymaj|Gedrückt/i }).waitFor({
-      state: "visible",
-      timeout: 10000,
-    });
-
+    const pttButton = page.getByRole("button", { name: /Hold to talk|Przytrzymaj|Gedrückt/i });
+    await pttButton.waitFor({ state: "visible", timeout: 10000 });
+    await expect(pttButton).toBeVisible();
     await page.screenshot({ path: "test-results/voice-orb-mobile.png", fullPage: false });
   });
 });

--- a/web-next/tests/voice-orb.spec.ts
+++ b/web-next/tests/voice-orb.spec.ts
@@ -1,7 +1,4 @@
 import { expect, test } from "@playwright/test";
-import { buildHttpUrl } from "./utils/url";
-
-const VOICE_URL = buildHttpUrl("127.0.0.1", 3000, "/voice");
 
 test.describe("VoiceOrb smoke", () => {
   test.beforeEach(async ({ page }) => {
@@ -26,30 +23,27 @@ test.describe("VoiceOrb smoke", () => {
   });
 
   test("voice orb is visible on /voice page in voice mode", async ({ page }) => {
-    await page.goto(VOICE_URL, { waitUntil: "domcontentloaded" });
+    await page.goto("/voice", { waitUntil: "domcontentloaded" });
 
-    // The VoiceCommandCenter renders with isVoiceModeEnabled = audioEnabled.
-    // When NEXT_PUBLIC_ENABLE_AUDIO_INTERFACE is not set, audioEnabled=false,
-    // so the toggle button puts us in text mode initially.
-    // We click the Voice/Text toggle to enable voice mode.
+    // Verify the page loaded and the core voice control chrome is rendered —
+    // confirms no JS crash during mount regardless of audio env-var config.
     const toggleButton = page.getByRole("button", { name: /Voice|Text/i }).first();
     await toggleButton.waitFor({ state: "visible", timeout: 10000 });
+    await expect(toggleButton).toBeVisible();
 
-    // When audio is disabled the orb should not be visible (voice mode blocked).
-    // If audio IS enabled (env var set), click to enable voice mode and verify orb.
-    // This test verifies the DOM structure regardless of env config.
+    // When audio is enabled the orb renders in voice mode; when disabled it does
+    // not. Either way, if the page loaded the data-orb-state attribute must have
+    // a valid value from VoiceOrbState when the orb is present.
     const orbContainer = page.locator("[data-orb-state]");
-
-    // orb renders only in voice mode - check if it exists in DOM at all
     const count = await orbContainer.count();
-
-    // Either orb is present (audio enabled + voice mode) or not (audio disabled).
-    // Both are valid - we just assert no JS crash occurred.
-    expect(count).toBeGreaterThanOrEqual(0);
+    if (count > 0) {
+      const orbStateAttr = await orbContainer.first().getAttribute("data-orb-state");
+      expect(["offline","ready","recording","stt","thinking","tts","complete","error"]).toContain(orbStateAttr);
+    }
   });
 
   test("voice page renders controls without layout shift from orb", async ({ page }) => {
-    await page.goto(VOICE_URL, { waitUntil: "domcontentloaded" });
+    await page.goto("/voice", { waitUntil: "domcontentloaded" });
 
     // Push-to-talk button must always be accessible
     const pttButton = page.getByRole("button", { name: /Hold to talk|Przytrzymaj|Gedrückt/i });
@@ -67,7 +61,7 @@ test.describe("VoiceOrb smoke", () => {
     page,
   }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
-    await page.goto(VOICE_URL, { waitUntil: "domcontentloaded" });
+    await page.goto("/voice", { waitUntil: "domcontentloaded" });
 
     await page.getByRole("button", { name: /Hold to talk|Przytrzymaj|Gedrückt/i }).waitFor({
       state: "visible",
@@ -79,7 +73,7 @@ test.describe("VoiceOrb smoke", () => {
 
   test("voice page mobile layout - controls remain accessible", async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
-    await page.goto(VOICE_URL, { waitUntil: "domcontentloaded" });
+    await page.goto("/voice", { waitUntil: "domcontentloaded" });
 
     await page.getByRole("button", { name: /Hold to talk|Przytrzymaj|Gedrückt/i }).waitFor({
       state: "visible",

--- a/web-next/tests/voice-orb.spec.ts
+++ b/web-next/tests/voice-orb.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "@playwright/test";
+import { buildHttpUrl } from "./utils/url";
+
+const VOICE_URL = buildHttpUrl("127.0.0.1", 3000, "/voice");
+
+test.describe("VoiceOrb smoke", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route("**/api/v1/audio/status", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          enabled: false,
+          connected_clients: 0,
+          active_recordings: 0,
+        }),
+      }),
+    );
+    await page.route("**/api/v1/system/llm-runtime/options**", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ status: "success", active: null, runtimes: [] }),
+      }),
+    );
+  });
+
+  test("voice orb is visible on /voice page in voice mode", async ({ page }) => {
+    await page.goto(VOICE_URL, { waitUntil: "domcontentloaded" });
+
+    // The VoiceCommandCenter renders with isVoiceModeEnabled = audioEnabled.
+    // When NEXT_PUBLIC_ENABLE_AUDIO_INTERFACE is not set, audioEnabled=false,
+    // so the toggle button puts us in text mode initially.
+    // We click the Voice/Text toggle to enable voice mode.
+    const toggleButton = page.getByRole("button", { name: /Voice|Text/i }).first();
+    await toggleButton.waitFor({ state: "visible", timeout: 10000 });
+
+    // When audio is disabled the orb should not be visible (voice mode blocked).
+    // If audio IS enabled (env var set), click to enable voice mode and verify orb.
+    // This test verifies the DOM structure regardless of env config.
+    const orbContainer = page.locator("[data-orb-state]");
+
+    // orb renders only in voice mode - check if it exists in DOM at all
+    const count = await orbContainer.count();
+
+    // Either orb is present (audio enabled + voice mode) or not (audio disabled).
+    // Both are valid - we just assert no JS crash occurred.
+    expect(count).toBeGreaterThanOrEqual(0);
+  });
+
+  test("voice page renders controls without layout shift from orb", async ({ page }) => {
+    await page.goto(VOICE_URL, { waitUntil: "domcontentloaded" });
+
+    // Push-to-talk button must always be accessible
+    const pttButton = page.getByRole("button", { name: /Hold to talk|Przytrzymaj|Gedrückt/i });
+    await pttButton.waitFor({ state: "visible", timeout: 10000 });
+
+    // Voice/Text toggle must be visible
+    const toggleButton = page.getByRole("button", { name: /Voice|Text/i }).first();
+    await expect(toggleButton).toBeVisible();
+
+    // TTS mute button must be visible
+    await expect(page.getByRole("button", { name: /TTS/i }).first()).toBeVisible();
+  });
+
+  test("voice page desktop layout - no overlap between orb and controls", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto(VOICE_URL, { waitUntil: "domcontentloaded" });
+
+    await page.getByRole("button", { name: /Hold to talk|Przytrzymaj|Gedrückt/i }).waitFor({
+      state: "visible",
+      timeout: 10000,
+    });
+
+    await page.screenshot({ path: "test-results/voice-orb-desktop.png", fullPage: false });
+  });
+
+  test("voice page mobile layout - controls remain accessible", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(VOICE_URL, { waitUntil: "domcontentloaded" });
+
+    await page.getByRole("button", { name: /Hold to talk|Przytrzymaj|Gedrückt/i }).waitFor({
+      state: "visible",
+      timeout: 10000,
+    });
+
+    await page.screenshot({ path: "test-results/voice-orb-mobile.png", fullPage: false });
+  });
+});


### PR DESCRIPTION
## Summary

This PR delivers the full voice-orb visualization stack — from the underlying audio pipeline fix that made voice responses work at all, through a UI repositioning, to a complete rewrite of the orb with eight layered real-time effects.

### Commits in this branch

| Commit | Scope |
|--------|-------|
| `03823cb` | Initial audio-reactive orb scaffolding (206 base) |
| `cec2734` | Fix: silent TTS failure when LLM returns empty content |
| `acb9d38` | Fix: bypass Ollama OpenAI-compat API for thinking models |
| `a57c20f` | Refactor: move orb to top of right panel (UX) |
| `b943731` | **feat: full WOW effects rewrite (206B)** |

---

## Bug fixes (reviewers: read these first)

### 1. Silent TTS failure — empty LLM response
`venom_core/agents/operator.py`

`generate_voice_response()` was returning an empty string without logging or raising an error when the LLM gave no content. The TTS pipeline swallowed the empty string silently, leaving the user with no audio response and no error message. Fixed by adding an early guard that logs and skips TTS when the response is empty.

### 2. Thinking models (gemma4, qwen3) return `content: ""`
`venom_core/agents/operator.py`

Root cause: Ollama's OpenAI-compatibility endpoint (`/v1/chat/completions`) places the model's answer in the `reasoning` / `thinking` field when the model is a "thinking" type (e.g. `gemma4:latest`, `qwen3`). Semantic Kernel's `OpenAIChatCompletion` reads only `choices[0].message.content`, which is `""` for these models.

Two-layer fix:
- **Primary**: `extra_body={"think": False}` injected into `OpenAIChatPromptExecutionSettings` via `_ollama_extra_body()` — requests Ollama to suppress the thinking chain.
- **Fallback**: `_ollama_native_call()` — direct `httpx.AsyncClient` call to Ollama's native `/api/chat` endpoint with `"think": false`. This endpoint reliably returns `message.content` for all model types. Triggered when SK still returns empty after the primary attempt.

The fallback is local-only (guarded by `LLM_SERVICE_TYPE == "local"`), has a 30s timeout, and raises on HTTP errors.

---

## New UI: orb repositioned

`web-next/components/voice/voice-command-center.tsx`

Orb moved from the bottom of the left column to the **top of the right sidebar**, aligned with the voice chat controls header. This makes the orb the visual focal point of the voice session rather than a footer element.

---

## Voice Orb WOW effects (206B)

### Architecture

```
VoiceCommandCenter
  └── VoiceCommandCenterStatusSidebar
        └── VoiceOrb
              ├── OrbFrequencyRing   (SVG FFT ring — new file)
              └── [8 effect layers]

useOrbEffectsConfig()              (new hook — env-var toggles)
```

### New files

**`components/voice/orb-frequency-ring.tsx`**
SVG `<path>` component driven by a `requestAnimationFrame` loop. Reads `AnalyserNode.getByteFrequencyData()` into a `Uint8Array` and maps 48 frequency buckets to radial displacements around the orb center. Path updated imperatively via `pathRef` — no React re-renders in the hot path. Returns `null` and cancels the RAF when `active=false`.

**`components/voice/use-orb-effects-config.ts`**
Hook exposing `OrbEffectsConfig` — a flat object of 8 booleans, each controlled by a `NEXT_PUBLIC_ORB_*` env var. Global kill-switch: `NEXT_PUBLIC_ORB_EFFECTS=off`. Useful for CI rendering tests or reduced-capability devices.

### Effect layers in `voice-orb.tsx`

| # | Effect | States | Implementation |
|---|--------|--------|----------------|
| 1 | **Ripple rings** | recording, tts | 3 `div`s with `animate-orb-ripple` + staggered `animationDelay` (0 / 0.48 / 0.96s) |
| 2 | **Liquid blob** | recording, tts | `animate-orb-blob` on core — 4-step border-radius morph between organic shapes |
| 3 | **Ambient glow** | all active | 3-layer `box-shadow` from `ORB_GLOW` table; radii scale with `audioLevel` (inner 16→34px, outer 52→114px) |
| 4 | **FFT frequency ring** | recording, tts | `OrbFrequencyRing` with mic or TTS `AnalyserNode` |
| 5 | **Transition flash** | recording→*, *→complete | `animate-orb-flash` (opacity 0→0.55→0, 320ms) on state entry |
| 6 | **Core texture** | all | Specular radial-gradient (3D gloss) + 2 rotating plasma rings (`orb-plasma-slow` / `orb-plasma-fast`) |
| 7 | **Particles** | recording, tts | 9 client-side particles (SSR-safe, generated in `useEffect`) drifting outward via `animate-orb-particle-rise` |
| 8 | **Complete burst** | complete | One-shot burst ring (`animate-orb-burst`, 580ms, scale 1→2.4) + flash; `burstKeyRef` as React `key` guarantees re-trigger on repeated completions |

All effects respect `reducedMotion` prop (disables everything) and individual `effectsConfig` flags.

### CSS additions

`tailwind.config.ts` — new keyframes: `orb-ripple`, `orb-blob`, `orb-flash`, `orb-burst`
`app/globals.css` — `orb-particle-rise`, `orb-plasma-slow`, `orb-plasma-fast` + `.animate-orb-*` utility classes

---

## Review notes

- **No logic changes to WebSocket or recording pipeline** — only `operator.py` (LLM layer) and React UI files touched.
- **FFT ring uses imperative DOM mutations** (`pathRef.current.setAttribute`) intentionally — avoids 60fps React re-renders.
- **Particle positions use `Math.random()` in `useEffect`** — safe for SSR, no hydration mismatch.
- **Pre-commit hook blocks `docs_dev/`** — planning doc `206B_pr_voice_orb_wow_effects_dev.md` lives locally only; not committed.
- All new TS files pass `tsc --noEmit` (pre-existing errors in test files are unrelated to this PR).

## Test plan

- [ ] Start voice session with a local Ollama model (`gemma4:latest` or `qwen3`) — confirm audio response is spoken (not silent)
- [ ] Speak into mic in `recording` state — verify ripple rings animate and FFT ring tracks voice frequency
- [ ] Trigger TTS playback — verify cyan FFT ring and ripple appear, blob morphs
- [ ] Cycle through states manually — verify ambient glow color matches state
- [ ] Enter `complete` state — verify burst ring fires once and does not loop
- [ ] Set `NEXT_PUBLIC_ORB_EFFECTS=off` — verify orb renders as static colored circle
- [ ] Enable `prefers-reduced-motion` in OS — verify all animations stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)