### PR TITLE
[codex] voice screen redesign 3d and react-three orb stack

### DIFF
--- a/docs/FRONTEND_NEXT_GUIDE.md
+++ b/docs/FRONTEND_NEXT_GUIDE.md
@@ -119,6 +119,16 @@ From repository root, you can use:
 - UI language (PL/EN/DE) is sent as `preferred_language` in `/api/v1/tasks` and backend translates response if different language detected.
 - Calculation results (e.g. JSON/arrays) are formatted in chat to tables/lists; when formulas detected we render KaTeX.
 
+### 0.6 Voice screen and `react-three` orb stack
+- `web-next/components/voice/*` is the dedicated voice surface for `/voice`: `VoiceCommandCenter`, `OrbZone`, `VoiceOrb`, `VoiceOrb3D`, dialog windows, metrics hooks, and orb-specific overlays.
+- The orb now has a `react-three` rendering path (`VoiceOrb3D` with `@react-three/fiber`, `@react-three/drei`, `@react-three/postprocessing`) plus a CSS fallback when WebGL or 3D mode is unavailable.
+- `web-next/tests/voice-orb.spec.ts` covers `/voice` layout stability and orb visibility in smoke-style Playwright checks.
+- Frontend helper scripts that matter for this stack live in `web-next/scripts/`:
+  - `run-e2e.mjs`
+  - `e2e-quality-gate.mjs`
+  - `check-dev-turbo.mjs`
+- When adding new voice visuals, document them as part of the orb stack first; treat CSS-only variants as fallback, not as the primary architecture.
+
 ## 1. Brain / Strategy – Data sources and hooks
 
 | View / module                     | Endpoints / hooks                                                                                              | Fallback / notes                                                                                           |

--- a/docs/PL/FRONTEND_NEXT_GUIDE.md
+++ b/docs/PL/FRONTEND_NEXT_GUIDE.md
@@ -119,6 +119,16 @@ Z poziomu roota repo możesz użyć:
 - Język UI (PL/EN/DE) jest przesyłany jako `preferred_language` w `/api/v1/tasks` i backend tłumaczy odpowiedź, jeśli wykryje inny język.
 - Wyniki obliczeń (np. JSON/tablice) są formatowane w czacie do tabel/list; przy wykryciu formuł renderujemy KaTeX.
 
+### 0.6 Ekran voice i stos orba `react-three`
+- `web-next/components/voice/*` to dedykowany ekran voice dla `/voice`: `VoiceCommandCenter`, `OrbZone`, `VoiceOrb`, `VoiceOrb3D`, okna dialogowe, hooki metryk i overlaye orba.
+- Orb ma już ścieżkę renderowania w `react-three` (`VoiceOrb3D` z `@react-three/fiber`, `@react-three/drei`, `@react-three/postprocessing`) oraz fallback CSS, gdy WebGL lub tryb 3D są niedostępne.
+- `web-next/tests/voice-orb.spec.ts` pokrywa stabilność layoutu `/voice` i widoczność orba w smoke testach Playwright.
+- Ważne skrypty frontendowe dla tego stosu znajdują się w `web-next/scripts/`:
+  - `run-e2e.mjs`
+  - `e2e-quality-gate.mjs`
+  - `check-dev-turbo.mjs`
+- Przy dodawaniu nowych efektów voice dokumentuj je najpierw jako część stosu orba; wariant CSS traktuj jako fallback, nie jako główną architekturę.
+
 ## 1. Brain / Strategy – Źródła danych i hooki
 
 | Widok / moduł                     | Endpointy / hooki                                                                                              | Fallback / uwagi                                                                                           |

--- a/docs/PL/VOICE_RUNTIME_CAPABILITIES.md
+++ b/docs/PL/VOICE_RUNTIME_CAPABILITIES.md
@@ -16,6 +16,13 @@ Aktualna bezpieczna ścieżka produkcyjna:
 5. TTS wykonuje Piper, jeśli model głosu jest dostępny,
 6. `/voice` pokazuje transkrypcję, odpowiedź, link do nagrania, czasy, metryki jakości i snapshot runtime.
 
+Ta gałąź traktuje też orb voice jako osobny stos UI, a nie luźny widget:
+
+1. `VoiceCommandCenter` zarządza stanem ekranu `/voice` i podpina orb do reszty strony,
+2. `VoiceOrb3D` to ścieżka renderowania `react-three` dla orba, gdy włączone są wizualizacje 3D,
+3. CSS orb pozostaje bezpiecznym fallbackiem, gdy WebGL jest niedostępny albo 3D jest wyłączone,
+4. smoke coverage dla voice siedzi w `web-next/tests/voice-orb.spec.ts`.
+
 ### Aktualny baseline STT
 
 Domyślny model speech-to-text to `medium`.

--- a/docs/VOICE_RUNTIME_CAPABILITIES.md
+++ b/docs/VOICE_RUNTIME_CAPABILITIES.md
@@ -16,6 +16,13 @@ Current production-safe path:
 5. TTS uses Piper when a voice model is available,
 6. `/voice` shows the transcript, response, recording link, timings, quality metrics, and runtime snapshot.
 
+The current branch also treats the voice orb as a dedicated UI stack, not a loose widget:
+
+1. `VoiceCommandCenter` owns the `/voice` screen state and wires the orb into the rest of the page,
+2. `VoiceOrb3D` is the `react-three` rendering path for the orb when 3D visuals are enabled,
+3. the CSS orb remains the safe fallback when WebGL is unavailable or 3D is disabled,
+4. voice-specific smoke coverage lives in `web-next/tests/voice-orb.spec.ts`.
+
 ### Current STT baseline
 
 The default speech-to-text model is `medium`.

--- a/venom_core/core/model_manager.py
+++ b/venom_core/core/model_manager.py
@@ -1,7 +1,9 @@
 """Moduł: model_manager - Zarządca Modeli i Hot Swap dla Adapterów LoRA."""
 
 import asyncio
+import math
 import subprocess
+import time
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
@@ -69,6 +71,26 @@ MAX_STORAGE_GB = 50  # Limit na modele w GB
 DEFAULT_MODEL_SIZE_GB = 4.0  # Szacowany domyślny rozmiar modelu dla Resource Guard
 BYTES_IN_GB = 1024**3
 _OLLAMA_GGUF_ADAPTER_FILENAMES = ("Adapter-F16-LoRA.gguf", "Adapter-F32-LoRA.gguf")
+
+# Network metrics sampling state (module-level, shared across calls)
+_NET_MAX_BPS: float = 10_000_000  # 10 MB/s = 100%
+_net_prev: object = None
+_net_prev_t: float = 0.0
+
+
+def _get_net_normalized() -> float:
+    """Return log-scaled network utilization 0-100. First call returns 0."""
+    global _net_prev, _net_prev_t  # noqa: PLW0603
+    now = time.monotonic()
+    cur = psutil.net_io_counters()
+    if _net_prev is None:
+        _net_prev, _net_prev_t = cur, now
+        return 0.0
+    dt = max(now - _net_prev_t, 0.01)
+    prev = _net_prev
+    bps = (cur.bytes_sent + cur.bytes_recv - prev.bytes_sent - prev.bytes_recv) / dt  # type: ignore[union-attr]
+    _net_prev, _net_prev_t = cur, now
+    return min(100.0, 100.0 * math.log10(1.0 + bps) / math.log10(1.0 + _NET_MAX_BPS))
 
 
 class ModelVersion:
@@ -888,6 +910,7 @@ PARAMETER top_k 40
             "models_count": models_count,
         }
         metrics.update(await self._collect_gpu_metrics())
+        metrics["net_usage_percent"] = round(_get_net_normalized(), 1)
 
         return metrics
 

--- a/venom_core/core/model_manager.py
+++ b/venom_core/core/model_manager.py
@@ -5,6 +5,7 @@ import math
 import subprocess
 import time
 from pathlib import Path
+from threading import Lock
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 
 import psutil
@@ -76,21 +77,34 @@ _OLLAMA_GGUF_ADAPTER_FILENAMES = ("Adapter-F16-LoRA.gguf", "Adapter-F32-LoRA.ggu
 _NET_MAX_BPS: float = 10_000_000  # 10 MB/s = 100%
 _net_prev: object = None
 _net_prev_t: float = 0.0
+_net_state_lock = Lock()
 
 
 def _get_net_normalized() -> float:
     """Return log-scaled network utilization 0-100. First call returns 0."""
     global _net_prev, _net_prev_t  # noqa: PLW0603
     now = time.monotonic()
-    cur = psutil.net_io_counters()
-    if _net_prev is None:
-        _net_prev, _net_prev_t = cur, now
+    try:
+        cur = psutil.net_io_counters()
+    except Exception:
         return 0.0
-    dt = max(now - _net_prev_t, 0.01)
-    prev = _net_prev
-    bps = (cur.bytes_sent + cur.bytes_recv - prev.bytes_sent - prev.bytes_recv) / dt  # type: ignore[union-attr]
-    _net_prev, _net_prev_t = cur, now
-    return min(100.0, 100.0 * math.log10(1.0 + bps) / math.log10(1.0 + _NET_MAX_BPS))
+    with _net_state_lock:
+        if _net_prev is None:
+            _net_prev, _net_prev_t = cur, now
+            return 0.0
+        dt = max(now - _net_prev_t, 0.01)
+        prev = _net_prev
+        raw_bps = (
+            cur.bytes_sent + cur.bytes_recv - prev.bytes_sent - prev.bytes_recv
+        ) / dt  # type: ignore[union-attr]
+        bps = max(0.0, raw_bps)
+        _net_prev, _net_prev_t = cur, now
+
+    try:
+        scale = math.log10(1.0 + _NET_MAX_BPS)
+        return min(100.0, 100.0 * math.log10(1.0 + bps) / scale)
+    except ValueError:
+        return 0.0
 
 
 class ModelVersion:

--- a/web-next/app/globals.css
+++ b/web-next/app/globals.css
@@ -911,3 +911,21 @@ html[data-theme="venom-light"] body::after {
 .animate-orb-particle-rise { animation: orb-particle-rise  2.1s ease-out forwards; }
 .animate-orb-plasma-slow   { animation: orb-plasma-slow    9s   linear infinite; }
 .animate-orb-plasma-fast   { animation: orb-plasma-fast    5.5s linear infinite; }
+
+/* OrbDialogWindow enter animations */
+@keyframes orb-dialog-in-top {
+  from { opacity: 0; transform: translateY(-12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes orb-dialog-in-bottom {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.animate-orb-dialog-in-top    { animation: orb-dialog-in-top    220ms ease-out both; }
+.animate-orb-dialog-in-bottom { animation: orb-dialog-in-bottom 220ms ease-out both; }
+
+/* DevDiagnosticsDrawer slide-up */
+@keyframes slideUpDrawer {
+  from { transform: translateY(40px); opacity: 0; }
+  to   { transform: translateY(0);    opacity: 1; }
+}

--- a/web-next/components/voice/dev-diagnostics-drawer.tsx
+++ b/web-next/components/voice/dev-diagnostics-drawer.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+
+type AudioStatus = {
+  enabled: boolean;
+  connected_clients: number;
+  active_recordings: number;
+  vad_threshold?: number;
+  whisper_model_size?: string | null;
+  stt_ready?: boolean;
+  tts_ready?: boolean;
+  tts_fallback?: boolean | null;
+  dependencies?: Record<string, boolean>;
+  message?: string;
+  latest_voice_session?: {
+    session_id: string;
+    duration_sec?: number | null;
+    sample_rate?: number | null;
+    input_format?: string | null;
+    voice_mode?: string | null;
+    gain_applied?: number | null;
+    peak_before_normalization?: number | null;
+    rms_after_normalization?: number | null;
+    timings_ms?: Record<string, number | null | undefined>;
+    download_url?: string | null;
+    transcription?: string;
+    runtime?: {
+      stt_model?: string | null;
+      stt_device?: string | null;
+      llm_service_id?: string | null;
+      llm_model?: string | null;
+      tts_sample_rate?: number | null;
+    };
+  } | null;
+  runtime_snapshot?: {
+    runtime_id?: string | null;
+    provider?: string | null;
+    model_name?: string | null;
+    error?: string | null;
+    runtime_capabilities?: {
+      compatibility_profile?: string | null;
+      probe_status?: string | null;
+      probes?: Record<string, { status?: string | null; reason?: string | null }>;
+    } | null;
+    voice_pipeline?: {
+      profile?: string | null;
+      stt?: string | null;
+      reasoning?: string | null;
+      tools?: string | null;
+      vision?: string | null;
+      tts?: string | null;
+      notes?: string[] | null;
+    } | null;
+  } | null;
+};
+
+type DevDiagnosticsDrawerProps = Readonly<{
+  isOpen: boolean;
+  onClose: () => void;
+  audioStatus: AudioStatus | null;
+  lastAudioSignal: string;
+  audioChunkCount: number;
+  statusMessage: string | null;
+}>;
+
+export function DevDiagnosticsDrawer({
+  isOpen,
+  onClose,
+  audioStatus,
+  lastAudioSignal,
+  audioChunkCount,
+  statusMessage,
+}: DevDiagnosticsDrawerProps) {
+  const drawerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (drawerRef.current && !drawerRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    setTimeout(() => document.addEventListener("mousedown", handler), 0);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const latestVoiceSession = audioStatus?.latest_voice_session;
+  const runtimeSnapshot = audioStatus?.runtime_snapshot ?? null;
+  const capabilities = runtimeSnapshot?.runtime_capabilities;
+  const probeStatus = capabilities?.probe_status ?? "unknown";
+  const probes = capabilities?.probes ?? {};
+  const probeSummary = Object.entries(probes)
+    .map(([name, probe]) => `${name}:${probe.status ?? "?"}`)
+    .join(" · ");
+  const pipeline = runtimeSnapshot?.voice_pipeline;
+
+  const getProbeTone = (status?: string | null): "success" | "warning" | "danger" | "neutral" => {
+    if (status === "verified") return "success";
+    if (status === "failed") return "danger";
+    if (status === "metadata_only") return "warning";
+    return "neutral";
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-center">
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+      <div
+        ref={drawerRef}
+        className="relative z-10 w-full max-w-3xl max-h-[80vh] overflow-y-auto rounded-t-3xl border border-white/10 bg-zinc-950 p-6 shadow-2xl"
+        style={{ animation: "slideUpDrawer 220ms ease-out" }}
+      >
+        <div className="mb-4 flex items-center justify-between">
+          <p className="text-sm font-semibold text-zinc-200">⚙ Diagnostics</p>
+          <Button size="xs" variant="outline" onClick={onClose}>
+            Zamknij
+          </Button>
+        </div>
+
+        <div className="space-y-3">
+          {/* Audio WS status */}
+          <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+            <p className="eyebrow mb-2">Audio WS</p>
+            {audioStatus ? (
+              <div className="grid gap-2 text-xs text-zinc-300 sm:grid-cols-2">
+                <div>
+                  <p className="text-caption">Włączony</p>
+                  <p className="text-white">{audioStatus.enabled ? "Tak" : "Nie"}</p>
+                </div>
+                <div>
+                  <p className="text-caption">Klienci</p>
+                  <p className="text-white">{audioStatus.connected_clients}</p>
+                </div>
+                <div>
+                  <p className="text-caption">Nagrania</p>
+                  <p className="text-white">{audioStatus.active_recordings}</p>
+                </div>
+                <div>
+                  <p className="text-caption">VAD</p>
+                  <p className="text-white">{audioStatus.vad_threshold ?? "—"}</p>
+                </div>
+                <div>
+                  <p className="text-caption">Whisper</p>
+                  <p className="text-white">{audioStatus.whisper_model_size ?? "—"}</p>
+                </div>
+                <div>
+                  <p className="text-caption">STT gotowe</p>
+                  <p className="text-white">{audioStatus.stt_ready ? "Tak" : "Nie"}</p>
+                </div>
+                <div>
+                  <p className="text-caption">TTS gotowe</p>
+                  <p className="text-white">{audioStatus.tts_ready ? "Tak" : "Nie"}</p>
+                </div>
+                <div>
+                  <p className="text-caption">TTS Fallback</p>
+                  <p className="text-white">{audioStatus.tts_fallback ? "Tak" : "Nie"}</p>
+                </div>
+                {audioStatus.dependencies && (
+                  <div className="sm:col-span-2">
+                    <p className="text-caption">Zależności</p>
+                    <p className="text-white">
+                      {Object.entries(audioStatus.dependencies)
+                        .map(([name, ok]) => `${name}:${ok ? "yes" : "no"}`)
+                        .join(" · ")}
+                    </p>
+                  </div>
+                )}
+                {audioStatus.message && (
+                  <div className="sm:col-span-2 text-hint">{audioStatus.message}</div>
+                )}
+              </div>
+            ) : (
+              <p className="text-hint text-xs">Brak danych</p>
+            )}
+          </div>
+
+          {/* Latest recording */}
+          {latestVoiceSession?.download_url && (
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+              <p className="eyebrow mb-2">Ostatnie nagranie</p>
+              <div className="flex flex-wrap items-center gap-2 mb-2">
+                <Button asChild size="xs" variant="outline">
+                  <a href={latestVoiceSession.download_url} target="_blank" rel="noreferrer">
+                    Pobierz WAV
+                  </a>
+                </Button>
+              </div>
+              <div className="space-y-1 text-xs text-zinc-400">
+                <p>ID sesji: {latestVoiceSession.session_id}</p>
+                {latestVoiceSession.duration_sec != null && (
+                  <p>{latestVoiceSession.duration_sec.toFixed(1)}s · {latestVoiceSession.sample_rate} Hz · {latestVoiceSession.input_format} · {latestVoiceSession.voice_mode} · gain {latestVoiceSession.gain_applied?.toFixed(1)}</p>
+                )}
+                {(latestVoiceSession.peak_before_normalization != null || latestVoiceSession.rms_after_normalization != null) && (
+                  <p>peak {latestVoiceSession.peak_before_normalization?.toFixed(2)} · rms {latestVoiceSession.rms_after_normalization?.toFixed(3)}</p>
+                )}
+                {latestVoiceSession.timings_ms && (
+                  <p>
+                    {[
+                      latestVoiceSession.timings_ms.stt_ms != null && `STT ${(latestVoiceSession.timings_ms.stt_ms / 1000).toFixed(2)}s`,
+                      latestVoiceSession.timings_ms.llm_ms != null && `LLM ${(latestVoiceSession.timings_ms.llm_ms / 1000).toFixed(2)}s`,
+                      latestVoiceSession.timings_ms.tts_ms != null && `TTS ${(latestVoiceSession.timings_ms.tts_ms / 1000).toFixed(2)}s`,
+                      latestVoiceSession.timings_ms.total_backend_ms != null && `total ${(latestVoiceSession.timings_ms.total_backend_ms / 1000).toFixed(2)}s`,
+                    ].filter(Boolean).join(" · ")}
+                  </p>
+                )}
+                {latestVoiceSession.runtime && (
+                  <p>
+                    {[
+                      latestVoiceSession.runtime.llm_model && `LLM ${latestVoiceSession.runtime.llm_service_id}:${latestVoiceSession.runtime.llm_model}`,
+                      latestVoiceSession.runtime.stt_model && `STT ${latestVoiceSession.runtime.stt_model}/${latestVoiceSession.runtime.stt_device}`,
+                      latestVoiceSession.runtime.tts_sample_rate && `TTS ${latestVoiceSession.runtime.tts_sample_rate} Hz`,
+                    ].filter(Boolean).join(" · ")}
+                  </p>
+                )}
+                {latestVoiceSession.transcription && (
+                  <p>STT: {latestVoiceSession.transcription}</p>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Runtime snapshot */}
+          {runtimeSnapshot && (
+            <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+              <div className="flex flex-wrap items-start justify-between gap-3 mb-3">
+                <div>
+                  <p className="eyebrow">Snapshot Runtime</p>
+                  <p className="mt-1 text-base font-semibold text-white">
+                    {runtimeSnapshot.model_name ?? "Unknown model"}
+                  </p>
+                  {runtimeSnapshot.error && (
+                    <p className="mt-1 text-xs text-rose-200">{runtimeSnapshot.error}</p>
+                  )}
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Badge tone={getProbeTone(probeStatus)}>
+                    Probe: {probeStatus}
+                  </Badge>
+                  <Badge tone="neutral">
+                    {capabilities?.compatibility_profile ?? pipeline?.profile ?? "unknown"}
+                  </Badge>
+                </div>
+              </div>
+              <div className="grid gap-2 text-xs sm:grid-cols-3 mb-3">
+                <div className="rounded-xl border border-white/10 bg-black/20 p-3">
+                  <p className="text-caption">Provider</p>
+                  <p className="mt-1 text-white">{runtimeSnapshot.provider ?? runtimeSnapshot.runtime_id ?? "—"}</p>
+                </div>
+                <div className="rounded-xl border border-white/10 bg-black/20 p-3">
+                  <p className="text-caption">Profil</p>
+                  <p className="mt-1 text-white">{capabilities?.compatibility_profile ?? "—"}</p>
+                </div>
+                <div className="rounded-xl border border-white/10 bg-black/20 p-3">
+                  <p className="text-caption">Pipeline</p>
+                  <p className="mt-1 text-white">{pipeline?.profile ?? "—"}</p>
+                </div>
+              </div>
+              {pipeline && (
+                <div className="grid gap-2 text-xs sm:grid-cols-5 mb-3">
+                  {[["STT", pipeline.stt], ["Reasoning", pipeline.reasoning], ["Tools", pipeline.tools], ["Vision", pipeline.vision], ["TTS", pipeline.tts]].map(([label, val]) => (
+                    <div key={label} className="rounded-xl border border-white/10 bg-black/20 p-3">
+                      <p className="text-caption">{label}</p>
+                      <p className="mt-1 text-white">{val ?? "—"}</p>
+                    </div>
+                  ))}
+                </div>
+              )}
+              {probeSummary && (
+                <div className="rounded-xl border border-white/10 bg-black/20 p-3 text-xs text-zinc-300">
+                  <p className="text-caption">Probes</p>
+                  <p className="mt-1 text-white">{probeSummary}</p>
+                  {pipeline?.notes && pipeline.notes.length > 0 && (
+                    <p className="mt-2 text-hint">{pipeline.notes.join(" · ")}</p>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Signal */}
+          <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+            <p className="eyebrow mb-2">Sygnał</p>
+            <div className="grid grid-cols-2 gap-2 text-xs">
+              <div>
+                <p className="text-caption">Sygnał</p>
+                <p className="text-white">{lastAudioSignal}</p>
+              </div>
+              <div>
+                <p className="text-caption">Chunki</p>
+                <p className="text-white">{audioChunkCount}</p>
+              </div>
+              {statusMessage && (
+                <div className="col-span-2">
+                  <p className="text-caption">Status</p>
+                  <p className="text-white">{statusMessage}</p>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web-next/components/voice/dev-diagnostics-drawer.tsx
+++ b/web-next/components/voice/dev-diagnostics-drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 
@@ -39,6 +39,8 @@ type AudioStatus = {
     runtime_id?: string | null;
     provider?: string | null;
     model_name?: string | null;
+    endpoint?: string | null;
+    config_hash?: string | null;
     error?: string | null;
     runtime_capabilities?: {
       compatibility_profile?: string | null;
@@ -66,6 +68,22 @@ type DevDiagnosticsDrawerProps = Readonly<{
   statusMessage: string | null;
 }>;
 
+function getProbeTone(status?: string | null): "success" | "warning" | "danger" | "neutral" {
+  if (status === "verified") return "success";
+  if (status === "failed") return "danger";
+  if (status === "metadata_only") return "warning";
+  return "neutral";
+}
+
+function formatSeconds(milliseconds?: number | null): string | null {
+  if (typeof milliseconds !== "number" || !Number.isFinite(milliseconds)) return null;
+  return `${(milliseconds / 1000).toFixed(2)}s`;
+}
+
+function joinParts(parts: Array<string | null | false | undefined>): string {
+  return parts.filter(Boolean).join(" · ");
+}
+
 export function DevDiagnosticsDrawer({
   isOpen,
   onClose,
@@ -74,8 +92,6 @@ export function DevDiagnosticsDrawer({
   audioChunkCount,
   statusMessage,
 }: DevDiagnosticsDrawerProps) {
-  const drawerRef = useRef<HTMLDivElement>(null);
-
   useEffect(() => {
     if (!isOpen) return;
     const handler = (e: KeyboardEvent) => {
@@ -85,233 +101,235 @@ export function DevDiagnosticsDrawer({
     return () => document.removeEventListener("keydown", handler);
   }, [isOpen, onClose]);
 
-  useEffect(() => {
-    if (!isOpen) return;
-    const handler = (e: MouseEvent) => {
-      if (drawerRef.current && !drawerRef.current.contains(e.target as Node)) {
-        onClose();
-      }
-    };
-    setTimeout(() => document.addEventListener("mousedown", handler), 0);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [isOpen, onClose]);
-
   if (!isOpen) return null;
 
-  const latestVoiceSession = audioStatus?.latest_voice_session;
+  const latestVoiceSession = audioStatus?.latest_voice_session ?? null;
   const runtimeSnapshot = audioStatus?.runtime_snapshot ?? null;
-  const capabilities = runtimeSnapshot?.runtime_capabilities;
-  const probeStatus = capabilities?.probe_status ?? "unknown";
-  const probes = capabilities?.probes ?? {};
-  const probeSummary = Object.entries(probes)
-    .map(([name, probe]) => `${name}:${probe.status ?? "?"}`)
-    .join(" · ");
-  const pipeline = runtimeSnapshot?.voice_pipeline;
-
-  const getProbeTone = (status?: string | null): "success" | "warning" | "danger" | "neutral" => {
-    if (status === "verified") return "success";
-    if (status === "failed") return "danger";
-    if (status === "metadata_only") return "warning";
-    return "neutral";
-  };
 
   return (
     <div className="fixed inset-0 z-50 flex items-end justify-center">
-      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+      <button
+        type="button"
+        aria-label="Zamknij diagnostics drawer"
+        className="absolute inset-0 z-0 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+      />
       <div
-        ref={drawerRef}
-        className="relative z-10 w-full max-w-3xl max-h-[80vh] overflow-y-auto rounded-t-3xl border border-white/10 bg-zinc-950 p-6 shadow-2xl"
+        className="relative z-10 max-h-[80vh] w-full max-w-3xl overflow-y-auto rounded-t-3xl border border-white/10 bg-zinc-950 p-6 shadow-2xl"
         style={{ animation: "slideUpDrawer 220ms ease-out" }}
       >
-        <div className="mb-4 flex items-center justify-between">
-          <p className="text-sm font-semibold text-zinc-200">⚙ Diagnostics</p>
+        <div className="mb-4 flex items-center justify-between gap-4">
+          <div>
+            <p className="text-sm font-semibold text-zinc-200">⚙ Diagnostics</p>
+            <p className="text-xs text-zinc-500">
+              {lastAudioSignal || "no signal"} · chunks {audioChunkCount}
+            </p>
+            {statusMessage && <p className="text-xs text-zinc-400">{statusMessage}</p>}
+          </div>
           <Button size="xs" variant="outline" onClick={onClose}>
             Zamknij
           </Button>
         </div>
 
         <div className="space-y-3">
-          {/* Audio WS status */}
-          <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
-            <p className="eyebrow mb-2">Audio WS</p>
-            {audioStatus ? (
-              <div className="grid gap-2 text-xs text-zinc-300 sm:grid-cols-2">
-                <div>
-                  <p className="text-caption">Włączony</p>
-                  <p className="text-white">{audioStatus.enabled ? "Tak" : "Nie"}</p>
-                </div>
-                <div>
-                  <p className="text-caption">Klienci</p>
-                  <p className="text-white">{audioStatus.connected_clients}</p>
-                </div>
-                <div>
-                  <p className="text-caption">Nagrania</p>
-                  <p className="text-white">{audioStatus.active_recordings}</p>
-                </div>
-                <div>
-                  <p className="text-caption">VAD</p>
-                  <p className="text-white">{audioStatus.vad_threshold ?? "—"}</p>
-                </div>
-                <div>
-                  <p className="text-caption">Whisper</p>
-                  <p className="text-white">{audioStatus.whisper_model_size ?? "—"}</p>
-                </div>
-                <div>
-                  <p className="text-caption">STT gotowe</p>
-                  <p className="text-white">{audioStatus.stt_ready ? "Tak" : "Nie"}</p>
-                </div>
-                <div>
-                  <p className="text-caption">TTS gotowe</p>
-                  <p className="text-white">{audioStatus.tts_ready ? "Tak" : "Nie"}</p>
-                </div>
-                <div>
-                  <p className="text-caption">TTS Fallback</p>
-                  <p className="text-white">{audioStatus.tts_fallback ? "Tak" : "Nie"}</p>
-                </div>
-                {audioStatus.dependencies && (
-                  <div className="sm:col-span-2">
-                    <p className="text-caption">Zależności</p>
-                    <p className="text-white">
-                      {Object.entries(audioStatus.dependencies)
-                        .map(([name, ok]) => `${name}:${ok ? "yes" : "no"}`)
-                        .join(" · ")}
-                    </p>
-                  </div>
-                )}
-                {audioStatus.message && (
-                  <div className="sm:col-span-2 text-hint">{audioStatus.message}</div>
-                )}
-              </div>
-            ) : (
-              <p className="text-hint text-xs">Brak danych</p>
-            )}
-          </div>
-
-          {/* Latest recording */}
-          {latestVoiceSession?.download_url && (
-            <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
-              <p className="eyebrow mb-2">Ostatnie nagranie</p>
-              <div className="flex flex-wrap items-center gap-2 mb-2">
-                <Button asChild size="xs" variant="outline">
-                  <a href={latestVoiceSession.download_url} target="_blank" rel="noreferrer">
-                    Pobierz WAV
-                  </a>
-                </Button>
-              </div>
-              <div className="space-y-1 text-xs text-zinc-400">
-                <p>ID sesji: {latestVoiceSession.session_id}</p>
-                {latestVoiceSession.duration_sec != null && (
-                  <p>{latestVoiceSession.duration_sec.toFixed(1)}s · {latestVoiceSession.sample_rate} Hz · {latestVoiceSession.input_format} · {latestVoiceSession.voice_mode} · gain {latestVoiceSession.gain_applied?.toFixed(1)}</p>
-                )}
-                {(latestVoiceSession.peak_before_normalization != null || latestVoiceSession.rms_after_normalization != null) && (
-                  <p>peak {latestVoiceSession.peak_before_normalization?.toFixed(2)} · rms {latestVoiceSession.rms_after_normalization?.toFixed(3)}</p>
-                )}
-                {latestVoiceSession.timings_ms && (
-                  <p>
-                    {[
-                      latestVoiceSession.timings_ms.stt_ms != null && `STT ${(latestVoiceSession.timings_ms.stt_ms / 1000).toFixed(2)}s`,
-                      latestVoiceSession.timings_ms.llm_ms != null && `LLM ${(latestVoiceSession.timings_ms.llm_ms / 1000).toFixed(2)}s`,
-                      latestVoiceSession.timings_ms.tts_ms != null && `TTS ${(latestVoiceSession.timings_ms.tts_ms / 1000).toFixed(2)}s`,
-                      latestVoiceSession.timings_ms.total_backend_ms != null && `total ${(latestVoiceSession.timings_ms.total_backend_ms / 1000).toFixed(2)}s`,
-                    ].filter(Boolean).join(" · ")}
-                  </p>
-                )}
-                {latestVoiceSession.runtime && (
-                  <p>
-                    {[
-                      latestVoiceSession.runtime.llm_model && `LLM ${latestVoiceSession.runtime.llm_service_id}:${latestVoiceSession.runtime.llm_model}`,
-                      latestVoiceSession.runtime.stt_model && `STT ${latestVoiceSession.runtime.stt_model}/${latestVoiceSession.runtime.stt_device}`,
-                      latestVoiceSession.runtime.tts_sample_rate && `TTS ${latestVoiceSession.runtime.tts_sample_rate} Hz`,
-                    ].filter(Boolean).join(" · ")}
-                  </p>
-                )}
-                {latestVoiceSession.transcription && (
-                  <p>STT: {latestVoiceSession.transcription}</p>
-                )}
-              </div>
-            </div>
-          )}
-
-          {/* Runtime snapshot */}
-          {runtimeSnapshot && (
-            <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
-              <div className="flex flex-wrap items-start justify-between gap-3 mb-3">
-                <div>
-                  <p className="eyebrow">Snapshot Runtime</p>
-                  <p className="mt-1 text-base font-semibold text-white">
-                    {runtimeSnapshot.model_name ?? "Unknown model"}
-                  </p>
-                  {runtimeSnapshot.error && (
-                    <p className="mt-1 text-xs text-rose-200">{runtimeSnapshot.error}</p>
-                  )}
-                </div>
-                <div className="flex flex-wrap gap-2">
-                  <Badge tone={getProbeTone(probeStatus)}>
-                    Probe: {probeStatus}
-                  </Badge>
-                  <Badge tone="neutral">
-                    {capabilities?.compatibility_profile ?? pipeline?.profile ?? "unknown"}
-                  </Badge>
-                </div>
-              </div>
-              <div className="grid gap-2 text-xs sm:grid-cols-3 mb-3">
-                <div className="rounded-xl border border-white/10 bg-black/20 p-3">
-                  <p className="text-caption">Provider</p>
-                  <p className="mt-1 text-white">{runtimeSnapshot.provider ?? runtimeSnapshot.runtime_id ?? "—"}</p>
-                </div>
-                <div className="rounded-xl border border-white/10 bg-black/20 p-3">
-                  <p className="text-caption">Profil</p>
-                  <p className="mt-1 text-white">{capabilities?.compatibility_profile ?? "—"}</p>
-                </div>
-                <div className="rounded-xl border border-white/10 bg-black/20 p-3">
-                  <p className="text-caption">Pipeline</p>
-                  <p className="mt-1 text-white">{pipeline?.profile ?? "—"}</p>
-                </div>
-              </div>
-              {pipeline && (
-                <div className="grid gap-2 text-xs sm:grid-cols-5 mb-3">
-                  {[["STT", pipeline.stt], ["Reasoning", pipeline.reasoning], ["Tools", pipeline.tools], ["Vision", pipeline.vision], ["TTS", pipeline.tts]].map(([label, val]) => (
-                    <div key={label} className="rounded-xl border border-white/10 bg-black/20 p-3">
-                      <p className="text-caption">{label}</p>
-                      <p className="mt-1 text-white">{val ?? "—"}</p>
-                    </div>
-                  ))}
-                </div>
-              )}
-              {probeSummary && (
-                <div className="rounded-xl border border-white/10 bg-black/20 p-3 text-xs text-zinc-300">
-                  <p className="text-caption">Probes</p>
-                  <p className="mt-1 text-white">{probeSummary}</p>
-                  {pipeline?.notes && pipeline.notes.length > 0 && (
-                    <p className="mt-2 text-hint">{pipeline.notes.join(" · ")}</p>
-                  )}
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* Signal */}
-          <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
-            <p className="eyebrow mb-2">Sygnał</p>
-            <div className="grid grid-cols-2 gap-2 text-xs">
-              <div>
-                <p className="text-caption">Sygnał</p>
-                <p className="text-white">{lastAudioSignal}</p>
-              </div>
-              <div>
-                <p className="text-caption">Chunki</p>
-                <p className="text-white">{audioChunkCount}</p>
-              </div>
-              {statusMessage && (
-                <div className="col-span-2">
-                  <p className="text-caption">Status</p>
-                  <p className="text-white">{statusMessage}</p>
-                </div>
-              )}
-            </div>
-          </div>
+          <AudioStatusSection audioStatus={audioStatus} />
+          <LatestRecordingSection latestVoiceSession={latestVoiceSession} />
+          <RuntimeSnapshotSection runtimeSnapshot={runtimeSnapshot} />
         </div>
       </div>
+    </div>
+  );
+}
+
+function AudioStatusSection({ audioStatus }: Readonly<{ audioStatus: AudioStatus | null }>) {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+      <p className="eyebrow mb-2">Audio WS</p>
+      {audioStatus ? (
+        <div className="grid gap-2 text-xs text-zinc-300 sm:grid-cols-2">
+          <div>
+            <p className="text-caption">Włączony</p>
+            <p className="text-white">{audioStatus.enabled ? "Tak" : "Nie"}</p>
+          </div>
+          <div>
+            <p className="text-caption">Klienci</p>
+            <p className="text-white">{audioStatus.connected_clients}</p>
+          </div>
+          <div>
+            <p className="text-caption">Nagrania</p>
+            <p className="text-white">{audioStatus.active_recordings}</p>
+          </div>
+          <div>
+            <p className="text-caption">VAD</p>
+            <p className="text-white">{audioStatus.vad_threshold ?? "—"}</p>
+          </div>
+          <div>
+            <p className="text-caption">Whisper</p>
+            <p className="text-white">{audioStatus.whisper_model_size ?? "—"}</p>
+          </div>
+          <div>
+            <p className="text-caption">STT gotowe</p>
+            <p className="text-white">{audioStatus.stt_ready ? "Tak" : "Nie"}</p>
+          </div>
+          <div>
+            <p className="text-caption">TTS gotowe</p>
+            <p className="text-white">{audioStatus.tts_ready ? "Tak" : "Nie"}</p>
+          </div>
+          <div>
+            <p className="text-caption">TTS Fallback</p>
+            <p className="text-white">{audioStatus.tts_fallback ? "Tak" : "Nie"}</p>
+          </div>
+          {audioStatus.dependencies && (
+            <div className="sm:col-span-2">
+              <p className="text-caption">Zależności</p>
+              <p className="text-white">
+                {Object.entries(audioStatus.dependencies)
+                  .map(([name, ok]) => `${name}:${ok ? "yes" : "no"}`)
+                  .join(" · ")}
+              </p>
+            </div>
+          )}
+          {audioStatus.message && <div className="sm:col-span-2 text-hint">{audioStatus.message}</div>}
+        </div>
+      ) : (
+        <p className="text-hint text-xs">Brak danych</p>
+      )}
+    </div>
+  );
+}
+
+function LatestRecordingSection({
+  latestVoiceSession,
+}: Readonly<{
+  latestVoiceSession: AudioStatus["latest_voice_session"];
+}>) {
+  if (!latestVoiceSession?.download_url) return null;
+
+  const timings = latestVoiceSession.timings_ms;
+  const runtime = latestVoiceSession.runtime;
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+      <p className="eyebrow mb-2">Ostatnie nagranie</p>
+      <div className="mb-2 flex flex-wrap items-center gap-2">
+        <Button asChild size="xs" variant="outline">
+          <a href={latestVoiceSession.download_url} target="_blank" rel="noreferrer">
+            Pobierz WAV
+          </a>
+        </Button>
+      </div>
+      <div className="space-y-1 text-xs text-zinc-400">
+        <p>ID sesji: {latestVoiceSession.session_id}</p>
+        {latestVoiceSession.duration_sec != null && (
+          <p>
+            {latestVoiceSession.duration_sec.toFixed(1)}s · {latestVoiceSession.sample_rate} Hz ·{" "}
+            {latestVoiceSession.input_format} · {latestVoiceSession.voice_mode} · gain{" "}
+            {latestVoiceSession.gain_applied?.toFixed(1)}
+          </p>
+        )}
+        {(latestVoiceSession.peak_before_normalization != null ||
+          latestVoiceSession.rms_after_normalization != null) && (
+          <p>
+            peak {latestVoiceSession.peak_before_normalization?.toFixed(2)} · rms{" "}
+            {latestVoiceSession.rms_after_normalization?.toFixed(3)}
+          </p>
+        )}
+        {timings && (
+          <p>
+            {joinParts([
+              formatSeconds(timings.stt_ms) && `STT ${formatSeconds(timings.stt_ms)}`,
+              formatSeconds(timings.llm_ms) && `LLM ${formatSeconds(timings.llm_ms)}`,
+              formatSeconds(timings.tts_ms) && `TTS ${formatSeconds(timings.tts_ms)}`,
+              formatSeconds(timings.total_backend_ms) && `total ${formatSeconds(timings.total_backend_ms)}`,
+            ])}
+          </p>
+        )}
+        {runtime && (
+          <p>
+            {joinParts([
+              runtime.llm_model && `LLM ${runtime.llm_service_id}:${runtime.llm_model}`,
+              runtime.stt_model && `STT ${runtime.stt_model}/${runtime.stt_device}`,
+              runtime.tts_sample_rate && `TTS ${runtime.tts_sample_rate} Hz`,
+            ])}
+          </p>
+        )}
+        {latestVoiceSession.transcription && <p>STT: {latestVoiceSession.transcription}</p>}
+      </div>
+    </div>
+  );
+}
+
+function RuntimeSnapshotSection({
+  runtimeSnapshot,
+}: Readonly<{
+  runtimeSnapshot: AudioStatus["runtime_snapshot"];
+}>) {
+  if (!runtimeSnapshot) return null;
+  const capabilities = runtimeSnapshot.runtime_capabilities;
+  const pipeline = runtimeSnapshot.voice_pipeline;
+  const probeStatus = capabilities?.probe_status ?? "unknown";
+  const probes = capabilities?.probes ?? {};
+  const probeSummary = Object.entries(probes)
+    .map(([name, probe]) => `${name}:${probe.status ?? "?"}`)
+    .join(" · ");
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
+      <div className="mb-3 flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="eyebrow">Snapshot Runtime</p>
+          <p className="mt-1 text-base font-semibold text-white">
+            {runtimeSnapshot.model_name ?? "Unknown model"}
+          </p>
+          {runtimeSnapshot.error && <p className="mt-1 text-xs text-rose-200">{runtimeSnapshot.error}</p>}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Badge tone={getProbeTone(probeStatus)}>Probe: {probeStatus}</Badge>
+          <Badge tone="neutral">{capabilities?.compatibility_profile ?? pipeline?.profile ?? "unknown"}</Badge>
+        </div>
+      </div>
+      <div className="mb-3 grid gap-2 text-xs sm:grid-cols-3">
+        <div className="rounded-xl border border-white/10 bg-black/20 p-3">
+          <p className="text-caption">Provider</p>
+          <p className="mt-1 text-white">{runtimeSnapshot.provider ?? runtimeSnapshot.runtime_id ?? "—"}</p>
+        </div>
+        <div className="rounded-xl border border-white/10 bg-black/20 p-3">
+          <p className="text-caption">Endpoint</p>
+          <p className="mt-1 text-white">{runtimeSnapshot.endpoint ?? "—"}</p>
+        </div>
+        <div className="rounded-xl border border-white/10 bg-black/20 p-3">
+          <p className="text-caption">Config hash</p>
+          <p className="mt-1 font-mono text-white">{runtimeSnapshot.config_hash ?? "—"}</p>
+        </div>
+      </div>
+      {capabilities?.probes && Object.keys(capabilities.probes).length > 0 && (
+        <div className="rounded-xl border border-white/10 bg-black/20 p-3 text-xs text-zinc-300">
+          <p className="mb-1 text-caption">Probes</p>
+          <p className="font-mono">{probeSummary || "—"}</p>
+        </div>
+      )}
+      {pipeline && (
+        <div className="rounded-xl border border-white/10 bg-black/20 p-3 text-xs text-zinc-300">
+          <p className="mb-1 text-caption">Voice pipeline</p>
+          <p className="font-mono">
+            {joinParts([
+              pipeline.profile && `profile:${pipeline.profile}`,
+              pipeline.stt && `stt:${pipeline.stt}`,
+              pipeline.reasoning && `reasoning:${pipeline.reasoning}`,
+              pipeline.tools && `tools:${pipeline.tools}`,
+              pipeline.vision && `vision:${pipeline.vision}`,
+              pipeline.tts && `tts:${pipeline.tts}`,
+            ]) || "—"}
+          </p>
+          {pipeline.notes && pipeline.notes.length > 0 && (
+            <ul className="mt-2 list-disc pl-4 text-zinc-400">
+              {pipeline.notes.map((note, index) => (
+                <li key={index}>{note}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/web-next/components/voice/dev-diagnostics-drawer.tsx
+++ b/web-next/components/voice/dev-diagnostics-drawer.tsx
@@ -323,8 +323,8 @@ function RuntimeSnapshotSection({
           </p>
           {pipeline.notes && pipeline.notes.length > 0 && (
             <ul className="mt-2 list-disc pl-4 text-zinc-400">
-              {pipeline.notes.map((note, index) => (
-                <li key={index}>{note}</li>
+              {pipeline.notes.map((note) => (
+                <li key={note}>{note}</li>
               ))}
             </ul>
           )}

--- a/web-next/components/voice/orb-dialog-window.tsx
+++ b/web-next/components/voice/orb-dialog-window.tsx
@@ -98,7 +98,7 @@ export function OrbDialogWindow({
   const isEmpty = !text;
 
   const bubbleClasses = [
-    "w-full max-w-[320px] rounded-2xl border px-4 py-3 text-sm leading-relaxed",
+    "w-full rounded-2xl border px-4 py-3 text-sm leading-relaxed",
     "transition-all duration-300",
     role === "user"
       ? "border-white/10 bg-white/[0.05] text-zinc-200 self-end text-right"
@@ -118,7 +118,7 @@ export function OrbDialogWindow({
 
   return (
     <div
-      className="flex w-full justify-center px-2"
+      className="w-full"
       style={{
         minHeight: "56px",
         display: "flex",

--- a/web-next/components/voice/orb-dialog-window.tsx
+++ b/web-next/components/voice/orb-dialog-window.tsx
@@ -29,6 +29,15 @@ function getEnterClass(
   return role === "user" ? "animate-orb-dialog-in-top" : "animate-orb-dialog-in-bottom";
 }
 
+function getOpacity(visible: boolean, isActive: boolean): number {
+  if (!visible) return 0;
+  return isActive ? 1 : 0.45;
+}
+
+function getSpeakerLabel(role: "user" | "assistant"): string {
+  return role === "user" ? "Ty" : "Asystent";
+}
+
 export function OrbDialogWindow({
   role,
   text,
@@ -112,7 +121,7 @@ export function OrbDialogWindow({
     .filter(Boolean)
     .join(" ");
 
-  const opacity = visible ? (isActive ? 1 : 0.45) : 0;
+  const opacity = getOpacity(visible, isActive);
 
   return (
     <div
@@ -130,7 +139,7 @@ export function OrbDialogWindow({
       {visible && (
         <div className={bubbleClasses}>
           <span className="mb-1 block text-[10px] font-semibold uppercase tracking-widest text-zinc-500">
-            {role === "user" ? "Ty" : "Asystent"}
+            {getSpeakerLabel(role)}
           </span>
           <span>{displayed || emptyLabel}</span>
         </div>

--- a/web-next/components/voice/orb-dialog-window.tsx
+++ b/web-next/components/voice/orb-dialog-window.tsx
@@ -11,7 +11,6 @@ type OrbDialogWindowProps = Readonly<{
   emptyLabel?: string;
 }>;
 
-const FADE_DELAY_MS = 5000;
 const TYPEWRITER_INTERVAL_MS = 18;
 
 function getBubbleClass(role: "user" | "assistant", isEmpty: boolean): string {
@@ -41,38 +40,39 @@ export function OrbDialogWindow({
   const [visible, setVisible] = useState(!!text);
   const [entering, setEntering] = useState(false);
   const prevTextRef = useRef(text);
-  const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Typewriter for assistant bubble
   useEffect(() => {
     if (role !== "assistant" || !text) return;
 
     if (reducedMotion) {
+      prevTextRef.current = text;
       const id = globalThis.setTimeout(() => setDisplayed(text), 0);
       return () => globalThis.clearTimeout(id);
     }
 
-    let i = prevTextRef.current === text ? text.length : 0;
+    const previousText = prevTextRef.current;
+    const startIndex = text.startsWith(previousText) ? previousText.length : 0;
     prevTextRef.current = text;
+    let index = startIndex;
     let intervalId: ReturnType<typeof setInterval> | null = null;
     const startId = globalThis.setTimeout(() => {
-      setDisplayed(text.slice(0, i));
+      setDisplayed(text.slice(0, index));
       intervalId = globalThis.setInterval(() => {
-        i += 1;
-        setDisplayed(text.slice(0, i));
-        if (i >= text.length && intervalId) {
-          clearInterval(intervalId);
+        index += 1;
+        setDisplayed(text.slice(0, index));
+        if (index >= text.length && intervalId) {
+          globalThis.clearInterval(intervalId);
+          intervalId = null;
         }
       }, TYPEWRITER_INTERVAL_MS);
     }, 0);
 
     return () => {
       globalThis.clearTimeout(startId);
-      if (intervalId) clearInterval(intervalId);
+      if (intervalId) globalThis.clearInterval(intervalId);
     };
   }, [text, role, reducedMotion]);
 
-  // For user bubble just show full text immediately
   useEffect(() => {
     if (role !== "user") return;
     prevTextRef.current = text;
@@ -80,45 +80,21 @@ export function OrbDialogWindow({
     return () => globalThis.clearTimeout(id);
   }, [text, role]);
 
-  // Visibility + enter animation on text change
   useEffect(() => {
-    if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
-
     if (text) {
       const visibleId = globalThis.setTimeout(() => setVisible(true), 0);
-      if (!reducedMotion) {
-        const enterId = globalThis.setTimeout(() => setEntering(true), 0);
-        const exitId = globalThis.setTimeout(() => setEntering(false), 240);
-        return () => {
-          globalThis.clearTimeout(visibleId);
-          globalThis.clearTimeout(enterId);
-          globalThis.clearTimeout(exitId);
-        };
-      }
-    } else {
-      const id = globalThis.setTimeout(() => setVisible(false), 0);
-      return () => globalThis.clearTimeout(id);
+      const enterId = reducedMotion ? null : globalThis.setTimeout(() => setEntering(true), 0);
+      const exitId = reducedMotion ? null : globalThis.setTimeout(() => setEntering(false), 240);
+      return () => {
+        globalThis.clearTimeout(visibleId);
+        if (enterId) globalThis.clearTimeout(enterId);
+        if (exitId) globalThis.clearTimeout(exitId);
+      };
     }
+
+    const hideId = globalThis.setTimeout(() => setVisible(false), 0);
+    return () => globalThis.clearTimeout(hideId);
   }, [text, reducedMotion]);
-
-  // Auto-fade after conversation ends
-  useEffect(() => {
-    if (!text) return;
-    const isActive =
-      orbState === "recording" ||
-      orbState === "stt" ||
-      orbState === "thinking" ||
-      orbState === "tts";
-
-    if (!isActive) {
-      fadeTimerRef.current = setTimeout(() => {
-        // just dim — don't remove from DOM so layout stays stable
-      }, FADE_DELAY_MS);
-    }
-    return () => {
-      if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
-    };
-  }, [orbState, text]);
 
   const isActive =
     (role === "user" && (orbState === "recording" || orbState === "stt")) ||
@@ -153,7 +129,7 @@ export function OrbDialogWindow({
     >
       {visible && (
         <div className={bubbleClasses}>
-          <span className="block text-[10px] font-semibold uppercase tracking-widest text-zinc-500 mb-1">
+          <span className="mb-1 block text-[10px] font-semibold uppercase tracking-widest text-zinc-500">
             {role === "user" ? "Ty" : "Asystent"}
           </span>
           <span>{displayed || emptyLabel}</span>

--- a/web-next/components/voice/orb-dialog-window.tsx
+++ b/web-next/components/voice/orb-dialog-window.tsx
@@ -14,6 +14,22 @@ type OrbDialogWindowProps = Readonly<{
 const FADE_DELAY_MS = 5000;
 const TYPEWRITER_INTERVAL_MS = 18;
 
+function getBubbleClass(role: "user" | "assistant", isEmpty: boolean): string {
+  if (isEmpty) return "border-transparent bg-transparent";
+  return role === "user"
+    ? "border-white/10 bg-white/[0.05] text-zinc-200 self-end text-right"
+    : "border-white/10 bg-white/[0.04] text-zinc-100 self-start text-left";
+}
+
+function getEnterClass(
+  role: "user" | "assistant",
+  entering: boolean,
+  reducedMotion: boolean,
+): string {
+  if (!entering || reducedMotion) return "";
+  return role === "user" ? "animate-orb-dialog-in-top" : "animate-orb-dialog-in-bottom";
+}
+
 export function OrbDialogWindow({
   role,
   text,
@@ -32,16 +48,16 @@ export function OrbDialogWindow({
     if (role !== "assistant" || !text) return;
 
     if (reducedMotion) {
-      const id = window.setTimeout(() => setDisplayed(text), 0);
-      return () => window.clearTimeout(id);
+      const id = globalThis.setTimeout(() => setDisplayed(text), 0);
+      return () => globalThis.clearTimeout(id);
     }
 
     let i = prevTextRef.current === text ? text.length : 0;
     prevTextRef.current = text;
     let intervalId: ReturnType<typeof setInterval> | null = null;
-    const startId = window.setTimeout(() => {
+    const startId = globalThis.setTimeout(() => {
       setDisplayed(text.slice(0, i));
-      intervalId = window.setInterval(() => {
+      intervalId = globalThis.setInterval(() => {
         i += 1;
         setDisplayed(text.slice(0, i));
         if (i >= text.length && intervalId) {
@@ -51,7 +67,7 @@ export function OrbDialogWindow({
     }, 0);
 
     return () => {
-      window.clearTimeout(startId);
+      globalThis.clearTimeout(startId);
       if (intervalId) clearInterval(intervalId);
     };
   }, [text, role, reducedMotion]);
@@ -60,8 +76,8 @@ export function OrbDialogWindow({
   useEffect(() => {
     if (role !== "user") return;
     prevTextRef.current = text;
-    const id = window.setTimeout(() => setDisplayed(text), 0);
-    return () => window.clearTimeout(id);
+    const id = globalThis.setTimeout(() => setDisplayed(text), 0);
+    return () => globalThis.clearTimeout(id);
   }, [text, role]);
 
   // Visibility + enter animation on text change
@@ -69,19 +85,19 @@ export function OrbDialogWindow({
     if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
 
     if (text) {
-      const visibleId = window.setTimeout(() => setVisible(true), 0);
+      const visibleId = globalThis.setTimeout(() => setVisible(true), 0);
       if (!reducedMotion) {
-        const enterId = window.setTimeout(() => setEntering(true), 0);
-        const exitId = window.setTimeout(() => setEntering(false), 240);
+        const enterId = globalThis.setTimeout(() => setEntering(true), 0);
+        const exitId = globalThis.setTimeout(() => setEntering(false), 240);
         return () => {
-          window.clearTimeout(visibleId);
-          window.clearTimeout(enterId);
-          window.clearTimeout(exitId);
+          globalThis.clearTimeout(visibleId);
+          globalThis.clearTimeout(enterId);
+          globalThis.clearTimeout(exitId);
         };
       }
     } else {
-      const id = window.setTimeout(() => setVisible(false), 0);
-      return () => window.clearTimeout(id);
+      const id = globalThis.setTimeout(() => setVisible(false), 0);
+      return () => globalThis.clearTimeout(id);
     }
   }, [text, reducedMotion]);
 
@@ -113,21 +129,14 @@ export function OrbDialogWindow({
   const bubbleClasses = [
     "w-full rounded-2xl border px-4 py-3 text-sm leading-relaxed",
     "transition-all duration-300",
-    role === "user"
-      ? "border-white/10 bg-white/[0.05] text-zinc-200 self-end text-right"
-      : "border-white/10 bg-white/[0.04] text-zinc-100 self-start text-left",
-    isEmpty ? "border-transparent bg-transparent" : "",
+    getBubbleClass(role, isEmpty),
     isActive ? "border-white/15" : "",
-    entering && !reducedMotion
-      ? role === "user"
-        ? "animate-orb-dialog-in-top"
-        : "animate-orb-dialog-in-bottom"
-      : "",
+    getEnterClass(role, entering, reducedMotion),
   ]
     .filter(Boolean)
     .join(" ");
 
-  const opacity = !visible ? 0 : isActive ? 1 : 0.45;
+  const opacity = visible ? (isActive ? 1 : 0.45) : 0;
 
   return (
     <div

--- a/web-next/components/voice/orb-dialog-window.tsx
+++ b/web-next/components/voice/orb-dialog-window.tsx
@@ -32,28 +32,36 @@ export function OrbDialogWindow({
     if (role !== "assistant" || !text) return;
 
     if (reducedMotion) {
-      setDisplayed(text);
-      return;
+      const id = window.setTimeout(() => setDisplayed(text), 0);
+      return () => window.clearTimeout(id);
     }
 
     let i = prevTextRef.current === text ? text.length : 0;
     prevTextRef.current = text;
-    setDisplayed(text.slice(0, i));
-
-    const id = setInterval(() => {
-      i += 1;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+    const startId = window.setTimeout(() => {
       setDisplayed(text.slice(0, i));
-      if (i >= text.length) clearInterval(id);
-    }, TYPEWRITER_INTERVAL_MS);
+      intervalId = window.setInterval(() => {
+        i += 1;
+        setDisplayed(text.slice(0, i));
+        if (i >= text.length && intervalId) {
+          clearInterval(intervalId);
+        }
+      }, TYPEWRITER_INTERVAL_MS);
+    }, 0);
 
-    return () => clearInterval(id);
+    return () => {
+      window.clearTimeout(startId);
+      if (intervalId) clearInterval(intervalId);
+    };
   }, [text, role, reducedMotion]);
 
   // For user bubble just show full text immediately
   useEffect(() => {
     if (role !== "user") return;
     prevTextRef.current = text;
-    setDisplayed(text);
+    const id = window.setTimeout(() => setDisplayed(text), 0);
+    return () => window.clearTimeout(id);
   }, [text, role]);
 
   // Visibility + enter animation on text change
@@ -61,14 +69,19 @@ export function OrbDialogWindow({
     if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
 
     if (text) {
-      setVisible(true);
+      const visibleId = window.setTimeout(() => setVisible(true), 0);
       if (!reducedMotion) {
-        setEntering(true);
-        const id = setTimeout(() => setEntering(false), 240);
-        return () => clearTimeout(id);
+        const enterId = window.setTimeout(() => setEntering(true), 0);
+        const exitId = window.setTimeout(() => setEntering(false), 240);
+        return () => {
+          window.clearTimeout(visibleId);
+          window.clearTimeout(enterId);
+          window.clearTimeout(exitId);
+        };
       }
     } else {
-      setVisible(false);
+      const id = window.setTimeout(() => setVisible(false), 0);
+      return () => window.clearTimeout(id);
     }
   }, [text, reducedMotion]);
 

--- a/web-next/components/voice/orb-dialog-window.tsx
+++ b/web-next/components/voice/orb-dialog-window.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { VoiceOrbState } from "@/components/voice/voice-orb";
+
+type OrbDialogWindowProps = Readonly<{
+  role: "user" | "assistant";
+  text: string;
+  orbState: VoiceOrbState;
+  reducedMotion: boolean;
+  emptyLabel?: string;
+}>;
+
+const FADE_DELAY_MS = 5000;
+const TYPEWRITER_INTERVAL_MS = 18;
+
+export function OrbDialogWindow({
+  role,
+  text,
+  orbState,
+  reducedMotion,
+  emptyLabel,
+}: OrbDialogWindowProps) {
+  const [displayed, setDisplayed] = useState(text);
+  const [visible, setVisible] = useState(!!text);
+  const [entering, setEntering] = useState(false);
+  const prevTextRef = useRef(text);
+  const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Typewriter for assistant bubble
+  useEffect(() => {
+    if (role !== "assistant" || !text) return;
+
+    if (reducedMotion) {
+      setDisplayed(text);
+      return;
+    }
+
+    let i = prevTextRef.current === text ? text.length : 0;
+    prevTextRef.current = text;
+    setDisplayed(text.slice(0, i));
+
+    const id = setInterval(() => {
+      i += 1;
+      setDisplayed(text.slice(0, i));
+      if (i >= text.length) clearInterval(id);
+    }, TYPEWRITER_INTERVAL_MS);
+
+    return () => clearInterval(id);
+  }, [text, role, reducedMotion]);
+
+  // For user bubble just show full text immediately
+  useEffect(() => {
+    if (role !== "user") return;
+    prevTextRef.current = text;
+    setDisplayed(text);
+  }, [text, role]);
+
+  // Visibility + enter animation on text change
+  useEffect(() => {
+    if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
+
+    if (text) {
+      setVisible(true);
+      if (!reducedMotion) {
+        setEntering(true);
+        const id = setTimeout(() => setEntering(false), 240);
+        return () => clearTimeout(id);
+      }
+    } else {
+      setVisible(false);
+    }
+  }, [text, reducedMotion]);
+
+  // Auto-fade after conversation ends
+  useEffect(() => {
+    if (!text) return;
+    const isActive =
+      orbState === "recording" ||
+      orbState === "stt" ||
+      orbState === "thinking" ||
+      orbState === "tts";
+
+    if (!isActive) {
+      fadeTimerRef.current = setTimeout(() => {
+        // just dim — don't remove from DOM so layout stays stable
+      }, FADE_DELAY_MS);
+    }
+    return () => {
+      if (fadeTimerRef.current) clearTimeout(fadeTimerRef.current);
+    };
+  }, [orbState, text]);
+
+  const isActive =
+    (role === "user" && (orbState === "recording" || orbState === "stt")) ||
+    (role === "assistant" && (orbState === "thinking" || orbState === "tts" || orbState === "complete"));
+
+  const isEmpty = !text;
+
+  const bubbleClasses = [
+    "w-full max-w-[320px] rounded-2xl border px-4 py-3 text-sm leading-relaxed",
+    "transition-all duration-300",
+    role === "user"
+      ? "border-white/10 bg-white/[0.05] text-zinc-200 self-end text-right"
+      : "border-white/10 bg-white/[0.04] text-zinc-100 self-start text-left",
+    isEmpty ? "border-transparent bg-transparent" : "",
+    isActive ? "border-white/15" : "",
+    entering && !reducedMotion
+      ? role === "user"
+        ? "animate-orb-dialog-in-top"
+        : "animate-orb-dialog-in-bottom"
+      : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const opacity = !visible ? 0 : isActive ? 1 : 0.45;
+
+  return (
+    <div
+      className="flex w-full justify-center px-2"
+      style={{
+        minHeight: "56px",
+        display: "flex",
+        alignItems: "center",
+        transition: "opacity 600ms ease",
+        opacity,
+      }}
+      aria-live={role === "assistant" ? "polite" : "off"}
+      aria-atomic="true"
+    >
+      {visible && (
+        <div className={bubbleClasses}>
+          <span className="block text-[10px] font-semibold uppercase tracking-widest text-zinc-500 mb-1">
+            {role === "user" ? "Ty" : "Asystent"}
+          </span>
+          <span>{displayed || emptyLabel}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web-next/components/voice/orb-zone.tsx
+++ b/web-next/components/voice/orb-zone.tsx
@@ -15,7 +15,7 @@ const VoiceOrb3D = dynamic(
 );
 
 function supportsWebGL(): boolean {
-  if (typeof window === "undefined") return false;
+  if (typeof globalThis.window === "undefined") return false;
   try {
     const canvas = document.createElement("canvas");
     return !!(

--- a/web-next/components/voice/orb-zone.tsx
+++ b/web-next/components/voice/orb-zone.tsx
@@ -17,7 +17,7 @@ const VoiceOrb3D = dynamic(
 );
 
 function supportsWebGL(): boolean {
-  if (typeof globalThis.window === "undefined") return false;
+  if (globalThis.window === undefined) return false;
   try {
     const canvas = document.createElement("canvas");
     return !!(

--- a/web-next/components/voice/orb-zone.tsx
+++ b/web-next/components/voice/orb-zone.tsx
@@ -54,11 +54,8 @@ export function OrbZone({
   const orbLabel = label ?? t(`voice.orb.stateLabel.${orbState}`);
 
   return (
-    <div
-      className="flex flex-col items-center gap-2 w-full"
-      style={{ minHeight: "520px" }}
-    >
-      {/* User bubble — above orb */}
+    <div className="flex flex-col gap-3 w-full" style={{ minHeight: "520px" }}>
+      {/* User bubble — above orb, full width */}
       <OrbDialogWindow
         role="user"
         text={transcription}
@@ -67,8 +64,8 @@ export function OrbZone({
         emptyLabel={t("voice.status.waitingForVoiceCommand")}
       />
 
-      {/* Orb — 2D CSS or 3D Three.js */}
-      <div className="flex items-center justify-center">
+      {/* Orb — centered, takes remaining vertical space */}
+      <div className="flex flex-1 items-center justify-center">
         {use3D ? (
           <VoiceOrb3D
             state={orbState}
@@ -77,10 +74,10 @@ export function OrbZone({
             micAnalyserRef={micAnalyserRef}
             ttsAnalyserRef={ttsAnalyserRef}
             disabled={!audioEnabled}
-            size={200}
+            size={240}
           />
         ) : (
-          <div className="flex justify-center rounded-2xl box-muted py-6 px-8">
+          <div className="flex justify-center rounded-2xl box-muted py-8 px-10">
             <VoiceOrb
               state={orbState}
               disabled={!audioEnabled}
@@ -94,7 +91,7 @@ export function OrbZone({
         )}
       </div>
 
-      {/* Assistant bubble — below orb */}
+      {/* Assistant bubble — below orb, full width */}
       <OrbDialogWindow
         role="assistant"
         text={response}

--- a/web-next/components/voice/orb-zone.tsx
+++ b/web-next/components/voice/orb-zone.tsx
@@ -8,10 +8,12 @@ import type { OrbEffectsConfig } from "@/components/voice/use-orb-effects-config
 import type { OrbMetrics } from "@/components/voice/use-orb-metrics";
 import { useTranslation } from "@/lib/i18n";
 
+const ORB_3D_SIZE = 240;
+
 // Lazy-load 3D orb — never included in initial bundle, SSR disabled
 const VoiceOrb3D = dynamic(
   () => import("@/components/voice/voice-orb-3d").then((m) => ({ default: m.VoiceOrb3D })),
-  { ssr: false, loading: () => <div style={{ width: 200, height: 200 }} /> },
+  { ssr: false, loading: () => <div style={{ width: ORB_3D_SIZE, height: ORB_3D_SIZE }} /> },
 );
 
 function supportsWebGL(): boolean {
@@ -77,7 +79,7 @@ export function OrbZone({
             micAnalyserRef={micAnalyserRef}
             ttsAnalyserRef={ttsAnalyserRef}
             disabled={!audioEnabled}
-            size={240}
+            size={ORB_3D_SIZE}
             metricsRef={metricsRef}
           />
         ) : (

--- a/web-next/components/voice/orb-zone.tsx
+++ b/web-next/components/voice/orb-zone.tsx
@@ -5,6 +5,7 @@ import type { RefObject } from "react";
 import { VoiceOrb, type VoiceOrbState } from "@/components/voice/voice-orb";
 import { OrbDialogWindow } from "@/components/voice/orb-dialog-window";
 import type { OrbEffectsConfig } from "@/components/voice/use-orb-effects-config";
+import type { OrbMetrics } from "@/components/voice/use-orb-metrics";
 import { useTranslation } from "@/lib/i18n";
 
 // Lazy-load 3D orb — never included in initial bundle, SSR disabled
@@ -36,6 +37,7 @@ type OrbZoneProps = Readonly<{
   micAnalyserRef: RefObject<AnalyserNode | null>;
   ttsAnalyserRef: RefObject<AnalyserNode | null>;
   label?: string;
+  metricsRef?: RefObject<OrbMetrics>;
 }>;
 
 export function OrbZone({
@@ -48,6 +50,7 @@ export function OrbZone({
   micAnalyserRef,
   ttsAnalyserRef,
   label,
+  metricsRef,
 }: OrbZoneProps) {
   const t = useTranslation();
   const use3D = effectsConfig.orb3D && !reducedMotion && supportsWebGL();
@@ -75,6 +78,7 @@ export function OrbZone({
             ttsAnalyserRef={ttsAnalyserRef}
             disabled={!audioEnabled}
             size={240}
+            metricsRef={metricsRef}
           />
         ) : (
           <div className="flex justify-center rounded-2xl box-muted py-8 px-10">
@@ -86,6 +90,7 @@ export function OrbZone({
               effectsConfig={effectsConfig}
               micAnalyserRef={micAnalyserRef}
               ttsAnalyserRef={ttsAnalyserRef}
+              metricsRef={metricsRef}
             />
           </div>
         )}

--- a/web-next/components/voice/orb-zone.tsx
+++ b/web-next/components/voice/orb-zone.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { RefObject } from "react";
+import { VoiceOrb, type VoiceOrbState } from "@/components/voice/voice-orb";
+import { OrbDialogWindow } from "@/components/voice/orb-dialog-window";
+import type { OrbEffectsConfig } from "@/components/voice/use-orb-effects-config";
+import { useTranslation } from "@/lib/i18n";
+
+// Lazy-load 3D orb — never included in initial bundle, SSR disabled
+const VoiceOrb3D = dynamic(
+  () => import("@/components/voice/voice-orb-3d").then((m) => ({ default: m.VoiceOrb3D })),
+  { ssr: false, loading: () => <div style={{ width: 200, height: 200 }} /> },
+);
+
+function supportsWebGL(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    const canvas = document.createElement("canvas");
+    return !!(
+      canvas.getContext("webgl") ||
+      canvas.getContext("experimental-webgl")
+    );
+  } catch {
+    return false;
+  }
+}
+
+type OrbZoneProps = Readonly<{
+  transcription: string;
+  response: string;
+  orbState: VoiceOrbState;
+  effectsConfig: OrbEffectsConfig;
+  reducedMotion: boolean;
+  audioEnabled: boolean;
+  micAnalyserRef: RefObject<AnalyserNode | null>;
+  ttsAnalyserRef: RefObject<AnalyserNode | null>;
+  label?: string;
+}>;
+
+export function OrbZone({
+  transcription,
+  response,
+  orbState,
+  effectsConfig,
+  reducedMotion,
+  audioEnabled,
+  micAnalyserRef,
+  ttsAnalyserRef,
+  label,
+}: OrbZoneProps) {
+  const t = useTranslation();
+  const use3D = effectsConfig.orb3D && !reducedMotion && supportsWebGL();
+  const orbLabel = label ?? t(`voice.orb.stateLabel.${orbState}`);
+
+  return (
+    <div
+      className="flex flex-col items-center gap-2 w-full"
+      style={{ minHeight: "520px" }}
+    >
+      {/* User bubble — above orb */}
+      <OrbDialogWindow
+        role="user"
+        text={transcription}
+        orbState={orbState}
+        reducedMotion={reducedMotion}
+        emptyLabel={t("voice.status.waitingForVoiceCommand")}
+      />
+
+      {/* Orb — 2D CSS or 3D Three.js */}
+      <div className="flex items-center justify-center">
+        {use3D ? (
+          <VoiceOrb3D
+            state={orbState}
+            effectsConfig={effectsConfig}
+            reducedMotion={reducedMotion}
+            micAnalyserRef={micAnalyserRef}
+            ttsAnalyserRef={ttsAnalyserRef}
+            disabled={!audioEnabled}
+            size={200}
+          />
+        ) : (
+          <div className="flex justify-center rounded-2xl box-muted py-6 px-8">
+            <VoiceOrb
+              state={orbState}
+              disabled={!audioEnabled}
+              reducedMotion={reducedMotion}
+              label={orbLabel}
+              effectsConfig={effectsConfig}
+              micAnalyserRef={micAnalyserRef}
+              ttsAnalyserRef={ttsAnalyserRef}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Assistant bubble — below orb */}
+      <OrbDialogWindow
+        role="assistant"
+        text={response}
+        orbState={orbState}
+        reducedMotion={reducedMotion}
+        emptyLabel={t("voice.status.noResponseYet")}
+      />
+    </div>
+  );
+}

--- a/web-next/components/voice/use-orb-effects-config.ts
+++ b/web-next/components/voice/use-orb-effects-config.ts
@@ -18,6 +18,8 @@ export type OrbEffectsConfig = {
   chromaticAberration: boolean;
   iridescence: boolean;
   volumetricLights: boolean;
+  // PR 208B — live system metrics bars radiating from orb center
+  orbMetricsBars: boolean;
 };
 
 const ALL_OFF: OrbEffectsConfig = {
@@ -34,6 +36,7 @@ const ALL_OFF: OrbEffectsConfig = {
   chromaticAberration: false,
   iridescence: false,
   volumetricLights: false,
+  orbMetricsBars: false,
 };
 
 // Next.js replaces NEXT_PUBLIC_* vars at build time only when referenced by
@@ -61,6 +64,8 @@ export function useOrbEffectsConfig(): OrbEffectsConfig {
       chromaticAberration: !isOff(process.env.NEXT_PUBLIC_ORB_CHROMATIC_ABERRATION),
       iridescence:         !isOff(process.env.NEXT_PUBLIC_ORB_IRIDESCENCE),
       volumetricLights:    !isOff(process.env.NEXT_PUBLIC_ORB_VOLUMETRIC_LIGHTS),
+      // PR 208B — metrics bars default to false (opt-in)
+      orbMetricsBars:      process.env.NEXT_PUBLIC_ORB_METRICS_BARS === "true",
     };
   }, []);
 }

--- a/web-next/components/voice/use-orb-effects-config.ts
+++ b/web-next/components/voice/use-orb-effects-config.ts
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 
 export type OrbEffectsConfig = {
+  // 2D CSS effects (from PR 206B)
   ripple: boolean;
   blob: boolean;
   glow: boolean;
@@ -11,6 +12,12 @@ export type OrbEffectsConfig = {
   coreTexture: boolean;
   particles: boolean;
   stateLabel: boolean;
+  // 3D mode (PR 207) — replaces CSS equivalents when true
+  orb3D: boolean;
+  bloom: boolean;
+  chromaticAberration: boolean;
+  iridescence: boolean;
+  volumetricLights: boolean;
 };
 
 const ALL_OFF: OrbEffectsConfig = {
@@ -22,6 +29,11 @@ const ALL_OFF: OrbEffectsConfig = {
   coreTexture: false,
   particles: false,
   stateLabel: false,
+  orb3D: false,
+  bloom: false,
+  chromaticAberration: false,
+  iridescence: false,
+  volumetricLights: false,
 };
 
 // Next.js replaces NEXT_PUBLIC_* vars at build time only when referenced by
@@ -35,14 +47,20 @@ export function useOrbEffectsConfig(): OrbEffectsConfig {
   return useMemo(() => {
     if (process.env.NEXT_PUBLIC_ORB_EFFECTS === "off") return ALL_OFF;
     return {
-      ripple:       !isOff(process.env.NEXT_PUBLIC_ORB_RIPPLE),
-      blob:         !isOff(process.env.NEXT_PUBLIC_ORB_BLOB),
-      glow:         !isOff(process.env.NEXT_PUBLIC_ORB_GLOW),
-      transitions:  !isOff(process.env.NEXT_PUBLIC_ORB_TRANSITIONS),
-      frequencyRing:!isOff(process.env.NEXT_PUBLIC_ORB_FREQUENCY_RING),
-      coreTexture:  !isOff(process.env.NEXT_PUBLIC_ORB_CORE_TEXTURE),
-      particles:    !isOff(process.env.NEXT_PUBLIC_ORB_PARTICLES),
-      stateLabel:   !isOff(process.env.NEXT_PUBLIC_ORB_STATE_LABEL),
+      ripple:              !isOff(process.env.NEXT_PUBLIC_ORB_RIPPLE),
+      blob:                !isOff(process.env.NEXT_PUBLIC_ORB_BLOB),
+      glow:                !isOff(process.env.NEXT_PUBLIC_ORB_GLOW),
+      transitions:         !isOff(process.env.NEXT_PUBLIC_ORB_TRANSITIONS),
+      frequencyRing:       !isOff(process.env.NEXT_PUBLIC_ORB_FREQUENCY_RING),
+      coreTexture:         !isOff(process.env.NEXT_PUBLIC_ORB_CORE_TEXTURE),
+      particles:           !isOff(process.env.NEXT_PUBLIC_ORB_PARTICLES),
+      stateLabel:          !isOff(process.env.NEXT_PUBLIC_ORB_STATE_LABEL),
+      // 3D effects — orb3D defaults to false (opt-in)
+      orb3D:               process.env.NEXT_PUBLIC_ORB_3D === "true",
+      bloom:               !isOff(process.env.NEXT_PUBLIC_ORB_BLOOM),
+      chromaticAberration: !isOff(process.env.NEXT_PUBLIC_ORB_CHROMATIC_ABERRATION),
+      iridescence:         !isOff(process.env.NEXT_PUBLIC_ORB_IRIDESCENCE),
+      volumetricLights:    !isOff(process.env.NEXT_PUBLIC_ORB_VOLUMETRIC_LIGHTS),
     };
   }, []);
 }

--- a/web-next/components/voice/use-orb-metrics.ts
+++ b/web-next/components/voice/use-orb-metrics.ts
@@ -15,14 +15,14 @@ const ZERO_METRICS: OrbMetrics = { cpu: 0, gpu: 0, net: 0, ram: 0 };
 
 export function useOrbMetrics(): RefObject<OrbMetrics> {
   const metricsRef = useRef<OrbMetrics>({ ...ZERO_METRICS });
-  const { data } = useModelsUsage(2000);
+  const { data } = useModelsUsage(5000);
 
   useEffect(() => {
     if (!data?.usage) return;
     const u = data.usage as Record<string, number | undefined>;
     metricsRef.current = {
       cpu: u.cpu_usage_percent ?? 0,
-      gpu: u.gpu_usage_percent ?? 0,
+      gpu: typeof u.gpu_usage_percent === "number" ? u.gpu_usage_percent : Number.NaN,
       net: u.net_usage_percent ?? 0,
       ram: u.memory_usage_percent ?? 0,
     };

--- a/web-next/components/voice/use-orb-metrics.ts
+++ b/web-next/components/voice/use-orb-metrics.ts
@@ -7,11 +7,11 @@ import { useModelsUsage } from "@/hooks/use-api";
 export type OrbMetrics = {
   cpu: number;
   gpu: number;
-  net: number;
+  vram: number;
   ram: number;
 };
 
-const ZERO_METRICS: OrbMetrics = { cpu: 0, gpu: 0, net: 0, ram: 0 };
+const ZERO_METRICS: OrbMetrics = { cpu: 0, gpu: 0, vram: 0, ram: 0 };
 
 export function useOrbMetrics(): RefObject<OrbMetrics> {
   const metricsRef = useRef<OrbMetrics>({ ...ZERO_METRICS });
@@ -23,7 +23,7 @@ export function useOrbMetrics(): RefObject<OrbMetrics> {
     metricsRef.current = {
       cpu: u.cpu_usage_percent ?? 0,
       gpu: typeof u.gpu_usage_percent === "number" ? u.gpu_usage_percent : Number.NaN,
-      net: u.net_usage_percent ?? 0,
+      vram: u.vram_usage_percent ?? 0,
       ram: u.memory_usage_percent ?? 0,
     };
   }, [data]);

--- a/web-next/components/voice/use-orb-metrics.ts
+++ b/web-next/components/voice/use-orb-metrics.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { RefObject } from "react";
+import { useModelsUsage } from "@/hooks/use-api";
+
+export type OrbMetrics = {
+  cpu: number;
+  gpu: number;
+  net: number;
+  ram: number;
+};
+
+const ZERO_METRICS: OrbMetrics = { cpu: 0, gpu: 0, net: 0, ram: 0 };
+
+export function useOrbMetrics(): RefObject<OrbMetrics> {
+  const metricsRef = useRef<OrbMetrics>({ ...ZERO_METRICS });
+  const { data } = useModelsUsage(2000);
+
+  useEffect(() => {
+    if (!data?.usage) return;
+    const u = data.usage as Record<string, number | undefined>;
+    metricsRef.current = {
+      cpu: u.cpu_usage_percent ?? 0,
+      gpu: u.gpu_usage_percent ?? 0,
+      net: u.net_usage_percent ?? 0,
+      ram: u.memory_usage_percent ?? 0,
+    };
+  }, [data]);
+
+  return metricsRef;
+}

--- a/web-next/components/voice/voice-chat-screen.tsx
+++ b/web-next/components/voice/voice-chat-screen.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import type { LucideIcon } from "lucide-react";
 import { ArrowLeft, Brain, MessageSquareText, Sparkles, ListTodo } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -11,7 +11,9 @@ import { useTranslation } from "@/lib/i18n";
 import {
   VoiceCommandCenter,
   type VoiceModePreset,
+  type VoiceStatusUpdate,
 } from "@/components/voice/voice-command-center";
+import { VoiceStatusSidebar } from "@/components/voice/voice-status-sidebar";
 
 type VoiceModeCard = {
   mode: VoiceModePreset;
@@ -49,7 +51,12 @@ const VOICE_MODES: VoiceModeCard[] = [
 
 export function VoiceChatScreen() {
   const [voiceModePreset, setVoiceModePreset] = useState<VoiceModePreset>("standard");
+  const [voiceStatus, setVoiceStatus] = useState<VoiceStatusUpdate | null>(null);
   const t = useTranslation();
+
+  const handleStatusUpdate = useCallback((s: VoiceStatusUpdate | null) => {
+    setVoiceStatus(s);
+  }, []);
 
   return (
     <div className="space-y-6 pb-10">
@@ -71,8 +78,12 @@ export function VoiceChatScreen() {
       />
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(0,0.85fr)]">
-        <VoiceCommandCenter voiceModePreset={voiceModePreset} />
-        <div className="space-y-6">
+        <VoiceCommandCenter
+          voiceModePreset={voiceModePreset}
+          onStatusUpdate={handleStatusUpdate}
+        />
+        <div className="space-y-4">
+          {/* Mode selector */}
           <div className="rounded-3xl box-muted p-4">
             <p className="eyebrow">{t("voice.modes.title")}</p>
             <p className="mt-1 text-sm text-zinc-300">{t("voice.modes.description")}</p>
@@ -101,6 +112,9 @@ export function VoiceChatScreen() {
             </div>
             <p className="mt-3 text-xs text-zinc-400">{t("voice.modes.hint")}</p>
           </div>
+
+          {/* STT/TTS + Runtime status — compact info boxes for tuning */}
+          <VoiceStatusSidebar status={voiceStatus} />
         </div>
       </div>
     </div>

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -178,6 +178,45 @@ const buildTimingSummary = (timings?: Record<string, number | null | undefined> 
     .join(" · ");
 };
 
+const TIMING_STAGES: Array<{ key: string; label: string; accent?: boolean }> = [
+  { key: "decode_ms", label: "Decode" },
+  { key: "stt_ms",    label: "STT" },
+  { key: "llm_ms",    label: "LLM" },
+  { key: "tts_ms",    label: "TTS" },
+  { key: "total_backend_ms", label: "Total", accent: true },
+];
+
+function TimingStrip({
+  timings,
+}: {
+  timings?: Record<string, number | null | undefined> | null;
+}) {
+  const hasAny = timings && TIMING_STAGES.some((s) => timings[s.key] != null);
+  return (
+    <div className="grid grid-cols-5 gap-1.5 text-xs">
+      {TIMING_STAGES.map(({ key, label, accent }) => {
+        const raw = timings?.[key];
+        const val = formatTimingSeconds(typeof raw === "number" ? raw : null);
+        return (
+          <div
+            key={key}
+            className={`rounded-xl p-2 text-center ${
+              accent
+                ? "border border-white/10 bg-white/[0.06]"
+                : "rounded-xl box-muted"
+            } ${!hasAny ? "opacity-40" : ""}`}
+          >
+            <p className="text-caption leading-none">{label}</p>
+            <p className={`mt-1 font-mono font-semibold leading-none ${accent ? "text-white" : "text-zinc-200"}`}>
+              {val ?? "—"}
+            </p>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 const buildRuntimeSummary = (runtime?: VoiceRuntime | null): string => {
   if (!runtime) return "";
   const parts: Array<string | null> = [
@@ -1836,6 +1875,9 @@ export function VoiceCommandCenter({
             <p className="text-white">{audioWsStateLabel}</p>
           </div>
         </div>
+
+        {/* Timing strip — last session stage durations */}
+        <TimingStrip timings={audioStatus?.latest_voice_session?.timings_ms} />
 
         <p className="text-hint text-xs">{statusMessage ?? t("voice.status.channelReady")}</p>
       </div>

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -239,11 +239,7 @@ const buildReconnectDelay = (attempt: number): number =>
 
 const closeAudioContext = (ctx: AudioContext | null | undefined) => {
   if (!ctx) return;
-  try {
-    ctx.close().catch(() => undefined);
-  } catch {
-    // ignore close races during reconnects
-  }
+  ctx.close().catch(() => undefined);
 };
 
 const createPlaybackContext = (
@@ -260,6 +256,15 @@ const createPlaybackContext = (
     return context;
   } catch {
     return null;
+  }
+};
+
+const tryResumeAudioContext = async (ctx: AudioContext): Promise<boolean> => {
+  try {
+    await ctx.resume();
+    return true;
+  } catch {
+    return false;
   }
 };
 
@@ -1116,11 +1121,7 @@ export function VoiceCommandCenter({
         );
         if (effectiveModelPath === modelPath) {
           releasePlaybackResources();
-          try {
-            wsRef.current?.close();
-          } catch {
-            // ignore socket close races after model switch
-          }
+          wsRef.current?.close();
         }
         await refreshAudioStatus();
         await refreshTtsModelOptions();
@@ -1147,41 +1148,28 @@ export function VoiceCommandCenter({
   const ensurePlaybackContext = useCallback(async () => {
     const browserWindow = getBrowserWindow();
     if (!browserWindow) return null;
-    const AudioContextCtor = browserWindow.AudioContext || browserWindow.webkitAudioContext;
+    const AudioContextCtor = getAudioContextCtor(browserWindow);
     if (!AudioContextCtor) return null;
 
     let ctx = ttsAudioContextRef.current;
 
-    // Rebuild closed context
     if (!ctx || ctx.state === "closed") {
       ctx = createPlaybackContext(AudioContextCtor, ttsSourceRef);
-      if (ctx) {
-        ttsAudioContextRef.current = ctx;
-      }
-      if (!ctx) return null;
+      if (ctx) ttsAudioContextRef.current = ctx;
+      return ctx;
     }
 
-    if (ctx.state === "suspended") {
-      try {
-        await ctx.resume();
-      } catch {
-        // Resume failed — create a fresh context for this play
-        closeAudioContext(ctx);
-        ctx = createPlaybackContext(AudioContextCtor, ttsSourceRef);
-        if (ctx) {
-          ttsAudioContextRef.current = ctx;
-        }
-        if (!ctx) return null;
-      }
+    if (ctx.state === "suspended" && !(await tryResumeAudioContext(ctx))) {
+      closeAudioContext(ctx);
+      ctx = createPlaybackContext(AudioContextCtor, ttsSourceRef);
+      if (ctx) ttsAudioContextRef.current = ctx;
+      return ctx;
     }
 
-    // Final guard: if still not running, replace with a fresh context
     if (ctx.state !== "running") {
       closeAudioContext(ctx);
       ctx = createPlaybackContext(AudioContextCtor, ttsSourceRef);
-      if (ctx) {
-        ttsAudioContextRef.current = ctx;
-      }
+      if (ctx) ttsAudioContextRef.current = ctx;
     }
 
     return ctx;
@@ -1493,7 +1481,7 @@ export function VoiceCommandCenter({
 
   const showDevButton =
     process.env.NEXT_PUBLIC_SHOW_DEV_PANEL === "true" ||
-    (typeof globalThis.location !== "undefined" &&
+    (globalThis.location !== undefined &&
       new URLSearchParams(globalThis.location.search).has("dev"));
 
   return (

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -1248,15 +1248,13 @@ export function VoiceCommandCenter({
   }, []);
 
   const releasePlaybackResources = useCallback(() => {
-    try {
-      ttsSourceRef.current?.stop();
-    } catch {
-      // ignore
-    }
-    ttsSourceRef.current?.disconnect();
+    const src = ttsSourceRef.current;
+    const analyser = ttsAnalyserRef.current;
     ttsSourceRef.current = null;
-    ttsAnalyserRef.current?.disconnect();
     ttsAnalyserRef.current = null;
+    try { src?.stop(); } catch { /* ignore races with natural end */ }
+    try { src?.disconnect(); } catch { /* ignore */ }
+    try { analyser?.disconnect(); } catch { /* ignore */ }
   }, []);
 
   const applyTtsModel = useCallback(
@@ -1319,21 +1317,49 @@ export function VoiceCommandCenter({
     const browserWindow = getBrowserWindow();
     if (!browserWindow) return null;
     const AudioContextCtor = browserWindow.AudioContext || browserWindow.webkitAudioContext;
-    if (!AudioContextCtor) {
-      return null;
-    }
+    if (!AudioContextCtor) return null;
+
+    const makeContext = (): AudioContext | null => {
+      try {
+        const c = new AudioContextCtor();
+        // Auto-resume if the browser suspends the context mid-playback
+        c.onstatechange = () => {
+          if (c.state === "suspended" && ttsSourceRef.current) {
+            c.resume().catch(() => undefined);
+          }
+        };
+        ttsAudioContextRef.current = c;
+        return c;
+      } catch {
+        return null;
+      }
+    };
+
     let ctx = ttsAudioContextRef.current;
-    if (!ctx) {
-      ctx = new AudioContextCtor();
-      ttsAudioContextRef.current = ctx;
+
+    // Rebuild closed context
+    if (!ctx || ctx.state === "closed") {
+      ctx = makeContext();
+      if (!ctx) return null;
     }
+
     if (ctx.state === "suspended") {
       try {
         await ctx.resume();
       } catch {
-        // ignore autoplay policy failures; user can replay after a gesture
+        // Resume failed — create a fresh context for this play
+        try { ctx.close().catch(() => undefined); } catch { /* ignore */ }
+        ctx = makeContext();
+        if (!ctx) return null;
       }
     }
+
+    // Final guard: if still not running, replace with a fresh context
+    if (ctx.state !== "running") {
+      try { ctx.close().catch(() => undefined); } catch { /* ignore */ }
+      ctx = makeContext();
+    }
+
     return ctx;
   }, []);
 
@@ -1373,10 +1399,12 @@ export function VoiceCommandCenter({
         ttsAnalyser.connect(ctx.destination);
         ttsAnalyserRef.current = ttsAnalyser;
         source.onended = () => {
+          // Always clean up the graph nodes for this play
+          try { source.disconnect(); } catch { /* ignore */ }
+          try { ttsAnalyser.disconnect(); } catch { /* ignore */ }
           if (ttsSourceRef.current === source) {
             setPlaybackState("idle");
             ttsSourceRef.current = null;
-            ttsAnalyser.disconnect();
             ttsAnalyserRef.current = null;
           }
         };

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -1512,7 +1512,8 @@ export function VoiceCommandCenter({
               size="xs"
               variant="outline"
               onClick={() => setDevDrawerOpen(true)}
-              title="Dev diagnostics"
+              title={t("voice.controls.diagnostics")}
+              aria-label={t("voice.controls.diagnostics")}
             >
               ⚙
             </Button>

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -165,12 +165,12 @@ const TIMING_STAGES: Array<{ key: string; label: string; accent?: boolean }> = [
   { key: "total_backend_ms", label: "Total", accent: true },
 ];
 
-function TimingStrip({
-  timings,
-}: {
+type TimingStripProps = Readonly<{
   timings?: Record<string, number | null | undefined> | null;
-}) {
-  const hasAny = timings && TIMING_STAGES.some((s) => timings[s.key] != null);
+}>;
+
+function TimingStrip({ timings }: TimingStripProps) {
+  const hasAny = Boolean(timings) && TIMING_STAGES.some((s) => timings[s.key] != null);
   return (
     <div className="grid grid-cols-5 gap-1.5 text-xs">
       {TIMING_STAGES.map(({ key, label, accent }) => {
@@ -183,7 +183,7 @@ function TimingStrip({
               accent
                 ? "border border-white/10 bg-white/[0.06]"
                 : "rounded-xl box-muted"
-            } ${!hasAny ? "opacity-40" : ""}`}
+            } ${hasAny ? "" : "opacity-40"}`}
           >
             <p className="text-caption leading-none">{label}</p>
             <p className={`mt-1 font-mono font-semibold leading-none ${accent ? "text-white" : "text-zinc-200"}`}>
@@ -236,6 +236,32 @@ const isWebSocketOpen = (ws: WebSocket | null | undefined): ws is WebSocket =>
 
 const buildReconnectDelay = (attempt: number): number =>
   Math.min(30000, 1000 * 2 ** attempt) + secureRandomInt(500);
+
+const closeAudioContext = (ctx: AudioContext | null | undefined) => {
+  if (!ctx) return;
+  try {
+    ctx.close().catch(() => undefined);
+  } catch {
+    // ignore close races during reconnects
+  }
+};
+
+const createPlaybackContext = (
+  AudioContextCtor: typeof AudioContext,
+  sourceRef: RefObject<MediaElementAudioSourceNode | null>,
+): AudioContext | null => {
+  try {
+    const context = new AudioContextCtor();
+    context.onstatechange = () => {
+      if (context.state === "suspended" && sourceRef.current) {
+        context.resume().catch(() => undefined);
+      }
+    };
+    return context;
+  } catch {
+    return null;
+  }
+};
 
 const syncVoiceModeSelection = (
   deps: Pick<
@@ -1124,27 +1150,14 @@ export function VoiceCommandCenter({
     const AudioContextCtor = browserWindow.AudioContext || browserWindow.webkitAudioContext;
     if (!AudioContextCtor) return null;
 
-    const makeContext = (): AudioContext | null => {
-      try {
-        const c = new AudioContextCtor();
-        // Auto-resume if the browser suspends the context mid-playback
-        c.onstatechange = () => {
-          if (c.state === "suspended" && ttsSourceRef.current) {
-            c.resume().catch(() => undefined);
-          }
-        };
-        ttsAudioContextRef.current = c;
-        return c;
-      } catch {
-        return null;
-      }
-    };
-
     let ctx = ttsAudioContextRef.current;
 
     // Rebuild closed context
     if (!ctx || ctx.state === "closed") {
-      ctx = makeContext();
+      ctx = createPlaybackContext(AudioContextCtor, ttsSourceRef);
+      if (ctx) {
+        ttsAudioContextRef.current = ctx;
+      }
       if (!ctx) return null;
     }
 
@@ -1153,16 +1166,22 @@ export function VoiceCommandCenter({
         await ctx.resume();
       } catch {
         // Resume failed — create a fresh context for this play
-        try { ctx.close().catch(() => undefined); } catch { /* ignore */ }
-        ctx = makeContext();
+        closeAudioContext(ctx);
+        ctx = createPlaybackContext(AudioContextCtor, ttsSourceRef);
+        if (ctx) {
+          ttsAudioContextRef.current = ctx;
+        }
         if (!ctx) return null;
       }
     }
 
     // Final guard: if still not running, replace with a fresh context
     if (ctx.state !== "running") {
-      try { ctx.close().catch(() => undefined); } catch { /* ignore */ }
-      ctx = makeContext();
+      closeAudioContext(ctx);
+      ctx = createPlaybackContext(AudioContextCtor, ttsSourceRef);
+      if (ctx) {
+        ttsAudioContextRef.current = ctx;
+      }
     }
 
     return ctx;
@@ -1474,7 +1493,8 @@ export function VoiceCommandCenter({
 
   const showDevButton =
     process.env.NEXT_PUBLIC_SHOW_DEV_PANEL === "true" ||
-    (typeof window !== "undefined" && new URLSearchParams(window.location.search).has("dev"));
+    (typeof globalThis.location !== "undefined" &&
+      new URLSearchParams(globalThis.location.search).has("dev"));
 
   return (
     <>

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -16,6 +16,7 @@ import { getAudioWsUrl } from "@/lib/env";
 import { useTranslation } from "@/lib/i18n";
 import type { VoiceOrbState } from "@/components/voice/voice-orb";
 import { useOrbEffectsConfig } from "@/components/voice/use-orb-effects-config";
+import { useOrbMetrics } from "@/components/voice/use-orb-metrics";
 import { OrbZone } from "@/components/voice/orb-zone";
 import { DevDiagnosticsDrawer } from "@/components/voice/dev-diagnostics-drawer";
 
@@ -98,8 +99,6 @@ type TtsModelOption = {
 };
 
 type Translator = (key: string, variables?: Record<string, string | number>) => string;
-type VoiceRuntime = NonNullable<NonNullable<AudioStatus["latest_voice_session"]>["runtime"]>;
-type RuntimeSnapshot = NonNullable<AudioStatus["runtime_snapshot"]>;
 
 declare global {
   interface Window {
@@ -158,31 +157,11 @@ const formatTimingSeconds = (milliseconds?: number | null): string | null => {
 const getBrowserWindow = (): BrowserWindowLike | undefined =>
   globalThis as unknown as BrowserWindowLike;
 
-const getVoiceModeMeta = (t: Translator, mode: VoiceModePreset) => ({
-  title: t(VOICE_MODE_TITLE_KEYS[mode]),
-  description: t(VOICE_MODE_HINT_KEYS[mode]),
-});
-
-const buildTimingSummary = (timings?: Record<string, number | null | undefined> | null): string => {
-  if (!timings) return "";
-  const entries: Array<[string, string | null]> = [
-    ["decode", formatTimingSeconds(timings.decode_ms)],
-    ["STT", formatTimingSeconds(timings.stt_ms)],
-    ["LLM", formatTimingSeconds(timings.llm_ms)],
-    ["TTS", formatTimingSeconds(timings.tts_ms)],
-    ["total", formatTimingSeconds(timings.total_backend_ms)],
-  ];
-  return entries
-    .filter((entry): entry is [string, string] => Boolean(entry[1]))
-    .map(([label, value]) => `${label} ${value}`)
-    .join(" · ");
-};
-
 const TIMING_STAGES: Array<{ key: string; label: string; accent?: boolean }> = [
   { key: "decode_ms", label: "Decode" },
-  { key: "stt_ms",    label: "STT" },
-  { key: "llm_ms",    label: "LLM" },
-  { key: "tts_ms",    label: "TTS" },
+  { key: "stt_ms", label: "STT" },
+  { key: "llm_ms", label: "LLM" },
+  { key: "tts_ms", label: "TTS" },
   { key: "total_backend_ms", label: "Total", accent: true },
 ];
 
@@ -216,212 +195,6 @@ function TimingStrip({
     </div>
   );
 }
-
-const buildRuntimeSummary = (runtime?: VoiceRuntime | null): string => {
-  if (!runtime) return "";
-  const parts: Array<string | null> = [
-    runtime.llm_model
-      ? `LLM ${runtime.llm_service_id ?? "runtime"}:${runtime.llm_model}`
-      : null,
-    runtime.stt_model
-      ? `STT ${runtime.stt_model}/${runtime.stt_device ?? "?"}`
-      : null,
-    runtime.tts_sample_rate ? `TTS ${runtime.tts_sample_rate} Hz` : null,
-  ];
-  return parts.filter((part): part is string => Boolean(part)).join(" · ");
-};
-
-const buildRuntimeSnapshotSummary = (
-  runtimeSnapshot: AudioStatus["runtime_snapshot"],
-): string => {
-  if (!runtimeSnapshot) return "";
-  if (runtimeSnapshot.error) return runtimeSnapshot.error;
-  const profile = runtimeSnapshot.runtime_capabilities?.compatibility_profile ?? "";
-  const probeStatus = runtimeSnapshot.runtime_capabilities?.probe_status ?? "";
-  const pipeline = runtimeSnapshot.voice_pipeline;
-  const parts = [
-    profile ? `profile ${profile}` : null,
-    probeStatus ? `probe ${probeStatus}` : null,
-    pipeline?.stt ? `stt ${pipeline.stt}` : null,
-    pipeline?.reasoning ? `reasoning ${pipeline.reasoning}` : null,
-    pipeline?.tools ? `tools ${pipeline.tools}` : null,
-    pipeline?.vision ? `vision ${pipeline.vision}` : null,
-    pipeline?.tts ? `tts ${pipeline.tts}` : null,
-  ];
-  return parts.filter((part): part is string => Boolean(part)).join(" · ");
-};
-
-const getProbeTone = (status?: string | null): "success" | "warning" | "danger" | "neutral" => {
-  if (status === "verified") return "success";
-  if (status === "failed") return "danger";
-  if (status === "metadata_only") return "warning";
-  return "neutral";
-};
-
-const getRuntimeSnapshotContainerClass = (
-  tone: "success" | "warning" | "danger" | "neutral",
-): string => {
-  if (tone === "danger") {
-    return "border-rose-400/25 bg-rose-500/[0.06] shadow-[0_0_32px_rgba(244,63,94,0.08)]";
-  }
-  if (tone === "warning") {
-    return "border-amber-400/25 bg-amber-500/[0.06] shadow-[0_0_32px_rgba(245,158,11,0.08)]";
-  }
-  if (tone === "neutral") {
-    return "border-white/10 bg-white/[0.03] shadow-none";
-  }
-  return "border-emerald-400/25 bg-emerald-500/[0.06] shadow-[0_0_32px_rgba(16,185,129,0.08)]";
-};
-
-const buildProbeSummary = (runtimeSnapshot: RuntimeSnapshot): string => {
-  const probes = runtimeSnapshot.runtime_capabilities?.probes ?? {};
-  return Object.entries(probes)
-    .map(([name, probe]) => `${name}:${probe.status ?? "?"}`)
-    .join(" · ");
-};
-
-const buildPipelineEntries = (runtimeSnapshot: RuntimeSnapshot): Array<[string, string]> => {
-  const pipeline = runtimeSnapshot.voice_pipeline;
-  return [
-    ["STT", pipeline?.stt ?? "—"],
-    ["Reasoning", pipeline?.reasoning ?? "—"],
-    ["Tools", pipeline?.tools ?? "—"],
-    ["Vision", pipeline?.vision ?? "—"],
-    ["TTS", pipeline?.tts ?? "—"],
-  ];
-};
-
-type RuntimeSnapshotPanelProps = Readonly<{
-  t: Translator;
-  runtimeSnapshot: RuntimeSnapshot | null;
-  runtimeSnapshotSummary: string;
-}>;
-
-function RuntimeSnapshotPanel({
-  t,
-  runtimeSnapshot,
-  runtimeSnapshotSummary,
-}: RuntimeSnapshotPanelProps) {
-  if (!runtimeSnapshot) {
-    return (
-      <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <p className="eyebrow">{t("voice.controls.runtimeSnapshot")}</p>
-            <p className="mt-1 text-sm text-zinc-300">{t("voice.controls.noRuntimeSnapshot")}</p>
-          </div>
-          <Badge tone="neutral">{t("voice.controls.offline")}</Badge>
-        </div>
-      </div>
-    );
-  }
-
-  const capabilities = runtimeSnapshot.runtime_capabilities;
-  const probeStatus = capabilities?.probe_status ?? "unknown";
-  const containerTone = getProbeTone(runtimeSnapshot.error ? "failed" : probeStatus);
-  const probeSummary = buildProbeSummary(runtimeSnapshot);
-  const pipelineEntries = buildPipelineEntries(runtimeSnapshot);
-  const notes = runtimeSnapshot.voice_pipeline?.notes ?? [];
-
-  return (
-    <div className={`rounded-2xl border p-4 ${getRuntimeSnapshotContainerClass(containerTone)}`}>
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div>
-          <p className="eyebrow">{t("voice.controls.runtimeSnapshot")}</p>
-          <p className="mt-1 text-base font-semibold text-white">
-            {runtimeSnapshot.model_name ?? t("voice.controls.unknownModel")}
-          </p>
-          <p className="mt-1 text-xs text-zinc-400">
-            {runtimeSnapshotSummary || runtimeSnapshot.provider || "—"}
-          </p>
-          {runtimeSnapshot.error ? (
-            <p className="mt-2 text-xs text-rose-200">{runtimeSnapshot.error}</p>
-          ) : null}
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <Badge tone={getProbeTone(probeStatus)}>
-            {t("voice.controls.probeStatus")}: {probeStatus}
-          </Badge>
-          <Badge tone="neutral">
-            {capabilities?.compatibility_profile ?? runtimeSnapshot.voice_pipeline?.profile ?? "unknown"}
-          </Badge>
-        </div>
-      </div>
-
-      <div className="mt-4 grid gap-2 sm:grid-cols-3">
-        <div className="rounded-xl border border-white/10 bg-black/20 p-3 text-xs text-zinc-300">
-          <p className="text-caption">{t("voice.controls.provider")}</p>
-          <p className="mt-1 text-white">{runtimeSnapshot.provider ?? runtimeSnapshot.runtime_id ?? "—"}</p>
-        </div>
-        <div className="rounded-xl border border-white/10 bg-black/20 p-3 text-xs text-zinc-300">
-          <p className="text-caption">{t("voice.controls.profile")}</p>
-          <p className="mt-1 text-white">{capabilities?.compatibility_profile ?? "—"}</p>
-        </div>
-        <div className="rounded-xl border border-white/10 bg-black/20 p-3 text-xs text-zinc-300">
-          <p className="text-caption">{t("voice.controls.pipeline")}</p>
-          <p className="mt-1 text-white">{runtimeSnapshot.voice_pipeline?.profile ?? "—"}</p>
-        </div>
-      </div>
-
-      <div className="mt-3 grid gap-2 sm:grid-cols-5">
-        {pipelineEntries.map(([label, value]) => (
-          <div key={label} className="rounded-xl border border-white/10 bg-black/20 p-3 text-xs">
-            <p className="text-caption">{label}</p>
-            <p className="mt-1 text-white">{value}</p>
-          </div>
-        ))}
-      </div>
-
-      <div className="mt-3 rounded-xl border border-white/10 bg-black/20 p-3 text-xs text-zinc-300">
-        <p className="text-caption">{t("voice.controls.probes")}</p>
-        <p className="mt-1 text-white">{probeSummary || "—"}</p>
-        {notes.length > 0 && <p className="mt-2 text-hint">{notes.join(" · ")}</p>}
-      </div>
-    </div>
-  );
-}
-
-const buildQualitySummary = (latestVoiceSession: AudioStatus["latest_voice_session"]): string => {
-  const parts: string[] = [];
-  if (latestVoiceSession) {
-    const peak = latestVoiceSession.peak_before_normalization;
-    if (typeof peak === "number" && Number.isFinite(peak)) {
-      parts.push(`peak ${peak.toFixed(2)}`);
-    }
-    const rms = latestVoiceSession.rms_after_normalization;
-    if (typeof rms === "number" && Number.isFinite(rms)) {
-      parts.push(`rms ${rms.toFixed(3)}`);
-    }
-  }
-  return parts.join(" · ");
-};
-
-const buildLatestRecordingSummary = (latestVoiceSession: AudioStatus["latest_voice_session"]): string => {
-  const parts: string[] = [];
-  if (latestVoiceSession) {
-    const duration = latestVoiceSession.duration_sec;
-    if (typeof duration === "number" && Number.isFinite(duration)) {
-      parts.push(`${duration.toFixed(1)} s`);
-    }
-    if (
-      typeof latestVoiceSession.sample_rate === "number" &&
-      Number.isFinite(latestVoiceSession.sample_rate)
-    ) {
-      parts.push(`${latestVoiceSession.sample_rate} Hz`);
-    }
-    if (latestVoiceSession.input_format) {
-      parts.push(latestVoiceSession.input_format);
-    }
-    if (latestVoiceSession.voice_mode) {
-      parts.push(latestVoiceSession.voice_mode);
-    }
-    const gain = latestVoiceSession.gain_applied;
-    if (typeof gain === "number" && Number.isFinite(gain)) {
-      parts.push(`gain ${gain.toFixed(1)}`);
-    }
-  }
-  return parts.join(" · ");
-};
 
 const getRecordingButtonClass = (
   audioEnabled: boolean,
@@ -1158,13 +931,6 @@ const VOICE_MODE_TITLE_KEYS: Record<VoiceModePreset, string> = {
   action_items: "voice.modes.actionItems.title",
 };
 
-const VOICE_MODE_HINT_KEYS: Record<VoiceModePreset, string> = {
-  standard: "voice.modes.standard.description",
-  deep_analysis: "voice.modes.deepAnalysis.description",
-  summary: "voice.modes.summary.description",
-  action_items: "voice.modes.actionItems.description",
-};
-
 type VoiceCommandCenterProps = Readonly<{
   onTranscriptReady?: (text: string) => void;
   voiceModePreset?: VoiceModePreset;
@@ -1691,6 +1457,7 @@ export function VoiceCommandCenter({
 
   const orbState = deriveOrbState(connected, recording, processingStatus, playbackState, lastAudioSignal);
   const effectsConfig = useOrbEffectsConfig();
+  const metricsRef = useOrbMetrics();
 
   const recordingButtonClass = getRecordingButtonClass(
     audioEnabled,
@@ -1745,6 +1512,7 @@ export function VoiceCommandCenter({
             audioEnabled={audioEnabled}
             micAnalyserRef={analyserRef}
             ttsAnalyserRef={ttsAnalyserRef}
+            metricsRef={metricsRef}
           />
         )}
 

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -19,7 +19,7 @@ import { useOrbEffectsConfig } from "@/components/voice/use-orb-effects-config";
 import { OrbZone } from "@/components/voice/orb-zone";
 import { DevDiagnosticsDrawer } from "@/components/voice/dev-diagnostics-drawer";
 
-type AudioStatus = {
+export type AudioStatus = {
   enabled: boolean;
   connected_clients: number;
   active_recordings: number;
@@ -1106,6 +1106,11 @@ const startVoiceCapture = async (deps: VoiceCaptureDeps): Promise<void> => {
 };
 
 export type VoiceModePreset = "standard" | "deep_analysis" | "summary" | "action_items";
+export type VoiceStatusUpdate = Pick<AudioStatus,
+  | "enabled" | "stt_ready" | "tts_ready" | "tts_fallback"
+  | "whisper_model_size" | "stt_backend" | "tts_backend"
+  | "vad_threshold" | "dependencies" | "runtime_snapshot"
+>;
 
 const VOICE_MODE_TITLE_KEYS: Record<VoiceModePreset, string> = {
   standard: "voice.modes.standard.title",
@@ -1124,11 +1129,13 @@ const VOICE_MODE_HINT_KEYS: Record<VoiceModePreset, string> = {
 type VoiceCommandCenterProps = Readonly<{
   onTranscriptReady?: (text: string) => void;
   voiceModePreset?: VoiceModePreset;
+  onStatusUpdate?: (status: VoiceStatusUpdate | null) => void;
 }>;
 
 export function VoiceCommandCenter({
   onTranscriptReady,
   voiceModePreset = "standard",
+  onStatusUpdate,
 }: VoiceCommandCenterProps) {
   const t = useTranslation();
   const audioEnabled = process.env.NEXT_PUBLIC_ENABLE_AUDIO_INTERFACE === "true";
@@ -1173,6 +1180,23 @@ export function VoiceCommandCenter({
     mq.addEventListener("change", handler);
     return () => mq.removeEventListener("change", handler);
   }, []);
+
+  useEffect(() => {
+    if (!onStatusUpdate) return;
+    if (!audioStatus) { onStatusUpdate(null); return; }
+    onStatusUpdate({
+      enabled:           audioStatus.enabled,
+      stt_ready:         audioStatus.stt_ready,
+      tts_ready:         audioStatus.tts_ready,
+      tts_fallback:      audioStatus.tts_fallback,
+      whisper_model_size:audioStatus.whisper_model_size,
+      stt_backend:       audioStatus.stt_backend,
+      tts_backend:       audioStatus.tts_backend,
+      vad_threshold:     audioStatus.vad_threshold,
+      dependencies:      audioStatus.dependencies,
+      runtime_snapshot:  audioStatus.runtime_snapshot,
+    });
+  }, [audioStatus, onStatusUpdate]);
 
   useEffect(() => {
     syncVoiceModeSelection({

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -14,8 +14,10 @@ import {
 } from "@/components/ui/select";
 import { getAudioWsUrl } from "@/lib/env";
 import { useTranslation } from "@/lib/i18n";
-import { VoiceOrb, type VoiceOrbState } from "@/components/voice/voice-orb";
-import { useOrbEffectsConfig, type OrbEffectsConfig } from "@/components/voice/use-orb-effects-config";
+import type { VoiceOrbState } from "@/components/voice/voice-orb";
+import { useOrbEffectsConfig } from "@/components/voice/use-orb-effects-config";
+import { OrbZone } from "@/components/voice/orb-zone";
+import { DevDiagnosticsDrawer } from "@/components/voice/dev-diagnostics-drawer";
 
 type AudioStatus = {
   enabled: boolean;
@@ -1119,144 +1121,6 @@ const VOICE_MODE_HINT_KEYS: Record<VoiceModePreset, string> = {
   action_items: "voice.modes.actionItems.description",
 };
 
-type VoiceCommandCenterStatusSidebarProps = Readonly<{
-  t: Translator;
-  audioStatus: AudioStatus | null;
-  latestVoiceSession: AudioStatus["latest_voice_session"];
-  latestRecordingSummary: string;
-  qualitySummary: string;
-  timingSummary: string;
-  runtimeSummary: string;
-  transcription: string;
-  response: string;
-  orbState: VoiceOrbState;
-  reducedMotion: boolean;
-  isVoiceModeEnabled: boolean;
-  audioEnabled: boolean;
-  effectsConfig: OrbEffectsConfig;
-  micAnalyserRef: RefObject<AnalyserNode | null>;
-  ttsAnalyserRef: RefObject<AnalyserNode | null>;
-}>;
-
-function VoiceCommandCenterStatusSidebar({
-  t,
-  audioStatus,
-  latestVoiceSession,
-  latestRecordingSummary,
-  qualitySummary,
-  timingSummary,
-  runtimeSummary,
-  transcription,
-  response,
-  orbState,
-  reducedMotion,
-  isVoiceModeEnabled,
-  audioEnabled,
-  effectsConfig,
-  micAnalyserRef,
-  ttsAnalyserRef,
-}: VoiceCommandCenterStatusSidebarProps) {
-  return (
-    <div className="space-y-3">
-      {isVoiceModeEnabled ? (
-        <div className="flex justify-center rounded-2xl box-muted py-6">
-          <VoiceOrb
-            state={orbState}
-            disabled={!audioEnabled}
-            reducedMotion={reducedMotion}
-            label={t(`voice.orb.stateLabel.${orbState}`)}
-            effectsConfig={effectsConfig}
-            micAnalyserRef={micAnalyserRef}
-            ttsAnalyserRef={ttsAnalyserRef}
-          />
-        </div>
-      ) : null}
-      <div className="rounded-2xl box-muted p-4">
-        <p className="eyebrow">{t("voice.controls.audioWs")}</p>
-        {audioStatus ? (
-          <div className="mt-2 grid gap-2 text-xs text-zinc-300 sm:grid-cols-2">
-            <div>
-              <p className="text-caption">{t("voice.controls.enabled")}</p>
-              <p className="text-white">{audioStatus.enabled ? t("common.yes") : t("common.no")}</p>
-            </div>
-            <div>
-              <p className="text-caption">{t("voice.controls.clients")}</p>
-              <p className="text-white">{audioStatus.connected_clients}</p>
-            </div>
-            <div>
-              <p className="text-caption">{t("voice.controls.recordings")}</p>
-              <p className="text-white">{audioStatus.active_recordings}</p>
-            </div>
-            <div>
-              <p className="text-caption">VAD</p>
-              <p className="text-white">{audioStatus.vad_threshold ?? "—"}</p>
-            </div>
-            <div>
-              <p className="text-caption">{t("voice.controls.whisper")}</p>
-              <p className="text-white">{audioStatus.whisper_model_size ?? "—"}</p>
-            </div>
-            <div>
-              <p className="text-caption">{t("voice.controls.sttReady")}</p>
-              <p className="text-white">{audioStatus.stt_ready ? t("common.yes") : t("common.no")}</p>
-            </div>
-            <div>
-              <p className="text-caption">{t("voice.controls.ttsReady")}</p>
-              <p className="text-white">{audioStatus.tts_ready ? t("common.yes") : t("common.no")}</p>
-            </div>
-            <div>
-              <p className="text-caption">{t("voice.controls.ttsFallback")}</p>
-              <p className="text-white">{audioStatus.tts_fallback ? t("common.yes") : t("common.no")}</p>
-            </div>
-            {audioStatus.dependencies && (
-              <div className="sm:col-span-2">
-                <p className="text-caption">{t("voice.controls.dependencies")}</p>
-                <p className="text-white">
-                  {Object.entries(audioStatus.dependencies)
-                    .map(([name, ok]) => `${name}:${ok ? "yes" : "no"}`)
-                    .join(" · ")}
-                </p>
-              </div>
-            )}
-            {latestVoiceSession?.download_url && (
-              <div className="sm:col-span-2">
-                <p className="text-caption">{t("voice.controls.latestRecording")}</p>
-                <div className="mt-1 flex flex-wrap items-center gap-2">
-                  <Button asChild size="xs" variant="outline">
-                    <a href={latestVoiceSession.download_url} target="_blank" rel="noreferrer">
-                      {t("voice.controls.downloadWav")}
-                    </a>
-                  </Button>
-                  <span className="text-[11px] text-zinc-400">{latestRecordingSummary || "—"}</span>
-                </div>
-                <p className="mt-1 text-hint">
-                  {t("voice.controls.sessionId")}: {latestVoiceSession.session_id}
-                </p>
-                {qualitySummary && <p className="mt-1 text-hint">{t("voice.controls.quality")}: {qualitySummary}</p>}
-                {timingSummary && <p className="mt-1 text-hint">{t("voice.controls.timings")}: {timingSummary}</p>}
-                {runtimeSummary && <p className="mt-1 text-hint">{t("voice.controls.runtime")}: {runtimeSummary}</p>}
-                {latestVoiceSession.transcription && (
-                  <p className="mt-1 text-hint">STT: {latestVoiceSession.transcription}</p>
-                )}
-              </div>
-            )}
-            {audioStatus.message && <div className="sm:col-span-2 text-hint">{audioStatus.message}</div>}
-          </div>
-        ) : (
-          <p className="mt-2 text-hint">{t("voice.controls.noRecordingYet")}</p>
-        )}
-      </div>
-      <div className="rounded-2xl box-muted p-4">
-        <p className="eyebrow">{t("voice.controls.transcription")}</p>
-        <p className="mt-2 text-sm text-white">{transcription || t("voice.status.waitingForVoiceCommand")}</p>
-      </div>
-      <div className="rounded-2xl box-muted p-4">
-        <p className="eyebrow">{t("voice.controls.response")}</p>
-        <p className="mt-2 text-sm text-white">{response || t("voice.status.noResponseYet")}</p>
-      </div>
-    </div>
-  );
-}
-
 type VoiceCommandCenterProps = Readonly<{
   onTranscriptReady?: (text: string) => void;
   voiceModePreset?: VoiceModePreset;
@@ -1284,6 +1148,7 @@ export function VoiceCommandCenter({
   const [lastAudioSignal, setLastAudioSignal] = useState("idle");
   const [processingStatus, setProcessingStatus] = useState<string | null>(null);
   const [reducedMotion, setReducedMotion] = useState(false);
+  const [devDrawerOpen, setDevDrawerOpen] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectAttemptsRef = useRef(0);
   const reconnectTimeoutRef = useRef<number | null>(null);
@@ -1743,201 +1608,194 @@ export function VoiceCommandCenter({
     connected,
   );
   const recordingButtonLabel = getRecordingButtonLabel(t, recording, isVoiceModeEnabled);
-  const latestVoiceSession = audioStatus?.latest_voice_session;
-  const runtimeSnapshot = audioStatus?.runtime_snapshot ?? null;
-  const activeVoiceMode: VoiceModePreset = voiceModePreset || "standard";
-  const activeVoiceModeMeta = getVoiceModeMeta(t, activeVoiceMode);
-  const timingSummary = buildTimingSummary(latestVoiceSession?.timings_ms);
-  const runtimeSummary = buildRuntimeSummary(latestVoiceSession?.runtime ?? null);
-  const runtimeSnapshotSummary = buildRuntimeSnapshotSummary(runtimeSnapshot);
-  const qualitySummary = buildQualitySummary(latestVoiceSession);
-  const latestRecordingSummary = buildLatestRecordingSummary(latestVoiceSession);
   const voiceChatModeLabel = isVoiceModeEnabled ? t("voice.controls.voiceChat") : t("voice.controls.textChat");
   const playbackStateLabel = getPlaybackStateLabel(t, playbackState, ttsMuted);
   const audioWsStateLabel = audioStatus?.enabled ? t("voice.controls.ready") : t("voice.controls.offline");
 
   useEffect(() => bindRecordingReleaseListeners(recording, stopRecording), [recording, stopRecording]);
 
+  const showDevButton =
+    process.env.NEXT_PUBLIC_SHOW_DEV_PANEL === "true" ||
+    (typeof window !== "undefined" && new URLSearchParams(window.location.search).has("dev"));
+
   return (
+    <>
     <Panel
       title={t("voice.page.title")}
       description={t("voice.page.description")}
       action={
-        <Badge tone={connected ? "success" : "warning"}>
-          {connected ? t("voice.status.connected") : t("voice.status.offline")}
-        </Badge>
+        <div className="flex items-center gap-2">
+          <Badge tone={connected ? "success" : "warning"}>
+            {connected ? t("voice.status.connected") : t("voice.status.offline")}
+          </Badge>
+          {showDevButton && (
+            <Button
+              type="button"
+              size="xs"
+              variant="outline"
+              onClick={() => setDevDrawerOpen(true)}
+              title="Dev diagnostics"
+            >
+              ⚙
+            </Button>
+          )}
+        </div>
       }
     >
-      <div className="grid gap-4 lg:grid-cols-2">
-        <div className="card-shell card-base space-y-3 p-4">
-          <div className="flex items-center justify-between gap-3">
-            <p className="eyebrow">{t("voice.controls.voiceChat")}</p>
-            <div className="flex flex-wrap gap-2">
-              <Button
-                type="button"
-                size="xs"
-                variant={isVoiceModeEnabled ? "primary" : "outline"}
-                onClick={() =>
-                  setIsVoiceModeEnabled((current) => {
-                    const next = !current;
-                    setStatusMessage(next ? t("voice.controls.voiceChat") : t("voice.controls.textChat"));
-                    return next;
-                  })
-                }
-                disabled={!audioEnabled}
-              >
-                {isVoiceModeEnabled ? t("voice.controls.voice") : t("voice.controls.text")}
-              </Button>
-              <Button
-                type="button"
-                size="xs"
-                variant="outline"
-                onClick={() => setTtsMuted((current) => !current)}
-                disabled={!audioEnabled}
-              >
-                {ttsMuted ? t("voice.controls.ttsMuted") : t("voice.controls.ttsOn")}
-              </Button>
-              <Button
-                type="button"
-                size="xs"
-                variant="outline"
-                onClick={() => {
-                  replayLastResponse().catch(() => undefined);
-                }}
-                disabled={!audioEnabled || !lastAudioResponseRef.current}
-              >
-                {t("voice.controls.replay")}
-              </Button>
-              <Button
-                type="button"
-                size="xs"
-                variant="outline"
-                onClick={() => {
-                  refreshAudioStatus().catch(() => undefined);
-                  refreshTtsModelOptions().catch(() => undefined);
-                }}
-              >
-                {t("voice.controls.refresh")}
-              </Button>
-            </div>
-          </div>
-          <div className="rounded-2xl box-muted p-3 text-xs text-zinc-300">
-            <p className="text-caption">{t("voice.controls.ttsVoice")}</p>
-            <div className="mt-2 flex flex-wrap items-center gap-2">
-              <div className="min-w-[260px] flex-1">
-                <Select
-                  value={selectedTtsModelPath}
-                  onValueChange={(value) => {
-                    setSelectedTtsModelPath(value);
-                    applyTtsModel(value).catch(() => undefined);
-                  }}
-                  disabled={!audioEnabled || ttsModelChanging || ttsModelOptions.length === 0}
-                >
-                  <SelectTrigger className="h-8 border-white/10 bg-white/5 text-xs text-zinc-100">
-                    <SelectValue placeholder={t("voice.controls.ttsVoiceSelect")} />
-                  </SelectTrigger>
-                  <SelectContent className="border-white/10 bg-zinc-950 text-zinc-100">
-                    {ttsModelOptions.map((option) => (
-                      <SelectItem key={option.path} value={option.path}>
-                        {option.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <span className="text-[11px] text-zinc-400">
-                {ttsModelChanging ? t("voice.controls.ttsVoiceChanging") : t("voice.controls.ttsVoiceAuto")}
-              </span>
-            </div>
-          </div>
-          <Button
-            type="button"
-            onPointerDown={(event) => {
-              event.preventDefault();
-              if (!recordingRef.current) {
-                try {
-                  event.currentTarget.setPointerCapture(event.pointerId);
-                } catch {
-                  // ignore pointer capture failures
-                }
-                startRecording().catch(() => undefined);
-              }
-            }}
-            onPointerUp={(event) => {
-              event.preventDefault();
-              stopRecording();
+      <div className="space-y-4">
+        {/* Orb zone — orb + dialog bubbles */}
+        {isVoiceModeEnabled && (
+          <OrbZone
+            transcription={transcription}
+            response={response}
+            orbState={orbState}
+            effectsConfig={effectsConfig}
+            reducedMotion={reducedMotion}
+            audioEnabled={audioEnabled}
+            micAnalyserRef={analyserRef}
+            ttsAnalyserRef={ttsAnalyserRef}
+          />
+        )}
+
+        {/* Push-to-talk */}
+        <Button
+          type="button"
+          onPointerDown={(event) => {
+            event.preventDefault();
+            if (!recordingRef.current) {
               try {
-                event.currentTarget.releasePointerCapture(event.pointerId);
+                event.currentTarget.setPointerCapture(event.pointerId);
               } catch {
                 // ignore pointer capture failures
               }
-            }}
-            onPointerCancel={() => stopRecording()}
-            onLostPointerCapture={() => stopRecording()}
-            variant="outline"
-            size="md"
-            className={`w-full justify-center rounded-2xl border px-4 py-6 text-lg font-semibold transition ${recordingButtonClass}`}
-            disabled={!connected || !isVoiceModeEnabled}
+              startRecording().catch(() => undefined);
+            }
+          }}
+          onPointerUp={(event) => {
+            event.preventDefault();
+            stopRecording();
+            try {
+              event.currentTarget.releasePointerCapture(event.pointerId);
+            } catch {
+              // ignore pointer capture failures
+            }
+          }}
+          onPointerCancel={() => stopRecording()}
+          onLostPointerCapture={() => stopRecording()}
+          variant="outline"
+          size="md"
+          className={`w-full justify-center rounded-2xl border px-4 py-6 text-lg font-semibold transition ${recordingButtonClass}`}
+          disabled={!connected || !isVoiceModeEnabled}
+        >
+          🎙 {recordingButtonLabel}
+        </Button>
+
+        {/* Controls row */}
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            size="xs"
+            variant={isVoiceModeEnabled ? "primary" : "outline"}
+            onClick={() =>
+              setIsVoiceModeEnabled((current) => {
+                const next = !current;
+                setStatusMessage(next ? t("voice.controls.voiceChat") : t("voice.controls.textChat"));
+                return next;
+              })
+            }
+            disabled={!audioEnabled}
           >
-            🎙 {recordingButtonLabel}
+            {isVoiceModeEnabled ? t("voice.controls.voice") : t("voice.controls.text")}
           </Button>
-          <div className="grid gap-2 sm:grid-cols-3">
-            <div className="rounded-2xl box-muted p-3 text-xs text-zinc-300">
-              <p className="text-caption">{t("voice.controls.voiceChat")}</p>
-              <p className="text-white">{voiceChatModeLabel}</p>
+          <Button
+            type="button"
+            size="xs"
+            variant="outline"
+            onClick={() => setTtsMuted((current) => !current)}
+            disabled={!audioEnabled}
+          >
+            {ttsMuted ? t("voice.controls.ttsMuted") : t("voice.controls.ttsOn")}
+          </Button>
+          <Button
+            type="button"
+            size="xs"
+            variant="outline"
+            onClick={() => replayLastResponse().catch(() => undefined)}
+            disabled={!audioEnabled || !lastAudioResponseRef.current}
+          >
+            {t("voice.controls.replay")}
+          </Button>
+          <Button
+            type="button"
+            size="xs"
+            variant="outline"
+            onClick={() => {
+              refreshAudioStatus().catch(() => undefined);
+              refreshTtsModelOptions().catch(() => undefined);
+            }}
+          >
+            {t("voice.controls.refresh")}
+          </Button>
+        </div>
+
+        {/* TTS voice selector */}
+        <div className="rounded-2xl box-muted p-3 text-xs text-zinc-300">
+          <p className="text-caption">{t("voice.controls.ttsVoice")}</p>
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            <div className="min-w-[260px] flex-1">
+              <Select
+                value={selectedTtsModelPath}
+                onValueChange={(value) => {
+                  setSelectedTtsModelPath(value);
+                  applyTtsModel(value).catch(() => undefined);
+                }}
+                disabled={!audioEnabled || ttsModelChanging || ttsModelOptions.length === 0}
+              >
+                <SelectTrigger className="h-8 border-white/10 bg-white/5 text-xs text-zinc-100">
+                  <SelectValue placeholder={t("voice.controls.ttsVoiceSelect")} />
+                </SelectTrigger>
+                <SelectContent className="border-white/10 bg-zinc-950 text-zinc-100">
+                  {ttsModelOptions.map((option) => (
+                    <SelectItem key={option.path} value={option.path}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
-            <div className="rounded-2xl box-muted p-3 text-xs text-zinc-300">
-              <p className="text-caption">{t("voice.controls.playback")}</p>
-              <p className="text-white">{playbackStateLabel}</p>
-            </div>
-            <div className="rounded-2xl box-muted p-3 text-xs text-zinc-300">
-              <p className="text-caption">{t("voice.controls.audioWs")}</p>
-              <p className="text-white">{audioWsStateLabel}</p>
-            </div>
-            <div className="rounded-2xl box-muted p-3 text-xs text-zinc-300 sm:col-span-3">
-              <p className="text-caption">{t("voice.modes.title")}</p>
-              <p className="text-white">{activeVoiceModeMeta.title}</p>
-              <p className="text-[11px] text-zinc-400">{activeVoiceModeMeta.description}</p>
-            </div>
-          </div>
-          <RuntimeSnapshotPanel
-            t={t}
-            runtimeSnapshot={runtimeSnapshot}
-            runtimeSnapshotSummary={runtimeSnapshotSummary}
-          />
-          <p className="text-hint">{statusMessage ?? t("voice.status.channelReady")}</p>
-          <div className="rounded-2xl box-muted p-3 text-xs text-zinc-300">
-            <div className="grid grid-cols-2 gap-2">
-              <div>
-                <p className="text-caption">{t("voice.controls.signal")}</p>
-                <p className="text-white">{lastAudioSignal}</p>
-              </div>
-              <div>
-                <p className="text-caption">{t("voice.controls.chunks")}</p>
-              <p className="text-white">{audioChunkCount}</p>
-              </div>
-            </div>
+            <span className="text-[11px] text-zinc-400">
+              {ttsModelChanging ? t("voice.controls.ttsVoiceChanging") : t("voice.controls.ttsVoiceAuto")}
+            </span>
           </div>
         </div>
-        <VoiceCommandCenterStatusSidebar
-          t={t}
-          audioStatus={audioStatus}
-          latestVoiceSession={latestVoiceSession}
-          latestRecordingSummary={latestRecordingSummary}
-          qualitySummary={qualitySummary}
-          timingSummary={timingSummary}
-          runtimeSummary={runtimeSummary}
-          transcription={transcription}
-          response={response}
-          orbState={orbState}
-          reducedMotion={reducedMotion}
-          isVoiceModeEnabled={isVoiceModeEnabled}
-          audioEnabled={audioEnabled}
-          effectsConfig={effectsConfig}
-          micAnalyserRef={analyserRef}
-          ttsAnalyserRef={ttsAnalyserRef}
-        />
+
+        {/* Status strip */}
+        <div className="grid gap-2 sm:grid-cols-3 text-xs">
+          <div className="rounded-2xl box-muted p-3 text-zinc-300">
+            <p className="text-caption">{t("voice.controls.voiceChat")}</p>
+            <p className="text-white">{voiceChatModeLabel}</p>
+          </div>
+          <div className="rounded-2xl box-muted p-3 text-zinc-300">
+            <p className="text-caption">{t("voice.controls.playback")}</p>
+            <p className="text-white">{playbackStateLabel}</p>
+          </div>
+          <div className="rounded-2xl box-muted p-3 text-zinc-300">
+            <p className="text-caption">{t("voice.controls.audioWs")}</p>
+            <p className="text-white">{audioWsStateLabel}</p>
+          </div>
+        </div>
+
+        <p className="text-hint text-xs">{statusMessage ?? t("voice.status.channelReady")}</p>
       </div>
     </Panel>
+    <DevDiagnosticsDrawer
+      isOpen={devDrawerOpen}
+      onClose={() => setDevDrawerOpen(false)}
+      audioStatus={audioStatus}
+      lastAudioSignal={lastAudioSignal}
+      audioChunkCount={audioChunkCount}
+      statusMessage={statusMessage}
+    />
+    </>
   );
 }

--- a/web-next/components/voice/voice-orb-3d.tsx
+++ b/web-next/components/voice/voice-orb-3d.tsx
@@ -140,129 +140,143 @@ type OrbMetricsBars3DProps = Readonly<{
   metricsRef: RefObject<OrbMetrics>;
 }>;
 
-function OrbMetricsBars3D({ metricsRef }: OrbMetricsBars3DProps) {
-  const groupRefs = useRef<Array<THREE.Group | null>>([null, null, null, null]);
-  const coreRefs = useRef<Array<THREE.Mesh | null>>([null, null, null, null]);
-  const glowRefs = useRef<Array<THREE.Mesh | null>>([null, null, null, null]);
-  const coreMaterialRefs = useRef<Array<THREE.MeshStandardMaterial | null>>([null, null, null, null]);
-  const glowMaterialRefs = useRef<Array<THREE.MeshStandardMaterial | null>>([null, null, null, null]);
-  const barGeo = useMemo(() => makeBarGeometry(), []);
-  const glowGeo = useMemo(() => makeGlowGeometry(), []);
+type OrbMetricBarRefs = Readonly<{
+  groupRef: RefObject<THREE.Group | null>;
+  coreRef: RefObject<THREE.Mesh | null>;
+  glowRef: RefObject<THREE.Mesh | null>;
+  coreMaterialRef: RefObject<THREE.MeshStandardMaterial | null>;
+  glowMaterialRef: RefObject<THREE.MeshStandardMaterial | null>;
+}>;
+
+function syncBarMaterial(
+  mat: THREE.MeshStandardMaterial | null,
+  color: string,
+  emissiveIntensity: number,
+  opacity: number,
+) {
+  if (!mat) return;
+  mat.color.set(color);
+  mat.emissive.set(color);
+  mat.emissiveIntensity = emissiveIntensity;
+  mat.transparent = true;
+  mat.opacity = opacity;
+  mat.depthWrite = false;
+}
+
+function syncOrbMetricBarFrame(
+  index: number,
+  metricsRef: RefObject<OrbMetrics>,
+  refs: OrbMetricBarRefs,
+) {
+  const metrics = metricsRef.current;
+  if (!metrics) return;
+  const rawValue = [metrics.cpu, metrics.gpu, metrics.net, metrics.ram][index];
+  const pct = Number.isFinite(rawValue) ? rawValue : 0;
+  const isGpuAbsent = index === 1 && !Number.isFinite(rawValue);
+  const target = MIN_BAR_SCALE + (pct / 100) * (MAX_BAR_RADIUS - MIN_BAR_SCALE);
+
+  const core = refs.coreRef.current;
+  if (core) {
+    core.scale.y += (target - core.scale.y) * BAR_LERP_ALPHA;
+    syncBarMaterial(
+      refs.coreMaterialRef.current,
+      BAR_DEFS[index]?.color ?? "#ffffff",
+      isGpuAbsent ? 0.04 : 0.35 + 0.65 * (pct / 100),
+      isGpuAbsent ? 0.2 : 0.92,
+    );
+  }
+
+  const glow = refs.glowRef.current;
+  if (glow) {
+    glow.scale.y += (target - glow.scale.y) * BAR_LERP_ALPHA;
+    syncBarMaterial(
+      refs.glowMaterialRef.current,
+      BAR_DEFS[index]?.color ?? "#ffffff",
+      isGpuAbsent ? 0.02 : 0.15 + 0.35 * (pct / 100),
+      isGpuAbsent ? 0.06 : 0.18 + 0.22 * (pct / 100),
+    );
+  }
+}
+
+function OrbMetricBar3D({
+  definition,
+  index,
+  metricsRef,
+  barGeo,
+  glowGeo,
+}: Readonly<{
+  definition: (typeof BAR_DEFS)[number];
+  index: number;
+  metricsRef: RefObject<OrbMetrics>;
+  barGeo: THREE.BoxGeometry;
+  glowGeo: THREE.BoxGeometry;
+}>) {
+  const groupRef = useRef<THREE.Group>(null);
+  const coreRef = useRef<THREE.Mesh>(null);
+  const glowRef = useRef<THREE.Mesh>(null);
+  const coreMaterialRef = useRef<THREE.MeshStandardMaterial>(null);
+  const glowMaterialRef = useRef<THREE.MeshStandardMaterial>(null);
+  const refs = { groupRef, coreRef, glowRef, coreMaterialRef, glowMaterialRef } as const;
 
   useEffect(() => {
-    coreRefs.current.forEach((mesh) => {
-      if (mesh) {
-        mesh.geometry = barGeo;
-      }
-    });
-    glowRefs.current.forEach((mesh) => {
-      if (mesh) {
-        mesh.geometry = glowGeo;
-      }
-    });
-    groupRefs.current.forEach((group, index) => {
-      const def = BAR_DEFS[index];
-      if (group && def) {
-        group.rotation.set(def.rotation[0], def.rotation[1], def.rotation[2]);
-      }
-    });
-  }, [barGeo, glowGeo]);
+    if (groupRef.current) {
+      groupRef.current.rotation.set(definition.rotation[0], definition.rotation[1], definition.rotation[2]);
+    }
+    if (coreRef.current) {
+      coreRef.current.geometry = barGeo;
+    }
+    if (glowRef.current) {
+      glowRef.current.geometry = glowGeo;
+    }
+  }, [barGeo, definition.rotation, glowGeo]);
 
   useFrame(() => {
-    const m = metricsRef.current;
-    if (!m) return;
-    const values: number[] = [m.cpu, m.gpu, m.net, m.ram];
-
-    values.forEach((pct, i) => {
-      const safePct = Number.isFinite(pct) ? pct : 0;
-      const isGpuAbsent = i === 1 && !Number.isFinite(pct);
-      const target = MIN_BAR_SCALE + (safePct / 100) * (MAX_BAR_RADIUS - MIN_BAR_SCALE);
-
-      const core = coreRefs.current[i];
-      if (core) {
-        core.scale.y += (target - core.scale.y) * BAR_LERP_ALPHA;
-        const mat = coreMaterialRefs.current[i];
-        if (mat) {
-          mat.color.set(BAR_DEFS[i]?.color ?? mat.color);
-          mat.emissive.set(BAR_DEFS[i]?.color ?? mat.emissive);
-          mat.emissiveIntensity = isGpuAbsent ? 0.04 : 0.35 + 0.65 * (safePct / 100);
-          mat.opacity = isGpuAbsent ? 0.2 : 0.92;
-          mat.transparent = true;
-          mat.depthWrite = false;
-        }
-      }
-
-      const glow = glowRefs.current[i];
-      if (glow) {
-        glow.scale.y += (target - glow.scale.y) * BAR_LERP_ALPHA;
-        const mat = glowMaterialRefs.current[i];
-        if (mat) {
-          mat.color.set(BAR_DEFS[i]?.color ?? mat.color);
-          mat.emissive.set(BAR_DEFS[i]?.color ?? mat.emissive);
-          mat.emissiveIntensity = isGpuAbsent ? 0.02 : 0.15 + 0.35 * (safePct / 100);
-          mat.opacity = isGpuAbsent ? 0.06 : 0.18 + 0.22 * (safePct / 100);
-          mat.transparent = true;
-          mat.depthWrite = false;
-        }
-      }
-    });
+    syncOrbMetricBarFrame(index, metricsRef, refs);
   });
 
   return (
+    <group ref={groupRef}>
+      <mesh ref={glowRef} scale={[1, MIN_BAR_SCALE, 1]}>
+        <meshStandardMaterial
+          ref={glowMaterialRef}
+          color={definition.color}
+          emissive={definition.color}
+          emissiveIntensity={0.15}
+          transparent
+          opacity={0.12}
+          depthWrite={false}
+        />
+      </mesh>
+      <mesh ref={coreRef} scale={[1, MIN_BAR_SCALE, 1]}>
+        <meshStandardMaterial
+          ref={coreMaterialRef}
+          color={definition.color}
+          emissive={definition.color}
+          emissiveIntensity={0.35}
+          transparent
+          opacity={0.9}
+          depthWrite={false}
+        />
+      </mesh>
+    </group>
+  );
+}
+
+function OrbMetricsBars3D({ metricsRef }: OrbMetricsBars3DProps) {
+  const barGeo = useMemo(() => makeBarGeometry(), []);
+  const glowGeo = useMemo(() => makeGlowGeometry(), []);
+
+  return (
     <>
-      {BAR_DEFS.map(({ key, color, rotation }, i) => (
-        <group
-          key={key}
-          ref={(group) => {
-            groupRefs.current[i] = group;
-            if (group) {
-              group.rotation.set(rotation[0], rotation[1], rotation[2]);
-            }
-          }}
-        >
-          {/* Glow halo — wide, semi-transparent */}
-          <mesh
-            ref={(el) => {
-              glowRefs.current[i] = el;
-            }}
-            scale={[1, MIN_BAR_SCALE, 1]}
-          >
-            <meshStandardMaterial
-              ref={(mat) => {
-                glowMaterialRefs.current[i] = mat;
-                if (mat) {
-                  mat.color.set(color);
-                  mat.emissive.set(color);
-                  mat.emissiveIntensity = 0.15;
-                  mat.transparent = true;
-                  mat.opacity = 0.12;
-                  mat.depthWrite = false;
-                }
-              }}
-            />
-          </mesh>
-          {/* Core beam */}
-          <mesh
-            ref={(el) => {
-              coreRefs.current[i] = el;
-            }}
-            scale={[1, MIN_BAR_SCALE, 1]}
-          >
-            <meshStandardMaterial
-              ref={(mat) => {
-                coreMaterialRefs.current[i] = mat;
-                if (mat) {
-                  mat.color.set(color);
-                  mat.emissive.set(color);
-                  mat.emissiveIntensity = 0.35;
-                  mat.transparent = true;
-                  mat.opacity = 0.9;
-                  mat.depthWrite = false;
-                }
-              }}
-            />
-          </mesh>
-        </group>
+      {BAR_DEFS.map((definition, index) => (
+        <OrbMetricBar3D
+          key={definition.key}
+          definition={definition}
+          index={index}
+          metricsRef={metricsRef}
+          barGeo={barGeo}
+          glowGeo={glowGeo}
+        />
       ))}
     </>
   );
@@ -395,18 +409,31 @@ function updateVolumetricLights(
   }
 }
 
-function updateShaderMaterial(
-  mat: THREE.ShaderMaterial | null,
-  state: VoiceOrbState,
-  colors: StateColors,
-  audioLevel: number,
-  elapsed: number,
-  delta: number,
-  effectsConfig: OrbEffectsConfig,
-  activeAnalyser: AnalyserNode | null,
-  rawFFT: MutableRefObject<Uint8Array>,
-  burstProgress: MutableRefObject<number>,
-) {
+type ShaderUpdateContext = Readonly<{
+  mat: THREE.ShaderMaterial | null;
+  state: VoiceOrbState;
+  colors: StateColors;
+  audioLevel: number;
+  elapsed: number;
+  delta: number;
+  effectsConfig: OrbEffectsConfig;
+  activeAnalyser: AnalyserNode | null;
+  rawFFT: MutableRefObject<Uint8Array>;
+  burstProgress: MutableRefObject<number>;
+}>;
+
+function updateShaderMaterial({
+  mat,
+  state,
+  colors,
+  audioLevel,
+  elapsed,
+  delta,
+  effectsConfig,
+  activeAnalyser,
+  rawFFT,
+  burstProgress,
+}: ShaderUpdateContext) {
   if (!mat) return;
   const uniforms = mat.uniforms as Record<string, { value: unknown }>;
   const setUniform = (name: string, value: unknown) => {
@@ -458,15 +485,13 @@ function updateShaderMaterial(
   GLOBAL_BLOOM_TARGET.current = getBloomTarget(state, audioLevel, elapsed, burstProgress.current);
 }
 
-function OrbParticles3D({
-  active,
-  color,
-  audioLevel,
-}: {
+type OrbParticles3DProps = Readonly<{
   active: boolean;
   color: THREE.Color;
   audioLevel: number;
-}) {
+}>;
+
+function OrbParticles3D({ active, color, audioLevel }: OrbParticles3DProps) {
   const pointsRef = useRef<THREE.Points>(null);
   const geometryRef = useRef<THREE.BufferGeometry | null>(null);
   const materialRef = useRef<THREE.PointsMaterial | null>(null);
@@ -527,7 +552,7 @@ function OrbParticles3D({
 
 // ─── Main orb scene (inside Canvas) ─────────────────────────────────────────
 
-type OrbSceneProps = {
+type OrbSceneProps = Readonly<{
   state: VoiceOrbState;
   effectsConfig: OrbEffectsConfig;
   micAnalyserRef?: RefObject<AnalyserNode | null>;
@@ -536,7 +561,13 @@ type OrbSceneProps = {
   outputLevel: number;
   reducedMotion: boolean;
   metricsRef?: RefObject<OrbMetrics>;
-};
+}>;
+
+function getOrbAudioLevel(state: VoiceOrbState, inputLevel: number, outputLevel: number): number {
+  if (state === "recording") return inputLevel;
+  if (state === "tts") return outputLevel;
+  return 0;
+}
 
 function OrbScene({
   state,
@@ -558,7 +589,7 @@ function OrbScene({
   const burstProgress = useRef(0);
   const rawFFT = useRef(new Uint8Array(128));
 
-  const audioLevel = state === "recording" ? inputLevel : state === "tts" ? outputLevel : 0;
+  const audioLevel = getOrbAudioLevel(state, inputLevel, outputLevel);
   const isActive = state === "recording" || state === "tts";
   const colors = STATE_COLORS[state];
   const activeAnalyser = getActiveAnalyser(state, micAnalyserRef, ttsAnalyserRef);
@@ -626,16 +657,18 @@ function OrbScene({
   useFrame((frameState, delta) => {
     const t = frameState.clock.elapsedTime;
     updateShaderMaterial(
-      shaderMaterial,
-      state,
-      colors,
-      audioLevel,
-      t,
-      delta,
-      effectsConfig,
-      activeAnalyser,
-      rawFFT,
-      burstProgress,
+      {
+        mat: shaderMaterial,
+        state,
+        colors,
+        audioLevel,
+        elapsed: t,
+        delta,
+        effectsConfig,
+        activeAnalyser,
+        rawFFT,
+        burstProgress,
+      },
     );
     updateVolumetricLights(
       light1Ref.current,

--- a/web-next/components/voice/voice-orb-3d.tsx
+++ b/web-next/components/voice/voice-orb-3d.tsx
@@ -10,6 +10,7 @@ import * as THREE from "three";
 import type { VoiceOrbState } from "@/components/voice/voice-orb";
 import type { OrbEffectsConfig } from "@/components/voice/use-orb-effects-config";
 import { useAudioLevel } from "@/components/voice/use-audio-level";
+import type { OrbMetrics } from "@/components/voice/use-orb-metrics";
 
 // ─── State color palette (matches CSS orb palette) ──────────────────────────
 
@@ -104,9 +105,166 @@ const fragmentShader = /* glsl */ `
   }
 `;
 
+// ─── Metrics bars 3D ────────────────────────────────────────────────────────
+
+const MAX_BAR_RADIUS = 2.2;  // extends visibly beyond orb sphere (radius ~0.62)
+const MIN_BAR_SCALE = 0.08;
+const BAR_LERP_ALPHA = 0.07;
+
+const BAR_DEFS: Array<{
+  key: keyof OrbMetrics;
+  color: string;
+  rotation: [number, number, number];
+}> = [
+  { key: "cpu", color: "#f97316", rotation: [0, 0, 0] },              // UP   (+Y)
+  { key: "gpu", color: "#a855f7", rotation: [0, 0, -Math.PI / 2] },   // RIGHT (+X)
+  { key: "net", color: "#4ade80", rotation: [0, 0, Math.PI] },        // DOWN  (-Y)
+  { key: "ram", color: "#22d3ee", rotation: [0, 0, Math.PI / 2] },    // LEFT  (-X)
+];
+
+// BoxGeometry with translate(0, 0.5, 0): bottom at Y=0 → scales grow outward.
+function makeBarGeometry() {
+  const geo = new THREE.BoxGeometry(0.055, 1.0, 0.055);
+  geo.translate(0, 0.5, 0);
+  return geo;
+}
+
+// Wider secondary "glow" geometry
+function makeGlowGeometry() {
+  const geo = new THREE.BoxGeometry(0.18, 1.0, 0.055);
+  geo.translate(0, 0.5, 0);
+  return geo;
+}
+
+type OrbMetricsBars3DProps = {
+  metricsRef: RefObject<OrbMetrics>;
+};
+
+function OrbMetricsBars3D({ metricsRef }: OrbMetricsBars3DProps) {
+  const coreRefs = useRef<Array<THREE.Mesh | null>>([null, null, null, null]);
+  const glowRefs = useRef<Array<THREE.Mesh | null>>([null, null, null, null]);
+  const barGeo = useMemo(() => makeBarGeometry(), []);
+  const glowGeo = useMemo(() => makeGlowGeometry(), []);
+
+  useFrame(() => {
+    const m = metricsRef.current;
+    const values: number[] = [m.cpu, m.gpu, m.net, m.ram];
+
+    values.forEach((pct, i) => {
+      const isGpuAbsent = i === 1 && pct === 0;
+      const target = MIN_BAR_SCALE + (pct / 100) * (MAX_BAR_RADIUS - MIN_BAR_SCALE);
+
+      const core = coreRefs.current[i];
+      if (core) {
+        core.scale.y += (target - core.scale.y) * BAR_LERP_ALPHA;
+        const mat = core.material as THREE.MeshStandardMaterial;
+        mat.emissiveIntensity = isGpuAbsent ? 0.04 : 0.35 + 0.65 * (pct / 100);
+        mat.opacity = isGpuAbsent ? 0.2 : 0.92;
+      }
+
+      const glow = glowRefs.current[i];
+      if (glow) {
+        glow.scale.y += (target - glow.scale.y) * BAR_LERP_ALPHA;
+        const mat = glow.material as THREE.MeshStandardMaterial;
+        mat.emissiveIntensity = isGpuAbsent ? 0.02 : 0.15 + 0.35 * (pct / 100);
+        mat.opacity = isGpuAbsent ? 0.06 : 0.18 + 0.22 * (pct / 100);
+      }
+    });
+  });
+
+  return (
+    <>
+      {BAR_DEFS.map(({ key, color, rotation }, i) => (
+        <group key={key} rotation={rotation}>
+          {/* Glow halo — wide, semi-transparent */}
+          <mesh
+            ref={(el) => { glowRefs.current[i] = el; }}
+            geometry={glowGeo}
+            scale={[1, MIN_BAR_SCALE, 1]}
+          >
+            <meshStandardMaterial
+              color={color}
+              emissive={color}
+              emissiveIntensity={0.15}
+              transparent
+              opacity={0.12}
+              depthWrite={false}
+            />
+          </mesh>
+          {/* Core beam */}
+          <mesh
+            ref={(el) => { coreRefs.current[i] = el; }}
+            geometry={barGeo}
+            scale={[1, MIN_BAR_SCALE, 1]}
+          >
+            <meshStandardMaterial
+              color={color}
+              emissive={color}
+              emissiveIntensity={0.35}
+              transparent
+              opacity={0.9}
+              depthWrite={false}
+            />
+          </mesh>
+        </group>
+      ))}
+    </>
+  );
+}
+
 // ─── Particles 3D ───────────────────────────────────────────────────────────
 
 const PARTICLE_COUNT = 40;
+
+function pseudoRandom(seed: number): number {
+  const x = Math.sin(seed) * 43758.5453123;
+  return x - Math.floor(x);
+}
+
+function sampleParticle(seed: number) {
+  const theta = pseudoRandom(seed * 1.17 + 1.0) * Math.PI * 2;
+  const phi = pseudoRandom(seed * 1.91 + 2.0) * (Math.PI / 2);
+  const r = 0.65 + pseudoRandom(seed * 2.53 + 3.0) * 0.15;
+  return {
+    theta,
+    phi,
+    r,
+    vy: 0.15 + pseudoRandom(seed * 3.11 + 4.0) * 0.25,
+    life: pseudoRandom(seed * 4.07 + 5.0),
+  };
+}
+
+type ParticleState = {
+  positions: Float32Array;
+  velocities: Float32Array;
+  lifetimes: Float32Array;
+  resetCounts: Uint32Array;
+};
+
+function createParticleState(): ParticleState {
+  const positions = new Float32Array(PARTICLE_COUNT * 3);
+  const velocities = new Float32Array(PARTICLE_COUNT * 3);
+  const lifetimes = new Float32Array(PARTICLE_COUNT);
+  const resetCounts = new Uint32Array(PARTICLE_COUNT);
+  for (let i = 0; i < PARTICLE_COUNT; i++) {
+    const sample = sampleParticle(i + 1);
+    positions[i * 3] = sample.r * Math.sin(sample.phi) * Math.cos(sample.theta);
+    positions[i * 3 + 1] = sample.r * Math.cos(sample.phi);
+    positions[i * 3 + 2] = sample.r * Math.sin(sample.phi) * Math.sin(sample.theta);
+    velocities[i * 3] = (pseudoRandom(i * 5.13 + 6.0) - 0.5) * 0.02;
+    velocities[i * 3 + 1] = sample.vy;
+    velocities[i * 3 + 2] = (pseudoRandom(i * 7.41 + 7.0) - 0.5) * 0.02;
+    lifetimes[i] = sample.life;
+  }
+  return { positions, velocities, lifetimes, resetCounts };
+}
+
+const GLOBAL_PARTICLE_STATE = createParticleState();
+const GLOBAL_FFT_DATA_ARRAY = new Uint8Array(128 * 4);
+const GLOBAL_FFT_TEXTURE = new THREE.DataTexture(GLOBAL_FFT_DATA_ARRAY, 128, 1, THREE.RGBAFormat);
+GLOBAL_FFT_TEXTURE.needsUpdate = true;
+const GLOBAL_BLOOM_TARGET = { current: 0.3 };
+const GLOBAL_CHROMATIC_OFFSET = new THREE.Vector2(0, 0);
 
 function OrbParticles3D({
   active,
@@ -118,34 +276,12 @@ function OrbParticles3D({
   audioLevel: number;
 }) {
   const pointsRef = useRef<THREE.Points>(null);
-  const velocitiesRef = useRef<Float32Array>(new Float32Array(PARTICLE_COUNT * 3));
-  const lifetimesRef = useRef<Float32Array>(new Float32Array(PARTICLE_COUNT));
-
-  const positions = useMemo(() => {
-    const arr = new Float32Array(PARTICLE_COUNT * 3);
-    const v = velocitiesRef.current;
-    const l = lifetimesRef.current;
-    for (let i = 0; i < PARTICLE_COUNT; i++) {
-      const theta = Math.random() * Math.PI * 2;
-      const phi = (Math.random() * Math.PI) / 2; // upper hemisphere
-      const r = 0.65 + Math.random() * 0.15;
-      arr[i * 3]     = r * Math.sin(phi) * Math.cos(theta);
-      arr[i * 3 + 1] = r * Math.cos(phi);
-      arr[i * 3 + 2] = r * Math.sin(phi) * Math.sin(theta);
-      v[i * 3]     = (Math.random() - 0.5) * 0.02;
-      v[i * 3 + 1] = 0.15 + Math.random() * 0.25;
-      v[i * 3 + 2] = (Math.random() - 0.5) * 0.02;
-      l[i] = Math.random();
-    }
-    return arr;
-  }, []);
-
   useFrame((_, delta) => {
     if (!active || !pointsRef.current) return;
     const pos = pointsRef.current.geometry.attributes.position?.array as Float32Array | undefined;
     if (!pos) return;
-    const v = velocitiesRef.current;
-    const l = lifetimesRef.current;
+    const v = GLOBAL_PARTICLE_STATE.velocities;
+    const l = GLOBAL_PARTICLE_STATE.lifetimes;
     const speed = 0.4 + audioLevel * 0.6;
     for (let i = 0; i < PARTICLE_COUNT; i++) {
       pos[i * 3]     += v[i * 3] * delta;
@@ -154,14 +290,14 @@ function OrbParticles3D({
       l[i] -= delta * 0.35;
       if (l[i] <= 0) {
         // Reset particle on sphere surface (upper hemisphere)
-        const theta = Math.random() * Math.PI * 2;
-        const phi = (Math.random() * Math.PI) / 2;
-        const r = 0.65 + Math.random() * 0.1;
-        pos[i * 3]     = r * Math.sin(phi) * Math.cos(theta);
-        pos[i * 3 + 1] = r * Math.cos(phi);
-        pos[i * 3 + 2] = r * Math.sin(phi) * Math.sin(theta);
-        v[i * 3 + 1] = 0.15 + Math.random() * 0.25;
-        l[i] = 0.5 + Math.random() * 0.5;
+        const resetIndex = (GLOBAL_PARTICLE_STATE.resetCounts[i] ?? 0) + 1;
+        GLOBAL_PARTICLE_STATE.resetCounts[i] = resetIndex;
+        const sample = sampleParticle(i + resetIndex * 17);
+        pos[i * 3] = sample.r * Math.sin(sample.phi) * Math.cos(sample.theta);
+        pos[i * 3 + 1] = sample.r * Math.cos(sample.phi);
+        pos[i * 3 + 2] = sample.r * Math.sin(sample.phi) * Math.sin(sample.theta);
+        v[i * 3 + 1] = sample.vy;
+        l[i] = 0.5 + sample.life * 0.5;
       }
     }
     (pointsRef.current.geometry.attributes.position as THREE.BufferAttribute).needsUpdate = true;
@@ -174,7 +310,7 @@ function OrbParticles3D({
       <bufferGeometry>
         <bufferAttribute
           attach="attributes-position"
-          args={[positions, 3]}
+          args={[GLOBAL_PARTICLE_STATE.positions, 3]}
         />
       </bufferGeometry>
       <pointsMaterial
@@ -199,6 +335,7 @@ type OrbSceneProps = {
   inputLevel: number;
   outputLevel: number;
   reducedMotion: boolean;
+  metricsRef?: RefObject<OrbMetrics>;
 };
 
 function OrbScene({
@@ -209,6 +346,7 @@ function OrbScene({
   inputLevel,
   outputLevel,
   reducedMotion,
+  metricsRef,
 }: OrbSceneProps) {
   const meshRef = useRef<THREE.Mesh>(null);
   const matRef = useRef<THREE.ShaderMaterial>(null);
@@ -216,27 +354,15 @@ function OrbScene({
   const light2Ref = useRef<THREE.PointLight>(null);
   const light1Angle = useRef(0);
   const light2Angle = useRef(Math.PI);
-  const chromaticOffsetRef = useRef(new THREE.Vector2(0, 0));
   const prevState = useRef(state);
   const burstProgress = useRef(0);
   const { camera } = useThree();
-
-  // DataTexture for FFT data (128 buckets → 128x1 RGBA texture)
-  const fftDataArray = useRef(new Uint8Array(128 * 4));
-  const fftTexture = useMemo(() => {
-    const tex = new THREE.DataTexture(fftDataArray.current, 128, 1, THREE.RGBAFormat);
-    tex.needsUpdate = true;
-    return tex;
-  }, []);
 
   const rawFFT = useRef(new Uint8Array(128));
 
   const audioLevel = state === "recording" ? inputLevel : state === "tts" ? outputLevel : 0;
   const isActive = state === "recording" || state === "tts";
   const colors = STATE_COLORS[state];
-
-  // Bloom intensity state
-  const bloomTarget = useRef(0.3);
 
   // Chromatic aberration spike on state change
   useEffect(() => {
@@ -248,7 +374,7 @@ function OrbScene({
     const tick = () => {
       const t = Math.min((performance.now() - start) / 280, 1);
       const ease = Math.sin(t * Math.PI);
-      chromaticOffsetRef.current.set(ease * 0.007, ease * 0.007);
+      GLOBAL_CHROMATIC_OFFSET.set(ease * 0.007, ease * 0.007);
       if (t < 1) requestAnimationFrame(tick);
     };
     requestAnimationFrame(tick);
@@ -274,7 +400,7 @@ function OrbScene({
 
     if (activeAnalyser) {
       activeAnalyser.getByteFrequencyData(rawFFT.current);
-      const fftArr = fftDataArray.current;
+      const fftArr = GLOBAL_FFT_DATA_ARRAY;
       for (let i = 0; i < 128; i++) {
         const val = rawFFT.current[i] ?? 0;
         fftArr[i * 4]     = val;
@@ -282,11 +408,11 @@ function OrbScene({
         fftArr[i * 4 + 2] = val;
         fftArr[i * 4 + 3] = 255;
       }
-      fftTexture.needsUpdate = true;
+      GLOBAL_FFT_TEXTURE.needsUpdate = true;
     }
 
     // Update material uniforms
-    mat.uniforms.fftTexture = { value: fftTexture };
+    mat.uniforms.fftTexture = { value: GLOBAL_FFT_TEXTURE };
     mat.uniforms.audioLevel = { value: audioLevel };
     mat.uniforms.time = { value: t };
     mat.uniforms.blobEnabled = { value: effectsConfig.blob && isActive ? 1 : 0 };
@@ -317,7 +443,7 @@ function OrbScene({
     mat.uniforms.emissionIntensity = { value: prevEmission + (emissionTarget - prevEmission) * delta * 5 };
 
     // Bloom intensity
-    bloomTarget.current =
+    GLOBAL_BLOOM_TARGET.current =
       state === "recording" ? 0.4 + audioLevel * 0.8 :
       state === "tts" ? 0.5 + audioLevel * 1.2 :
       state === "thinking" ? 0.4 + Math.sin(t * 2) * 0.15 :
@@ -350,8 +476,8 @@ function OrbScene({
     void camera;
   });
 
-  const shaderUniforms = useMemo(() => ({
-    fftTexture: { value: fftTexture },
+  const shaderUniforms = {
+    fftTexture: { value: GLOBAL_FFT_TEXTURE },
     audioLevel: { value: 0 },
     time: { value: 0 },
     blobEnabled: { value: 1 },
@@ -360,7 +486,7 @@ function OrbScene({
     baseColor: { value: colors.base.clone() },
     emissionColor: { value: colors.emission.clone() },
     emissionIntensity: { value: 0.2 },
-  }), []); // eslint-disable-line react-hooks/exhaustive-deps
+  };
 
   return (
     <>
@@ -391,17 +517,21 @@ function OrbScene({
         <Environment preset="city" background={false} />
       ) : null}
 
+      {effectsConfig.orbMetricsBars && metricsRef && !reducedMotion ? (
+        <OrbMetricsBars3D metricsRef={metricsRef} />
+      ) : null}
+
       {effectsConfig.bloom && !reducedMotion ? (
         <EffectComposer>
           <Bloom
-            intensity={bloomTarget.current}
+            intensity={GLOBAL_BLOOM_TARGET.current}
             luminanceThreshold={0.22}
             luminanceSmoothing={0.9}
             blendFunction={BlendFunction.ADD}
           />
           <ChromaticAberration
             offset={effectsConfig.chromaticAberration && !reducedMotion
-              ? chromaticOffsetRef.current
+              ? GLOBAL_CHROMATIC_OFFSET
               : new THREE.Vector2(0, 0)}
             radialModulation={false}
             modulationOffset={0}
@@ -422,6 +552,7 @@ type VoiceOrb3DProps = Readonly<{
   ttsAnalyserRef?: RefObject<AnalyserNode | null>;
   disabled?: boolean;
   size?: number;
+  metricsRef?: RefObject<OrbMetrics>;
 }>;
 
 export function VoiceOrb3D({
@@ -432,6 +563,7 @@ export function VoiceOrb3D({
   ttsAnalyserRef,
   disabled = false,
   size = 200,
+  metricsRef,
 }: VoiceOrb3DProps) {
   const fallbackRef = useRef<AnalyserNode | null>(null);
   const effectiveState: VoiceOrbState = disabled ? "offline" : state;
@@ -460,6 +592,7 @@ export function VoiceOrb3D({
           inputLevel={inputLevel}
           outputLevel={outputLevel}
           reducedMotion={reducedMotion}
+          metricsRef={metricsRef}
         />
       </Canvas>
     </div>

--- a/web-next/components/voice/voice-orb-3d.tsx
+++ b/web-next/components/voice/voice-orb-3d.tsx
@@ -118,8 +118,8 @@ const BAR_DEFS: Array<{
 }> = [
   { key: "cpu", color: "#f97316", rotation: [0, 0, 0] },              // UP   (+Y)
   { key: "gpu", color: "#a855f7", rotation: [0, 0, -Math.PI / 2] },   // RIGHT (+X)
-  { key: "net", color: "#4ade80", rotation: [0, 0, Math.PI] },        // DOWN  (-Y)
-  { key: "ram", color: "#22d3ee", rotation: [0, 0, Math.PI / 2] },    // LEFT  (-X)
+  { key: "vram", color: "#22d3ee", rotation: [0, 0, Math.PI / 2] },   // LEFT  (-X)
+  { key: "ram", color: "#4ade80", rotation: [0, 0, Math.PI] },        // DOWN  (-Y)
 ];
 
 // BoxGeometry with translate(0, 0.5, 0): bottom at Y=0 → scales grow outward.
@@ -170,7 +170,7 @@ function syncOrbMetricBarFrame(
 ) {
   const metrics = metricsRef.current;
   if (!metrics) return;
-  const rawValue = [metrics.cpu, metrics.gpu, metrics.net, metrics.ram][index];
+  const rawValue = [metrics.cpu, metrics.gpu, metrics.vram, metrics.ram][index];
   const pct = Number.isFinite(rawValue) ? rawValue : 0;
   const isGpuAbsent = index === 1 && !Number.isFinite(rawValue);
   const target = MIN_BAR_SCALE + (pct / 100) * (MAX_BAR_RADIUS - MIN_BAR_SCALE);

--- a/web-next/components/voice/voice-orb-3d.tsx
+++ b/web-next/components/voice/voice-orb-3d.tsx
@@ -1,0 +1,467 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import type { RefObject } from "react";
+import { Canvas, useFrame, useThree } from "@react-three/fiber";
+import { Environment } from "@react-three/drei";
+import { EffectComposer, Bloom, ChromaticAberration } from "@react-three/postprocessing";
+import { BlendFunction } from "postprocessing";
+import * as THREE from "three";
+import type { VoiceOrbState } from "@/components/voice/voice-orb";
+import type { OrbEffectsConfig } from "@/components/voice/use-orb-effects-config";
+import { useAudioLevel } from "@/components/voice/use-audio-level";
+
+// ─── State color palette (matches CSS orb palette) ──────────────────────────
+
+type StateColors = { base: THREE.Color; emission: THREE.Color };
+
+const STATE_COLORS: Record<VoiceOrbState, StateColors> = {
+  offline:   { base: new THREE.Color("#3f3f46"), emission: new THREE.Color("#3f3f46") },
+  ready:     { base: new THREE.Color("#4f46e5"), emission: new THREE.Color("#6366f1") },
+  recording: { base: new THREE.Color("#059669"), emission: new THREE.Color("#10b981") },
+  stt:       { base: new THREE.Color("#d97706"), emission: new THREE.Color("#f59e0b") },
+  thinking:  { base: new THREE.Color("#6d28d9"), emission: new THREE.Color("#7c3aed") },
+  tts:       { base: new THREE.Color("#0891b2"), emission: new THREE.Color("#06b6d4") },
+  complete:  { base: new THREE.Color("#0f766e"), emission: new THREE.Color("#14b8a6") },
+  error:     { base: new THREE.Color("#be123c"), emission: new THREE.Color("#e11d48") },
+};
+
+// ─── GLSL shaders ───────────────────────────────────────────────────────────
+
+const vertexShader = /* glsl */ `
+  uniform sampler2D fftTexture;
+  uniform float audioLevel;
+  uniform float time;
+  uniform float blobEnabled;
+  uniform float fftEnabled;
+
+  varying vec3 vNormal;
+  varying vec3 vWorldPos;
+
+  void main() {
+    vec3 pos = position;
+
+    // Organic blob morphing via multi-frequency sine waves
+    if (blobEnabled > 0.5) {
+      float w1 = sin(position.y * 4.0 + time * 1.2) * 0.5 + 0.5;
+      float w2 = sin(position.x * 3.0 + time * 0.85) * 0.5 + 0.5;
+      float w3 = cos(position.z * 5.0 + time * 1.55) * 0.5 + 0.5;
+      float blob = w1 * 0.4 + w2 * 0.35 + w3 * 0.25;
+      pos += normal * blob * audioLevel * 0.18;
+    }
+
+    // FFT-driven radial displacement
+    if (fftEnabled > 0.5) {
+      float azimuth = atan(position.y, position.x);
+      float u = (azimuth + 3.14159265) / (2.0 * 3.14159265);
+      float fftVal = texture2D(fftTexture, vec2(u, 0.5)).r;
+      pos += normal * fftVal * audioLevel * 0.22;
+    }
+
+    vNormal = normalize(normalMatrix * normal);
+    vec4 worldPos4 = modelMatrix * vec4(pos, 1.0);
+    vWorldPos = worldPos4.xyz;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
+  }
+`;
+
+const fragmentShader = /* glsl */ `
+  uniform vec3 baseColor;
+  uniform vec3 emissionColor;
+  uniform float emissionIntensity;
+  uniform float iridescenceEnabled;
+
+  varying vec3 vNormal;
+  varying vec3 vWorldPos;
+
+  void main() {
+    vec3 viewDir = normalize(cameraPosition - vWorldPos);
+    float NdotV = max(dot(vNormal, viewDir), 0.0);
+    float fresnel = pow(1.0 - NdotV, 3.0);
+
+    vec3 color = baseColor;
+
+    // Iridescence: channel-rotate based on Fresnel angle
+    if (iridescenceEnabled > 0.5) {
+      float t = fresnel * 0.5;
+      vec3 shifted = vec3(
+        mix(color.r, color.b, t),
+        mix(color.g, color.r, t * 0.7),
+        mix(color.b, color.g, t * 0.5)
+      );
+      color = mix(color, shifted, fresnel * 0.55);
+    }
+
+    // Emission + rim
+    color += emissionColor * emissionIntensity;
+    color += emissionColor * fresnel * 0.35;
+
+    // Specular highlight (fake top-left)
+    float spec = pow(max(dot(vNormal, normalize(vec3(0.6, 0.8, 1.0))), 0.0), 28.0);
+    color += vec3(spec * 0.25);
+
+    gl_FragColor = vec4(color, 1.0);
+  }
+`;
+
+// ─── Particles 3D ───────────────────────────────────────────────────────────
+
+const PARTICLE_COUNT = 40;
+
+function OrbParticles3D({
+  active,
+  color,
+  audioLevel,
+}: {
+  active: boolean;
+  color: THREE.Color;
+  audioLevel: number;
+}) {
+  const pointsRef = useRef<THREE.Points>(null);
+  const velocitiesRef = useRef<Float32Array>(new Float32Array(PARTICLE_COUNT * 3));
+  const lifetimesRef = useRef<Float32Array>(new Float32Array(PARTICLE_COUNT));
+
+  const positions = useMemo(() => {
+    const arr = new Float32Array(PARTICLE_COUNT * 3);
+    const v = velocitiesRef.current;
+    const l = lifetimesRef.current;
+    for (let i = 0; i < PARTICLE_COUNT; i++) {
+      const theta = Math.random() * Math.PI * 2;
+      const phi = (Math.random() * Math.PI) / 2; // upper hemisphere
+      const r = 0.65 + Math.random() * 0.15;
+      arr[i * 3]     = r * Math.sin(phi) * Math.cos(theta);
+      arr[i * 3 + 1] = r * Math.cos(phi);
+      arr[i * 3 + 2] = r * Math.sin(phi) * Math.sin(theta);
+      v[i * 3]     = (Math.random() - 0.5) * 0.02;
+      v[i * 3 + 1] = 0.15 + Math.random() * 0.25;
+      v[i * 3 + 2] = (Math.random() - 0.5) * 0.02;
+      l[i] = Math.random();
+    }
+    return arr;
+  }, []);
+
+  useFrame((_, delta) => {
+    if (!active || !pointsRef.current) return;
+    const pos = pointsRef.current.geometry.attributes.position?.array as Float32Array | undefined;
+    if (!pos) return;
+    const v = velocitiesRef.current;
+    const l = lifetimesRef.current;
+    const speed = 0.4 + audioLevel * 0.6;
+    for (let i = 0; i < PARTICLE_COUNT; i++) {
+      pos[i * 3]     += v[i * 3] * delta;
+      pos[i * 3 + 1] += v[i * 3 + 1] * speed * delta;
+      pos[i * 3 + 2] += v[i * 3 + 2] * delta;
+      l[i] -= delta * 0.35;
+      if (l[i] <= 0) {
+        // Reset particle on sphere surface (upper hemisphere)
+        const theta = Math.random() * Math.PI * 2;
+        const phi = (Math.random() * Math.PI) / 2;
+        const r = 0.65 + Math.random() * 0.1;
+        pos[i * 3]     = r * Math.sin(phi) * Math.cos(theta);
+        pos[i * 3 + 1] = r * Math.cos(phi);
+        pos[i * 3 + 2] = r * Math.sin(phi) * Math.sin(theta);
+        v[i * 3 + 1] = 0.15 + Math.random() * 0.25;
+        l[i] = 0.5 + Math.random() * 0.5;
+      }
+    }
+    (pointsRef.current.geometry.attributes.position as THREE.BufferAttribute).needsUpdate = true;
+  });
+
+  if (!active) return null;
+
+  return (
+    <points ref={pointsRef}>
+      <bufferGeometry>
+        <bufferAttribute
+          attach="attributes-position"
+          args={[positions, 3]}
+        />
+      </bufferGeometry>
+      <pointsMaterial
+        size={0.035}
+        color={color}
+        transparent
+        opacity={0.55}
+        depthWrite={false}
+        sizeAttenuation
+      />
+    </points>
+  );
+}
+
+// ─── Main orb scene (inside Canvas) ─────────────────────────────────────────
+
+type OrbSceneProps = {
+  state: VoiceOrbState;
+  effectsConfig: OrbEffectsConfig;
+  micAnalyserRef?: RefObject<AnalyserNode | null>;
+  ttsAnalyserRef?: RefObject<AnalyserNode | null>;
+  inputLevel: number;
+  outputLevel: number;
+  reducedMotion: boolean;
+};
+
+function OrbScene({
+  state,
+  effectsConfig,
+  micAnalyserRef,
+  ttsAnalyserRef,
+  inputLevel,
+  outputLevel,
+  reducedMotion,
+}: OrbSceneProps) {
+  const meshRef = useRef<THREE.Mesh>(null);
+  const matRef = useRef<THREE.ShaderMaterial>(null);
+  const light1Ref = useRef<THREE.PointLight>(null);
+  const light2Ref = useRef<THREE.PointLight>(null);
+  const light1Angle = useRef(0);
+  const light2Angle = useRef(Math.PI);
+  const chromaticOffsetRef = useRef(new THREE.Vector2(0, 0));
+  const prevState = useRef(state);
+  const burstProgress = useRef(0);
+  const { camera } = useThree();
+
+  // DataTexture for FFT data (128 buckets → 128x1 RGBA texture)
+  const fftDataArray = useRef(new Uint8Array(128 * 4));
+  const fftTexture = useMemo(() => {
+    const tex = new THREE.DataTexture(fftDataArray.current, 128, 1, THREE.RGBAFormat);
+    tex.needsUpdate = true;
+    return tex;
+  }, []);
+
+  const rawFFT = useRef(new Uint8Array(128));
+
+  const audioLevel = state === "recording" ? inputLevel : state === "tts" ? outputLevel : 0;
+  const isActive = state === "recording" || state === "tts";
+  const colors = STATE_COLORS[state];
+
+  // Bloom intensity state
+  const bloomTarget = useRef(0.3);
+
+  // Chromatic aberration spike on state change
+  useEffect(() => {
+    if (!effectsConfig.transitions || !effectsConfig.chromaticAberration || reducedMotion) return;
+    if (prevState.current === state) return;
+    prevState.current = state;
+
+    const start = performance.now();
+    const tick = () => {
+      const t = Math.min((performance.now() - start) / 280, 1);
+      const ease = Math.sin(t * Math.PI);
+      chromaticOffsetRef.current.set(ease * 0.007, ease * 0.007);
+      if (t < 1) requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  }, [state, effectsConfig.transitions, effectsConfig.chromaticAberration, reducedMotion]);
+
+  // Complete state burst
+  useEffect(() => {
+    if (state === "complete") {
+      burstProgress.current = 1;
+    }
+  }, [state]);
+
+  useFrame((frameState, delta) => {
+    const mat = matRef.current;
+    if (!mat) return;
+
+    const t = frameState.clock.elapsedTime;
+
+    // Update FFT texture
+    const activeAnalyser =
+      state === "recording" ? micAnalyserRef?.current :
+      state === "tts" ? ttsAnalyserRef?.current : null;
+
+    if (activeAnalyser) {
+      activeAnalyser.getByteFrequencyData(rawFFT.current);
+      const fftArr = fftDataArray.current;
+      for (let i = 0; i < 128; i++) {
+        const val = rawFFT.current[i] ?? 0;
+        fftArr[i * 4]     = val;
+        fftArr[i * 4 + 1] = val;
+        fftArr[i * 4 + 2] = val;
+        fftArr[i * 4 + 3] = 255;
+      }
+      fftTexture.needsUpdate = true;
+    }
+
+    // Update material uniforms
+    mat.uniforms.fftTexture = { value: fftTexture };
+    mat.uniforms.audioLevel = { value: audioLevel };
+    mat.uniforms.time = { value: t };
+    mat.uniforms.blobEnabled = { value: effectsConfig.blob && isActive ? 1 : 0 };
+    mat.uniforms.fftEnabled = { value: effectsConfig.frequencyRing && !!activeAnalyser ? 1 : 0 };
+    mat.uniforms.iridescenceEnabled = { value: effectsConfig.iridescence ? 1 : 0 };
+
+    // Lerp colors toward target state
+    const currentBase = (mat.uniforms.baseColor?.value as THREE.Color) ?? colors.base.clone();
+    const currentEmission = (mat.uniforms.emissionColor?.value as THREE.Color) ?? colors.emission.clone();
+    currentBase.lerp(colors.base, delta * 4);
+    currentEmission.lerp(colors.emission, delta * 4);
+    mat.uniforms.baseColor = { value: currentBase };
+    mat.uniforms.emissionColor = { value: currentEmission };
+
+    // Emission intensity per state + audio reactivity
+    let emissionTarget = 0.1;
+    if (state === "recording") emissionTarget = 0.25 + audioLevel * 0.6;
+    else if (state === "tts") emissionTarget = 0.3 + audioLevel * 0.9;
+    else if (state === "thinking") emissionTarget = 0.3 + Math.sin(t * 2.2) * 0.15;
+    else if (state === "complete") emissionTarget = Math.max(0, burstProgress.current);
+    else if (state === "ready") emissionTarget = 0.15 + Math.sin(t * 1.5) * 0.05;
+
+    if (state === "complete" && burstProgress.current > 0) {
+      burstProgress.current = Math.max(0, burstProgress.current - delta * 1.8);
+    }
+
+    const prevEmission = (mat.uniforms.emissionIntensity?.value as number) ?? 0;
+    mat.uniforms.emissionIntensity = { value: prevEmission + (emissionTarget - prevEmission) * delta * 5 };
+
+    // Bloom intensity
+    bloomTarget.current =
+      state === "recording" ? 0.4 + audioLevel * 0.8 :
+      state === "tts" ? 0.5 + audioLevel * 1.2 :
+      state === "thinking" ? 0.4 + Math.sin(t * 2) * 0.15 :
+      state === "complete" ? 1.2 * burstProgress.current :
+      state === "ready" ? 0.25 : 0.1;
+
+    // Volumetric orbiting lights
+    if (effectsConfig.volumetricLights) {
+      light1Angle.current += delta * (Math.PI * 2 / 6);
+      light2Angle.current += delta * (Math.PI * 2 / 10);
+      if (light1Ref.current) {
+        light1Ref.current.position.set(
+          Math.cos(light1Angle.current) * 2,
+          Math.sin(light1Angle.current * 0.7) * 1.2,
+          Math.sin(light1Angle.current) * 2,
+        );
+        light1Ref.current.intensity = 0.6 + audioLevel * 1.0;
+      }
+      if (light2Ref.current) {
+        light2Ref.current.position.set(
+          Math.cos(light2Angle.current + Math.PI) * 2.5,
+          Math.sin(light2Angle.current * 0.5) * 1.5,
+          Math.sin(light2Angle.current + Math.PI) * 2.5,
+        );
+        light2Ref.current.intensity = 0.4 + audioLevel * 0.6;
+      }
+    }
+
+    // Suppress unused variable warning
+    void camera;
+  });
+
+  const shaderUniforms = useMemo(() => ({
+    fftTexture: { value: fftTexture },
+    audioLevel: { value: 0 },
+    time: { value: 0 },
+    blobEnabled: { value: 1 },
+    fftEnabled: { value: 1 },
+    iridescenceEnabled: { value: effectsConfig.iridescence ? 1 : 0 },
+    baseColor: { value: colors.base.clone() },
+    emissionColor: { value: colors.emission.clone() },
+    emissionIntensity: { value: 0.2 },
+  }), []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <>
+      <ambientLight intensity={0.15} />
+
+      {effectsConfig.volumetricLights && (
+        <>
+          <pointLight ref={light1Ref} color={colors.emission} intensity={0.6} distance={5} decay={2} />
+          <pointLight ref={light2Ref} color={colors.base} intensity={0.4} distance={5} decay={2} />
+        </>
+      )}
+
+      <mesh ref={meshRef}>
+        <sphereGeometry args={[0.62, 64, 64]} />
+        <shaderMaterial
+          ref={matRef}
+          vertexShader={vertexShader}
+          fragmentShader={fragmentShader}
+          uniforms={shaderUniforms}
+        />
+      </mesh>
+
+      {effectsConfig.particles ? (
+        <OrbParticles3D active={isActive} color={colors.emission} audioLevel={audioLevel} />
+      ) : null}
+
+      {effectsConfig.coreTexture ? (
+        <Environment preset="city" background={false} />
+      ) : null}
+
+      {effectsConfig.bloom && !reducedMotion ? (
+        <EffectComposer>
+          <Bloom
+            intensity={bloomTarget.current}
+            luminanceThreshold={0.22}
+            luminanceSmoothing={0.9}
+            blendFunction={BlendFunction.ADD}
+          />
+          <ChromaticAberration
+            offset={effectsConfig.chromaticAberration && !reducedMotion
+              ? chromaticOffsetRef.current
+              : new THREE.Vector2(0, 0)}
+            radialModulation={false}
+            modulationOffset={0}
+          />
+        </EffectComposer>
+      ) : null}
+    </>
+  );
+}
+
+// ─── Public component ────────────────────────────────────────────────────────
+
+type VoiceOrb3DProps = Readonly<{
+  state: VoiceOrbState;
+  effectsConfig: OrbEffectsConfig;
+  reducedMotion?: boolean;
+  micAnalyserRef?: RefObject<AnalyserNode | null>;
+  ttsAnalyserRef?: RefObject<AnalyserNode | null>;
+  disabled?: boolean;
+  size?: number;
+}>;
+
+export function VoiceOrb3D({
+  state,
+  effectsConfig,
+  reducedMotion = false,
+  micAnalyserRef,
+  ttsAnalyserRef,
+  disabled = false,
+  size = 200,
+}: VoiceOrb3DProps) {
+  const fallbackRef = useRef<AnalyserNode | null>(null);
+  const effectiveState: VoiceOrbState = disabled ? "offline" : state;
+
+  const inputLevel = useAudioLevel(micAnalyserRef ?? fallbackRef, effectiveState === "recording");
+  const outputLevel = useAudioLevel(ttsAnalyserRef ?? fallbackRef, effectiveState === "tts");
+
+  return (
+    <div
+      style={{ width: size, height: size }}
+      aria-label="Voice orb visualization"
+      role="presentation"
+      data-orb-state={effectiveState}
+    >
+      <Canvas
+        camera={{ position: [0, 0, 2.2], fov: 42 }}
+        gl={{ antialias: true, alpha: true }}
+        style={{ width: size, height: size }}
+        dpr={[1, 2]}
+      >
+        <OrbScene
+          state={effectiveState}
+          effectsConfig={effectsConfig}
+          micAnalyserRef={micAnalyserRef}
+          ttsAnalyserRef={ttsAnalyserRef}
+          inputLevel={inputLevel}
+          outputLevel={outputLevel}
+          reducedMotion={reducedMotion}
+        />
+      </Canvas>
+    </div>
+  );
+}

--- a/web-next/components/voice/voice-orb-3d.tsx
+++ b/web-next/components/voice/voice-orb-3d.tsx
@@ -228,7 +228,9 @@ function OrbMetricBar3D({
     if (glowRef.current) {
       glowRef.current.geometry = glowGeo;
     }
-  }, [barGeo, definition.rotation, glowGeo]);
+    syncBarMaterial(coreMaterialRef.current, definition.color, 0.35, 0.9);
+    syncBarMaterial(glowMaterialRef.current, definition.color, 0.15, 0.12);
+  }, [barGeo, definition.color, definition.rotation, glowGeo]);
 
   useFrame(() => {
     syncOrbMetricBarFrame(index, metricsRef, refs);
@@ -237,26 +239,10 @@ function OrbMetricBar3D({
   return (
     <group ref={groupRef}>
       <mesh ref={glowRef} scale={[1, MIN_BAR_SCALE, 1]}>
-        <meshStandardMaterial
-          ref={glowMaterialRef}
-          color={definition.color}
-          emissive={definition.color}
-          emissiveIntensity={0.15}
-          transparent
-          opacity={0.12}
-          depthWrite={false}
-        />
+        <meshStandardMaterial ref={glowMaterialRef} />
       </mesh>
       <mesh ref={coreRef} scale={[1, MIN_BAR_SCALE, 1]}>
-        <meshStandardMaterial
-          ref={coreMaterialRef}
-          color={definition.color}
-          emissive={definition.color}
-          emissiveIntensity={0.35}
-          transparent
-          opacity={0.9}
-          depthWrite={false}
-        />
+        <meshStandardMaterial ref={coreMaterialRef} />
       </mesh>
     </group>
   );

--- a/web-next/components/voice/voice-orb-3d.tsx
+++ b/web-next/components/voice/voice-orb-3d.tsx
@@ -136,9 +136,9 @@ function makeGlowGeometry() {
   return geo;
 }
 
-type OrbMetricsBars3DProps = {
+type OrbMetricsBars3DProps = Readonly<{
   metricsRef: RefObject<OrbMetrics>;
-};
+}>;
 
 function OrbMetricsBars3D({ metricsRef }: OrbMetricsBars3DProps) {
   const groupRefs = useRef<Array<THREE.Group | null>>([null, null, null, null]);
@@ -174,8 +174,9 @@ function OrbMetricsBars3D({ metricsRef }: OrbMetricsBars3DProps) {
     const values: number[] = [m.cpu, m.gpu, m.net, m.ram];
 
     values.forEach((pct, i) => {
-      const isGpuAbsent = i === 1 && pct === 0;
-      const target = MIN_BAR_SCALE + (pct / 100) * (MAX_BAR_RADIUS - MIN_BAR_SCALE);
+      const safePct = Number.isFinite(pct) ? pct : 0;
+      const isGpuAbsent = i === 1 && !Number.isFinite(pct);
+      const target = MIN_BAR_SCALE + (safePct / 100) * (MAX_BAR_RADIUS - MIN_BAR_SCALE);
 
       const core = coreRefs.current[i];
       if (core) {
@@ -184,7 +185,7 @@ function OrbMetricsBars3D({ metricsRef }: OrbMetricsBars3DProps) {
         if (mat) {
           mat.color.set(BAR_DEFS[i]?.color ?? mat.color);
           mat.emissive.set(BAR_DEFS[i]?.color ?? mat.emissive);
-          mat.emissiveIntensity = isGpuAbsent ? 0.04 : 0.35 + 0.65 * (pct / 100);
+          mat.emissiveIntensity = isGpuAbsent ? 0.04 : 0.35 + 0.65 * (safePct / 100);
           mat.opacity = isGpuAbsent ? 0.2 : 0.92;
           mat.transparent = true;
           mat.depthWrite = false;
@@ -198,8 +199,8 @@ function OrbMetricsBars3D({ metricsRef }: OrbMetricsBars3DProps) {
         if (mat) {
           mat.color.set(BAR_DEFS[i]?.color ?? mat.color);
           mat.emissive.set(BAR_DEFS[i]?.color ?? mat.emissive);
-          mat.emissiveIntensity = isGpuAbsent ? 0.02 : 0.15 + 0.35 * (pct / 100);
-          mat.opacity = isGpuAbsent ? 0.06 : 0.18 + 0.22 * (pct / 100);
+          mat.emissiveIntensity = isGpuAbsent ? 0.02 : 0.15 + 0.35 * (safePct / 100);
+          mat.opacity = isGpuAbsent ? 0.06 : 0.18 + 0.22 * (safePct / 100);
           mat.transparent = true;
           mat.depthWrite = false;
         }

--- a/web-next/components/voice/voice-orb-3d.tsx
+++ b/web-next/components/voice/voice-orb-3d.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useEffect, useMemo, useRef } from "react";
-import type { RefObject } from "react";
-import { Canvas, useFrame, useThree } from "@react-three/fiber";
+import type { MutableRefObject, RefObject } from "react";
+import { Canvas, useFrame } from "@react-three/fiber";
 import { Environment } from "@react-three/drei";
 import { EffectComposer, Bloom, ChromaticAberration } from "@react-three/postprocessing";
 import { BlendFunction } from "postprocessing";
@@ -124,14 +124,14 @@ const BAR_DEFS: Array<{
 
 // BoxGeometry with translate(0, 0.5, 0): bottom at Y=0 → scales grow outward.
 function makeBarGeometry() {
-  const geo = new THREE.BoxGeometry(0.055, 1.0, 0.055);
+  const geo = new THREE.BoxGeometry(0.055, 1, 0.055);
   geo.translate(0, 0.5, 0);
   return geo;
 }
 
 // Wider secondary "glow" geometry
 function makeGlowGeometry() {
-  const geo = new THREE.BoxGeometry(0.18, 1.0, 0.055);
+  const geo = new THREE.BoxGeometry(0.18, 1, 0.055);
   geo.translate(0, 0.5, 0);
   return geo;
 }
@@ -141,13 +141,36 @@ type OrbMetricsBars3DProps = {
 };
 
 function OrbMetricsBars3D({ metricsRef }: OrbMetricsBars3DProps) {
+  const groupRefs = useRef<Array<THREE.Group | null>>([null, null, null, null]);
   const coreRefs = useRef<Array<THREE.Mesh | null>>([null, null, null, null]);
   const glowRefs = useRef<Array<THREE.Mesh | null>>([null, null, null, null]);
+  const coreMaterialRefs = useRef<Array<THREE.MeshStandardMaterial | null>>([null, null, null, null]);
+  const glowMaterialRefs = useRef<Array<THREE.MeshStandardMaterial | null>>([null, null, null, null]);
   const barGeo = useMemo(() => makeBarGeometry(), []);
   const glowGeo = useMemo(() => makeGlowGeometry(), []);
 
+  useEffect(() => {
+    coreRefs.current.forEach((mesh) => {
+      if (mesh) {
+        mesh.geometry = barGeo;
+      }
+    });
+    glowRefs.current.forEach((mesh) => {
+      if (mesh) {
+        mesh.geometry = glowGeo;
+      }
+    });
+    groupRefs.current.forEach((group, index) => {
+      const def = BAR_DEFS[index];
+      if (group && def) {
+        group.rotation.set(def.rotation[0], def.rotation[1], def.rotation[2]);
+      }
+    });
+  }, [barGeo, glowGeo]);
+
   useFrame(() => {
     const m = metricsRef.current;
+    if (!m) return;
     const values: number[] = [m.cpu, m.gpu, m.net, m.ram];
 
     values.forEach((pct, i) => {
@@ -157,17 +180,29 @@ function OrbMetricsBars3D({ metricsRef }: OrbMetricsBars3DProps) {
       const core = coreRefs.current[i];
       if (core) {
         core.scale.y += (target - core.scale.y) * BAR_LERP_ALPHA;
-        const mat = core.material as THREE.MeshStandardMaterial;
-        mat.emissiveIntensity = isGpuAbsent ? 0.04 : 0.35 + 0.65 * (pct / 100);
-        mat.opacity = isGpuAbsent ? 0.2 : 0.92;
+        const mat = coreMaterialRefs.current[i];
+        if (mat) {
+          mat.color.set(BAR_DEFS[i]?.color ?? mat.color);
+          mat.emissive.set(BAR_DEFS[i]?.color ?? mat.emissive);
+          mat.emissiveIntensity = isGpuAbsent ? 0.04 : 0.35 + 0.65 * (pct / 100);
+          mat.opacity = isGpuAbsent ? 0.2 : 0.92;
+          mat.transparent = true;
+          mat.depthWrite = false;
+        }
       }
 
       const glow = glowRefs.current[i];
       if (glow) {
         glow.scale.y += (target - glow.scale.y) * BAR_LERP_ALPHA;
-        const mat = glow.material as THREE.MeshStandardMaterial;
-        mat.emissiveIntensity = isGpuAbsent ? 0.02 : 0.15 + 0.35 * (pct / 100);
-        mat.opacity = isGpuAbsent ? 0.06 : 0.18 + 0.22 * (pct / 100);
+        const mat = glowMaterialRefs.current[i];
+        if (mat) {
+          mat.color.set(BAR_DEFS[i]?.color ?? mat.color);
+          mat.emissive.set(BAR_DEFS[i]?.color ?? mat.emissive);
+          mat.emissiveIntensity = isGpuAbsent ? 0.02 : 0.15 + 0.35 * (pct / 100);
+          mat.opacity = isGpuAbsent ? 0.06 : 0.18 + 0.22 * (pct / 100);
+          mat.transparent = true;
+          mat.depthWrite = false;
+        }
       }
     });
   });
@@ -175,35 +210,55 @@ function OrbMetricsBars3D({ metricsRef }: OrbMetricsBars3DProps) {
   return (
     <>
       {BAR_DEFS.map(({ key, color, rotation }, i) => (
-        <group key={key} rotation={rotation}>
+        <group
+          key={key}
+          ref={(group) => {
+            groupRefs.current[i] = group;
+            if (group) {
+              group.rotation.set(rotation[0], rotation[1], rotation[2]);
+            }
+          }}
+        >
           {/* Glow halo — wide, semi-transparent */}
           <mesh
-            ref={(el) => { glowRefs.current[i] = el; }}
-            geometry={glowGeo}
+            ref={(el) => {
+              glowRefs.current[i] = el;
+            }}
             scale={[1, MIN_BAR_SCALE, 1]}
           >
             <meshStandardMaterial
-              color={color}
-              emissive={color}
-              emissiveIntensity={0.15}
-              transparent
-              opacity={0.12}
-              depthWrite={false}
+              ref={(mat) => {
+                glowMaterialRefs.current[i] = mat;
+                if (mat) {
+                  mat.color.set(color);
+                  mat.emissive.set(color);
+                  mat.emissiveIntensity = 0.15;
+                  mat.transparent = true;
+                  mat.opacity = 0.12;
+                  mat.depthWrite = false;
+                }
+              }}
             />
           </mesh>
           {/* Core beam */}
           <mesh
-            ref={(el) => { coreRefs.current[i] = el; }}
-            geometry={barGeo}
+            ref={(el) => {
+              coreRefs.current[i] = el;
+            }}
             scale={[1, MIN_BAR_SCALE, 1]}
           >
             <meshStandardMaterial
-              color={color}
-              emissive={color}
-              emissiveIntensity={0.35}
-              transparent
-              opacity={0.9}
-              depthWrite={false}
+              ref={(mat) => {
+                coreMaterialRefs.current[i] = mat;
+                if (mat) {
+                  mat.color.set(color);
+                  mat.emissive.set(color);
+                  mat.emissiveIntensity = 0.35;
+                  mat.transparent = true;
+                  mat.opacity = 0.9;
+                  mat.depthWrite = false;
+                }
+              }}
             />
           </mesh>
         </group>
@@ -222,15 +277,15 @@ function pseudoRandom(seed: number): number {
 }
 
 function sampleParticle(seed: number) {
-  const theta = pseudoRandom(seed * 1.17 + 1.0) * Math.PI * 2;
-  const phi = pseudoRandom(seed * 1.91 + 2.0) * (Math.PI / 2);
-  const r = 0.65 + pseudoRandom(seed * 2.53 + 3.0) * 0.15;
+  const theta = pseudoRandom(seed * 1.17 + 1) * Math.PI * 2;
+  const phi = pseudoRandom(seed * 1.91 + 2) * (Math.PI / 2);
+  const r = 0.65 + pseudoRandom(seed * 2.53 + 3) * 0.15;
   return {
     theta,
     phi,
     r,
-    vy: 0.15 + pseudoRandom(seed * 3.11 + 4.0) * 0.25,
-    life: pseudoRandom(seed * 4.07 + 5.0),
+    vy: 0.15 + pseudoRandom(seed * 3.11 + 4) * 0.25,
+    life: pseudoRandom(seed * 4.07 + 5),
   };
 }
 
@@ -251,9 +306,9 @@ function createParticleState(): ParticleState {
     positions[i * 3] = sample.r * Math.sin(sample.phi) * Math.cos(sample.theta);
     positions[i * 3 + 1] = sample.r * Math.cos(sample.phi);
     positions[i * 3 + 2] = sample.r * Math.sin(sample.phi) * Math.sin(sample.theta);
-    velocities[i * 3] = (pseudoRandom(i * 5.13 + 6.0) - 0.5) * 0.02;
+    velocities[i * 3] = (pseudoRandom(i * 5.13 + 6) - 0.5) * 0.02;
     velocities[i * 3 + 1] = sample.vy;
-    velocities[i * 3 + 2] = (pseudoRandom(i * 7.41 + 7.0) - 0.5) * 0.02;
+    velocities[i * 3 + 2] = (pseudoRandom(i * 7.41 + 7) - 0.5) * 0.02;
     lifetimes[i] = sample.life;
   }
   return { positions, velocities, lifetimes, resetCounts };
@@ -265,6 +320,142 @@ const GLOBAL_FFT_TEXTURE = new THREE.DataTexture(GLOBAL_FFT_DATA_ARRAY, 128, 1, 
 GLOBAL_FFT_TEXTURE.needsUpdate = true;
 const GLOBAL_BLOOM_TARGET = { current: 0.3 };
 const GLOBAL_CHROMATIC_OFFSET = new THREE.Vector2(0, 0);
+const GLOBAL_ORB_SHADER_MATERIAL = new THREE.ShaderMaterial({
+  uniforms: {
+    fftTexture: { value: GLOBAL_FFT_TEXTURE },
+    audioLevel: { value: 0 },
+    time: { value: 0 },
+    blobEnabled: { value: 1 },
+    fftEnabled: { value: 1 },
+    iridescenceEnabled: { value: 0 },
+    baseColor: { value: STATE_COLORS.ready.base.clone() },
+    emissionColor: { value: STATE_COLORS.ready.emission.clone() },
+    emissionIntensity: { value: 0.2 },
+  },
+  vertexShader,
+  fragmentShader,
+});
+
+function getActiveAnalyser(
+  state: VoiceOrbState,
+  micAnalyserRef?: RefObject<AnalyserNode | null>,
+  ttsAnalyserRef?: RefObject<AnalyserNode | null>,
+): AnalyserNode | null {
+  if (state === "recording") return micAnalyserRef?.current ?? null;
+  if (state === "tts") return ttsAnalyserRef?.current ?? null;
+  return null;
+}
+
+function getEmissionTarget(state: VoiceOrbState, audioLevel: number, elapsed: number, burst: number): number {
+  if (state === "recording") return 0.25 + audioLevel * 0.6;
+  if (state === "tts") return 0.3 + audioLevel * 0.9;
+  if (state === "thinking") return 0.3 + Math.sin(elapsed * 2.2) * 0.15;
+  if (state === "complete") return Math.max(0, burst);
+  if (state === "ready") return 0.15 + Math.sin(elapsed * 1.5) * 0.05;
+  return 0.1;
+}
+
+function getBloomTarget(state: VoiceOrbState, audioLevel: number, elapsed: number, burst: number): number {
+  if (state === "recording") return 0.4 + audioLevel * 0.8;
+  if (state === "tts") return 0.5 + audioLevel * 1.2;
+  if (state === "thinking") return 0.4 + Math.sin(elapsed * 2) * 0.15;
+  if (state === "complete") return 1.2 * burst;
+  if (state === "ready") return 0.25;
+  return 0.1;
+}
+
+function updateVolumetricLights(
+  light1: THREE.PointLight | null,
+  light2: THREE.PointLight | null,
+  delta: number,
+  audioLevel: number,
+  enabled: boolean,
+  light1Angle: MutableRefObject<number>,
+  light2Angle: MutableRefObject<number>,
+) {
+  if (!enabled) return;
+  light1Angle.current += delta * (Math.PI * 2 / 6);
+  light2Angle.current += delta * (Math.PI * 2 / 10);
+  if (light1) {
+    light1.position.set(
+      Math.cos(light1Angle.current) * 2,
+      Math.sin(light1Angle.current * 0.7) * 1.2,
+      Math.sin(light1Angle.current) * 2,
+    );
+    light1.intensity = 0.6 + audioLevel;
+  }
+  if (light2) {
+    light2.position.set(
+      Math.cos(light2Angle.current + Math.PI) * 2.5,
+      Math.sin(light2Angle.current * 0.5) * 1.5,
+      Math.sin(light2Angle.current + Math.PI) * 2.5,
+    );
+    light2.intensity = 0.4 + audioLevel * 0.6;
+  }
+}
+
+function updateShaderMaterial(
+  mat: THREE.ShaderMaterial | null,
+  state: VoiceOrbState,
+  colors: StateColors,
+  audioLevel: number,
+  elapsed: number,
+  delta: number,
+  effectsConfig: OrbEffectsConfig,
+  activeAnalyser: AnalyserNode | null,
+  rawFFT: MutableRefObject<Uint8Array>,
+  burstProgress: MutableRefObject<number>,
+) {
+  if (!mat) return;
+  const uniforms = mat.uniforms as Record<string, { value: unknown }>;
+  const setUniform = (name: string, value: unknown) => {
+    const uniform = uniforms[name];
+    if (uniform) {
+      uniform.value = value;
+      return;
+    }
+    uniforms[name] = { value };
+  };
+
+  if (activeAnalyser) {
+    activeAnalyser.getByteFrequencyData(rawFFT.current);
+    for (let i = 0; i < 128; i++) {
+      const val = rawFFT.current[i] ?? 0;
+      GLOBAL_FFT_DATA_ARRAY[i * 4] = val;
+      GLOBAL_FFT_DATA_ARRAY[i * 4 + 1] = val;
+      GLOBAL_FFT_DATA_ARRAY[i * 4 + 2] = val;
+      GLOBAL_FFT_DATA_ARRAY[i * 4 + 3] = 255;
+    }
+    GLOBAL_FFT_TEXTURE.needsUpdate = true;
+  }
+
+  setUniform("fftTexture", GLOBAL_FFT_TEXTURE);
+  setUniform("audioLevel", audioLevel);
+  setUniform("time", elapsed);
+  setUniform("blobEnabled", effectsConfig.blob && (state === "recording" || state === "tts") ? 1 : 0);
+  setUniform("fftEnabled", effectsConfig.frequencyRing && !!activeAnalyser ? 1 : 0);
+  setUniform("iridescenceEnabled", effectsConfig.iridescence ? 1 : 0);
+
+  const currentBase = (uniforms.baseColor?.value as THREE.Color | undefined) ?? colors.base.clone();
+  const currentEmission = (uniforms.emissionColor?.value as THREE.Color | undefined) ?? colors.emission.clone();
+  currentBase.lerp(colors.base, delta * 4);
+  currentEmission.lerp(colors.emission, delta * 4);
+  setUniform("baseColor", currentBase);
+  setUniform("emissionColor", currentEmission);
+
+  if (state === "complete" && burstProgress.current > 0) {
+    burstProgress.current = Math.max(0, burstProgress.current - delta * 1.8);
+  }
+
+  const currentEmissionIntensity = (uniforms.emissionIntensity?.value as number | undefined) ?? 0;
+  setUniform(
+    "emissionIntensity",
+    currentEmissionIntensity +
+      (getEmissionTarget(state, audioLevel, elapsed, burstProgress.current) - currentEmissionIntensity) * delta * 5,
+  );
+
+  GLOBAL_BLOOM_TARGET.current = getBloomTarget(state, audioLevel, elapsed, burstProgress.current);
+}
 
 function OrbParticles3D({
   active,
@@ -276,6 +467,26 @@ function OrbParticles3D({
   audioLevel: number;
 }) {
   const pointsRef = useRef<THREE.Points>(null);
+  const geometryRef = useRef<THREE.BufferGeometry | null>(null);
+  const materialRef = useRef<THREE.PointsMaterial | null>(null);
+
+  useEffect(() => {
+    if (geometryRef.current) {
+      geometryRef.current.setAttribute(
+        "position",
+        new THREE.BufferAttribute(GLOBAL_PARTICLE_STATE.positions, 3),
+      );
+    }
+    if (materialRef.current) {
+      materialRef.current.color.set(color);
+      materialRef.current.size = 0.035;
+      materialRef.current.transparent = true;
+      materialRef.current.opacity = 0.55;
+      materialRef.current.depthWrite = false;
+      materialRef.current.sizeAttenuation = true;
+    }
+  }, [color]);
+
   useFrame((_, delta) => {
     if (!active || !pointsRef.current) return;
     const pos = pointsRef.current.geometry.attributes.position?.array as Float32Array | undefined;
@@ -307,20 +518,8 @@ function OrbParticles3D({
 
   return (
     <points ref={pointsRef}>
-      <bufferGeometry>
-        <bufferAttribute
-          attach="attributes-position"
-          args={[GLOBAL_PARTICLE_STATE.positions, 3]}
-        />
-      </bufferGeometry>
-      <pointsMaterial
-        size={0.035}
-        color={color}
-        transparent
-        opacity={0.55}
-        depthWrite={false}
-        sizeAttenuation
-      />
+      <bufferGeometry ref={geometryRef} />
+      <pointsMaterial ref={materialRef} />
     </points>
   );
 }
@@ -349,20 +548,21 @@ function OrbScene({
   metricsRef,
 }: OrbSceneProps) {
   const meshRef = useRef<THREE.Mesh>(null);
-  const matRef = useRef<THREE.ShaderMaterial>(null);
+  const ambientLightRef = useRef<THREE.AmbientLight>(null);
   const light1Ref = useRef<THREE.PointLight>(null);
   const light2Ref = useRef<THREE.PointLight>(null);
   const light1Angle = useRef(0);
   const light2Angle = useRef(Math.PI);
   const prevState = useRef(state);
   const burstProgress = useRef(0);
-  const { camera } = useThree();
-
   const rawFFT = useRef(new Uint8Array(128));
 
   const audioLevel = state === "recording" ? inputLevel : state === "tts" ? outputLevel : 0;
   const isActive = state === "recording" || state === "tts";
   const colors = STATE_COLORS[state];
+  const activeAnalyser = getActiveAnalyser(state, micAnalyserRef, ttsAnalyserRef);
+  const orbGeometry = useMemo(() => new THREE.SphereGeometry(0.62, 64, 64), []);
+  const shaderMaterial = GLOBAL_ORB_SHADER_MATERIAL;
 
   // Chromatic aberration spike on state change
   useEffect(() => {
@@ -387,127 +587,78 @@ function OrbScene({
     }
   }, [state]);
 
+  useEffect(() => {
+    if (meshRef.current) {
+      meshRef.current.geometry = orbGeometry;
+      meshRef.current.material = shaderMaterial;
+    }
+    return () => {
+      orbGeometry.dispose();
+    };
+  }, [orbGeometry, shaderMaterial]);
+
+  useEffect(() => {
+    const uniforms = shaderMaterial.uniforms as Record<string, { value: unknown }>;
+    (uniforms.baseColor.value as THREE.Color).copy(colors.base);
+    (uniforms.emissionColor.value as THREE.Color).copy(colors.emission);
+    if (uniforms.iridescenceEnabled) {
+      uniforms.iridescenceEnabled.value = effectsConfig.iridescence ? 1 : 0;
+    }
+  }, [colors, effectsConfig.iridescence, shaderMaterial]);
+
+  useEffect(() => {
+    if (ambientLightRef.current) {
+      ambientLightRef.current.intensity = 0.15;
+    }
+    if (light1Ref.current) {
+      light1Ref.current.color.copy(colors.emission);
+      light1Ref.current.distance = 5;
+      light1Ref.current.decay = 2;
+    }
+    if (light2Ref.current) {
+      light2Ref.current.color.copy(colors.base);
+      light2Ref.current.distance = 5;
+      light2Ref.current.decay = 2;
+    }
+  }, [colors]);
+
   useFrame((frameState, delta) => {
-    const mat = matRef.current;
-    if (!mat) return;
-
     const t = frameState.clock.elapsedTime;
-
-    // Update FFT texture
-    const activeAnalyser =
-      state === "recording" ? micAnalyserRef?.current :
-      state === "tts" ? ttsAnalyserRef?.current : null;
-
-    if (activeAnalyser) {
-      activeAnalyser.getByteFrequencyData(rawFFT.current);
-      const fftArr = GLOBAL_FFT_DATA_ARRAY;
-      for (let i = 0; i < 128; i++) {
-        const val = rawFFT.current[i] ?? 0;
-        fftArr[i * 4]     = val;
-        fftArr[i * 4 + 1] = val;
-        fftArr[i * 4 + 2] = val;
-        fftArr[i * 4 + 3] = 255;
-      }
-      GLOBAL_FFT_TEXTURE.needsUpdate = true;
-    }
-
-    // Update material uniforms
-    mat.uniforms.fftTexture = { value: GLOBAL_FFT_TEXTURE };
-    mat.uniforms.audioLevel = { value: audioLevel };
-    mat.uniforms.time = { value: t };
-    mat.uniforms.blobEnabled = { value: effectsConfig.blob && isActive ? 1 : 0 };
-    mat.uniforms.fftEnabled = { value: effectsConfig.frequencyRing && !!activeAnalyser ? 1 : 0 };
-    mat.uniforms.iridescenceEnabled = { value: effectsConfig.iridescence ? 1 : 0 };
-
-    // Lerp colors toward target state
-    const currentBase = (mat.uniforms.baseColor?.value as THREE.Color) ?? colors.base.clone();
-    const currentEmission = (mat.uniforms.emissionColor?.value as THREE.Color) ?? colors.emission.clone();
-    currentBase.lerp(colors.base, delta * 4);
-    currentEmission.lerp(colors.emission, delta * 4);
-    mat.uniforms.baseColor = { value: currentBase };
-    mat.uniforms.emissionColor = { value: currentEmission };
-
-    // Emission intensity per state + audio reactivity
-    let emissionTarget = 0.1;
-    if (state === "recording") emissionTarget = 0.25 + audioLevel * 0.6;
-    else if (state === "tts") emissionTarget = 0.3 + audioLevel * 0.9;
-    else if (state === "thinking") emissionTarget = 0.3 + Math.sin(t * 2.2) * 0.15;
-    else if (state === "complete") emissionTarget = Math.max(0, burstProgress.current);
-    else if (state === "ready") emissionTarget = 0.15 + Math.sin(t * 1.5) * 0.05;
-
-    if (state === "complete" && burstProgress.current > 0) {
-      burstProgress.current = Math.max(0, burstProgress.current - delta * 1.8);
-    }
-
-    const prevEmission = (mat.uniforms.emissionIntensity?.value as number) ?? 0;
-    mat.uniforms.emissionIntensity = { value: prevEmission + (emissionTarget - prevEmission) * delta * 5 };
-
-    // Bloom intensity
-    GLOBAL_BLOOM_TARGET.current =
-      state === "recording" ? 0.4 + audioLevel * 0.8 :
-      state === "tts" ? 0.5 + audioLevel * 1.2 :
-      state === "thinking" ? 0.4 + Math.sin(t * 2) * 0.15 :
-      state === "complete" ? 1.2 * burstProgress.current :
-      state === "ready" ? 0.25 : 0.1;
-
-    // Volumetric orbiting lights
-    if (effectsConfig.volumetricLights) {
-      light1Angle.current += delta * (Math.PI * 2 / 6);
-      light2Angle.current += delta * (Math.PI * 2 / 10);
-      if (light1Ref.current) {
-        light1Ref.current.position.set(
-          Math.cos(light1Angle.current) * 2,
-          Math.sin(light1Angle.current * 0.7) * 1.2,
-          Math.sin(light1Angle.current) * 2,
-        );
-        light1Ref.current.intensity = 0.6 + audioLevel * 1.0;
-      }
-      if (light2Ref.current) {
-        light2Ref.current.position.set(
-          Math.cos(light2Angle.current + Math.PI) * 2.5,
-          Math.sin(light2Angle.current * 0.5) * 1.5,
-          Math.sin(light2Angle.current + Math.PI) * 2.5,
-        );
-        light2Ref.current.intensity = 0.4 + audioLevel * 0.6;
-      }
-    }
-
-    // Suppress unused variable warning
-    void camera;
+    updateShaderMaterial(
+      shaderMaterial,
+      state,
+      colors,
+      audioLevel,
+      t,
+      delta,
+      effectsConfig,
+      activeAnalyser,
+      rawFFT,
+      burstProgress,
+    );
+    updateVolumetricLights(
+      light1Ref.current,
+      light2Ref.current,
+      delta,
+      audioLevel,
+      effectsConfig.volumetricLights,
+      light1Angle,
+      light2Angle,
+    );
   });
-
-  const shaderUniforms = {
-    fftTexture: { value: GLOBAL_FFT_TEXTURE },
-    audioLevel: { value: 0 },
-    time: { value: 0 },
-    blobEnabled: { value: 1 },
-    fftEnabled: { value: 1 },
-    iridescenceEnabled: { value: effectsConfig.iridescence ? 1 : 0 },
-    baseColor: { value: colors.base.clone() },
-    emissionColor: { value: colors.emission.clone() },
-    emissionIntensity: { value: 0.2 },
-  };
 
   return (
     <>
-      <ambientLight intensity={0.15} />
+      <ambientLight ref={ambientLightRef} />
 
       {effectsConfig.volumetricLights && (
         <>
-          <pointLight ref={light1Ref} color={colors.emission} intensity={0.6} distance={5} decay={2} />
-          <pointLight ref={light2Ref} color={colors.base} intensity={0.4} distance={5} decay={2} />
+          <pointLight ref={light1Ref} />
+          <pointLight ref={light2Ref} />
         </>
       )}
 
-      <mesh ref={meshRef}>
-        <sphereGeometry args={[0.62, 64, 64]} />
-        <shaderMaterial
-          ref={matRef}
-          vertexShader={vertexShader}
-          fragmentShader={fragmentShader}
-          uniforms={shaderUniforms}
-        />
-      </mesh>
+      <mesh ref={meshRef} />
 
       {effectsConfig.particles ? (
         <OrbParticles3D active={isActive} color={colors.emission} audioLevel={audioLevel} />
@@ -575,7 +726,7 @@ export function VoiceOrb3D({
     <div
       style={{ width: size, height: size }}
       aria-label="Voice orb visualization"
-      role="presentation"
+      role="img"
       data-orb-state={effectiveState}
     >
       <Canvas

--- a/web-next/components/voice/voice-orb.tsx
+++ b/web-next/components/voice/voice-orb.tsx
@@ -233,9 +233,11 @@ function useOrbParticles() {
 const ARC_DEFS = [
   { key: "cpu" as keyof OrbMetrics, color: "#f97316", startDeg:  45, endDeg: 135 }, // top
   { key: "gpu" as keyof OrbMetrics, color: "#a855f7", startDeg: -45, endDeg:  45 }, // right
-  { key: "net" as keyof OrbMetrics, color: "#4ade80", startDeg: 225, endDeg: 315 }, // bottom
-  { key: "ram" as keyof OrbMetrics, color: "#22d3ee", startDeg: 135, endDeg: 225 }, // left
+  { key: "vram" as keyof OrbMetrics, color: "#22d3ee", startDeg: 135, endDeg: 225 }, // left
+  { key: "ram" as keyof OrbMetrics, color: "#4ade80", startDeg: 225, endDeg: 315 }, // bottom
 ] as const;
+
+const MONO_METRIC_COLOR = "#6b7280";
 
 function arcPath(cx: number, cy: number, r: number, startDeg: number, endDeg: number): string {
   const s  = (startDeg * Math.PI) / 180;
@@ -248,6 +250,34 @@ function arcPath(cx: number, cy: number, r: number, startDeg: number, endDeg: nu
   return `M ${x1.toFixed(2)} ${y1.toFixed(2)} A ${r.toFixed(2)} ${r.toFixed(2)} 0 0 0 ${x2.toFixed(2)} ${y2.toFixed(2)}`;
 }
 
+function sectorPath(
+  cx: number,
+  cy: number,
+  innerR: number,
+  outerR: number,
+  startDeg: number,
+  endDeg: number,
+): string {
+  const s = (startDeg * Math.PI) / 180;
+  const e = (endDeg * Math.PI) / 180;
+  const x1 = cx + outerR * Math.cos(s);
+  const y1 = cy - outerR * Math.sin(s);
+  const x2 = cx + outerR * Math.cos(e);
+  const y2 = cy - outerR * Math.sin(e);
+  const ix2 = cx + innerR * Math.cos(e);
+  const iy2 = cy - innerR * Math.sin(e);
+  const ix1 = cx + innerR * Math.cos(s);
+  const iy1 = cy - innerR * Math.sin(s);
+  return [
+    `M ${cx.toFixed(2)} ${cy.toFixed(2)}`,
+    `L ${x1.toFixed(2)} ${y1.toFixed(2)}`,
+    `A ${outerR.toFixed(2)} ${outerR.toFixed(2)} 0 0 0 ${x2.toFixed(2)} ${y2.toFixed(2)}`,
+    `L ${ix2.toFixed(2)} ${iy2.toFixed(2)}`,
+    `A ${innerR.toFixed(2)} ${innerR.toFixed(2)} 0 0 1 ${ix1.toFixed(2)} ${iy1.toFixed(2)}`,
+    "Z",
+  ].join(" ");
+}
+
 type OrbMetricsBars2DProps = Readonly<{
   metricsRef: RefObject<OrbMetrics>;
   orbSize: number;
@@ -255,6 +285,7 @@ type OrbMetricsBars2DProps = Readonly<{
 }>;
 
 function OrbMetricsBars2D({ metricsRef, orbSize, colorMode }: OrbMetricsBars2DProps) {
+  const sectorRefs = useRef<Array<SVGPathElement | null>>([null, null, null, null]);
   const coreRefs   = useRef<Array<SVGPathElement | null>>([null, null, null, null]);
   const glowRefs   = useRef<Array<SVGPathElement | null>>([null, null, null, null]);
   const rippleRefs = useRef<Array<SVGPathElement | null>>([null, null, null, null]);
@@ -266,6 +297,7 @@ function OrbMetricsBars2D({ metricsRef, orbSize, colorMode }: OrbMetricsBars2DPr
     const cx     = orbSize / 2;
     const cy     = orbSize / 2;
     const ORB_R  = orbSize / 2;
+    const SECTOR_INNER_R = ORB_R * 0.84;
     const MIN_R  = ORB_R * 1.08; // just outside the orb edge
     const MAX_R  = ORB_R * 1.95; // fully loaded: arcs nearly double the orb radius
     const PHASES = [0, Math.PI * 0.5, Math.PI, Math.PI * 1.5]; // 90° stagger per arc
@@ -278,7 +310,7 @@ function OrbMetricsBars2D({ metricsRef, orbSize, colorMode }: OrbMetricsBars2DPr
     const tick = (now: number) => {
       const t    = now / 1000;
       const m    = metricsRef.current;
-      const vals = [m.cpu, m.gpu, m.net, m.ram];
+      const vals = [m.cpu, m.gpu, m.vram, m.ram];
 
       currents.current = currents.current.map((c, i) => {
         const pct = Number.isFinite(vals[i] ?? Number.NaN) ? (vals[i] as number) : 0;
@@ -298,6 +330,15 @@ function OrbMetricsBars2D({ metricsRef, orbSize, colorMode }: OrbMetricsBars2DPr
         const sw = 1.8 + 3.8 * pct + breathe * (0.8 + 1.2 * pct);
         const opa = 0.35 + 0.65 * Math.max(pct, loadPct);
         const d = arcPath(cx, cy, Math.max(MIN_R * 0.95, effR), def.startDeg, def.endDeg);
+        const sectorOuter = Math.max(MIN_R * 0.98, effR + orbSize * 0.02);
+        const sectorOpacity = 0.14 + 0.18 * Math.max(pct, loadPct);
+        const sector = sectorRefs.current[i];
+        if (sector) {
+          sector.setAttribute("d", sectorPath(cx, cy, SECTOR_INNER_R, sectorOuter, def.startDeg, def.endDeg));
+          sector.setAttribute("fill", colorMode ? def.color : MONO_METRIC_COLOR);
+          sector.setAttribute("fill-opacity", String(sectorOpacity.toFixed(3)));
+          sector.setAttribute("stroke", "none");
+        }
 
         const core = coreRefs.current[i];
         if (core) {
@@ -340,9 +381,7 @@ function OrbMetricsBars2D({ metricsRef, orbSize, colorMode }: OrbMetricsBars2DPr
 
     raf = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf);
-  }, [metricsRef, orbSize]);
-
-  const MONO = "#6b7280";
+  }, [colorMode, metricsRef, orbSize]);
 
   return (
     <svg
@@ -364,13 +403,24 @@ function OrbMetricsBars2D({ metricsRef, orbSize, colorMode }: OrbMetricsBars2DPr
         </filter>
       </defs>
 
+      {/* Filled quarter sectors — translucent outer layer */}
+      {ARC_DEFS.map(({ key, color }, i) => (
+        <path
+          key={`s-${key}`}
+          ref={(el) => { sectorRefs.current[i] = el; }}
+          fill={colorMode ? color : MONO}
+          fillOpacity={0.14}
+          stroke="none"
+        />
+      ))}
+
       {/* Glow bloom — wide blurred arc copies */}
       {ARC_DEFS.map(({ key, color }, i) => (
         <path
           key={`g-${key}`}
           ref={(el) => { glowRefs.current[i] = el; }}
           fill="none"
-          stroke={colorMode ? color : MONO}
+        stroke={colorMode ? color : MONO_METRIC_COLOR}
           strokeLinecap="round"
           filter="url(#orb-arc-glow)"
         />
@@ -382,7 +432,7 @@ function OrbMetricsBars2D({ metricsRef, orbSize, colorMode }: OrbMetricsBars2DPr
           key={`c-${key}`}
           ref={(el) => { coreRefs.current[i] = el; }}
           fill="none"
-          stroke={colorMode ? color : MONO}
+        stroke={colorMode ? color : MONO_METRIC_COLOR}
           strokeLinecap="round"
         />
       ))}
@@ -393,7 +443,7 @@ function OrbMetricsBars2D({ metricsRef, orbSize, colorMode }: OrbMetricsBars2DPr
           key={`r-${key}`}
           ref={(el) => { rippleRefs.current[i] = el; }}
           fill="none"
-          stroke={colorMode ? color : MONO}
+        stroke={colorMode ? color : MONO_METRIC_COLOR}
           strokeLinecap="round"
           opacity={0}
         />

--- a/web-next/components/voice/voice-orb.tsx
+++ b/web-next/components/voice/voice-orb.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState, type RefObject } from "react";
 import { OrbFrequencyRing } from "@/components/voice/orb-frequency-ring";
 import { useAudioLevel } from "@/components/voice/use-audio-level";
 import type { OrbEffectsConfig } from "@/components/voice/use-orb-effects-config";
+import type { OrbMetrics } from "@/components/voice/use-orb-metrics";
 
 export type VoiceOrbState =
   | "offline"
@@ -227,6 +228,176 @@ function useOrbParticles() {
   return particles;
 }
 
+// ─── Metrics arcs — 4 quarter-circle arcs floating outward from the orb ──────
+
+const ARC_DEFS = [
+  { key: "cpu" as keyof OrbMetrics, color: "#f97316", startDeg:  45, endDeg: 135 }, // top
+  { key: "gpu" as keyof OrbMetrics, color: "#a855f7", startDeg: -45, endDeg:  45 }, // right
+  { key: "net" as keyof OrbMetrics, color: "#4ade80", startDeg: 225, endDeg: 315 }, // bottom
+  { key: "ram" as keyof OrbMetrics, color: "#22d3ee", startDeg: 135, endDeg: 225 }, // left
+] as const;
+
+function arcPath(cx: number, cy: number, r: number, startDeg: number, endDeg: number): string {
+  const s  = (startDeg * Math.PI) / 180;
+  const e  = (endDeg   * Math.PI) / 180;
+  const x1 = cx + r * Math.cos(s);
+  const y1 = cy - r * Math.sin(s);
+  const x2 = cx + r * Math.cos(e);
+  const y2 = cy - r * Math.sin(e);
+  // sweep-flag=0: counter-clockwise in SVG, draws the short arc through the quadrant centre
+  return `M ${x1.toFixed(2)} ${y1.toFixed(2)} A ${r.toFixed(2)} ${r.toFixed(2)} 0 0 0 ${x2.toFixed(2)} ${y2.toFixed(2)}`;
+}
+
+type OrbMetricsBars2DProps = Readonly<{
+  metricsRef: RefObject<OrbMetrics>;
+  orbSize: number;
+  colorMode: boolean;
+}>;
+
+function OrbMetricsBars2D({ metricsRef, orbSize, colorMode }: OrbMetricsBars2DProps) {
+  const coreRefs   = useRef<Array<SVGPathElement | null>>([null, null, null, null]);
+  const glowRefs   = useRef<Array<SVGPathElement | null>>([null, null, null, null]);
+  const rippleRefs = useRef<Array<SVGPathElement | null>>([null, null, null, null]);
+  const currents   = useRef([0, 0, 0, 0]);
+  const prevRadii  = useRef<number[]>([]);
+  const rippleSt   = useRef([0, 0, 0, 0]);
+
+  useEffect(() => {
+    const cx     = orbSize / 2;
+    const cy     = orbSize / 2;
+    const ORB_R  = orbSize / 2;
+    const MIN_R  = ORB_R * 1.08; // just outside the orb edge
+    const MAX_R  = ORB_R * 1.95; // fully loaded: arcs nearly double the orb radius
+    const PHASES = [0, Math.PI * 0.5, Math.PI, Math.PI * 1.5]; // 90° stagger per arc
+
+    currents.current  = [MIN_R, MIN_R, MIN_R, MIN_R];
+    prevRadii.current = [MIN_R, MIN_R, MIN_R, MIN_R];
+
+    let raf: number;
+
+    const tick = (now: number) => {
+      const t    = now / 1000;
+      const m    = metricsRef.current;
+      const vals = [m.cpu, m.gpu, m.net, m.ram];
+
+      currents.current = currents.current.map((c, i) => {
+        const tgt = MIN_R + ((vals[i] ?? 0) / 100) * (MAX_R - MIN_R);
+        return c + (tgt - c) * 0.06;
+      });
+
+      currents.current.forEach((r, i) => {
+        const def         = ARC_DEFS[i]!;
+        const pct         = Math.max(0, Math.min(1, (r - MIN_R) / (MAX_R - MIN_R)));
+        const breathPhase = t * 2.1 + (PHASES[i] ?? 0);
+        const breathe     = Math.sin(breathPhase);
+        const effR        = r + breathe * orbSize * 0.012;
+        const sw          = 1.8 + 3.8 * pct + breathe * (0.8 + 1.2 * pct);
+        const opa         = 0.35 + 0.65 * pct;
+        const d           = arcPath(cx, cy, Math.max(MIN_R * 0.95, effR), def.startDeg, def.endDeg);
+
+        const core = coreRefs.current[i];
+        if (core) {
+          core.setAttribute("d",            d);
+          core.setAttribute("stroke-width", String(Math.max(1.2, sw).toFixed(2)));
+          core.setAttribute("opacity",      String(opa.toFixed(3)));
+        }
+
+        const glow = glowRefs.current[i];
+        if (glow) {
+          glow.setAttribute("d",            d);
+          glow.setAttribute("stroke-width", String(Math.max(4, sw * 3.5).toFixed(2)));
+          glow.setAttribute("opacity",      String((0.10 + 0.22 * pct).toFixed(3)));
+        }
+
+        // Ripple arc: spawns when radius spikes (load surge)
+        const prev = prevRadii.current[i] ?? MIN_R;
+        const rp   = rippleSt.current[i] ?? 0;
+        if (r - prev > (MAX_R - MIN_R) * 0.06 && pct > 0.15 && rp === 0) {
+          rippleSt.current[i] = 1.0;
+        }
+        prevRadii.current[i] = r;
+
+        const ripple = rippleRefs.current[i];
+        if (ripple) {
+          if (rp > 0) {
+            const rOuter = effR + (1 - rp) * orbSize * 0.28;
+            ripple.setAttribute("d",            arcPath(cx, cy, Math.max(MIN_R, rOuter), def.startDeg, def.endDeg));
+            ripple.setAttribute("stroke-width", "2.0");
+            ripple.setAttribute("opacity",      String((rp * 0.65).toFixed(3)));
+            rippleSt.current[i] = Math.max(0, rp - 0.018);
+          } else {
+            ripple.setAttribute("opacity", "0");
+          }
+        }
+      });
+
+      raf = requestAnimationFrame(tick);
+    };
+
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [metricsRef, orbSize]);
+
+  const MONO = "#6b7280";
+
+  return (
+    <svg
+      style={{
+        position: "absolute",
+        left: "50%",
+        top: "50%",
+        transform: "translate(-50%, -50%)",
+        pointerEvents: "none",
+        overflow: "visible",
+      }}
+      width={orbSize}
+      height={orbSize}
+      aria-hidden="true"
+    >
+      <defs>
+        <filter id="orb-arc-glow" x="-200%" y="-200%" width="500%" height="500%">
+          <feGaussianBlur stdDeviation="4.5" in="SourceGraphic" />
+        </filter>
+      </defs>
+
+      {/* Glow bloom — wide blurred arc copies */}
+      {ARC_DEFS.map(({ key, color }, i) => (
+        <path
+          key={`g-${key}`}
+          ref={(el) => { glowRefs.current[i] = el; }}
+          fill="none"
+          stroke={colorMode ? color : MONO}
+          strokeLinecap="round"
+          filter="url(#orb-arc-glow)"
+        />
+      ))}
+
+      {/* Core arcs */}
+      {ARC_DEFS.map(({ key, color }, i) => (
+        <path
+          key={`c-${key}`}
+          ref={(el) => { coreRefs.current[i] = el; }}
+          fill="none"
+          stroke={colorMode ? color : MONO}
+          strokeLinecap="round"
+        />
+      ))}
+
+      {/* Ripple arcs that expand outward on load surge */}
+      {ARC_DEFS.map(({ key, color }, i) => (
+        <path
+          key={`r-${key}`}
+          ref={(el) => { rippleRefs.current[i] = el; }}
+          fill="none"
+          stroke={colorMode ? color : MONO}
+          strokeLinecap="round"
+          opacity={0}
+        />
+      ))}
+    </svg>
+  );
+}
+
 type VoiceOrbProps = Readonly<{
   state: VoiceOrbState;
   /** Override audio level - used in tests; omit in production (computed internally). */
@@ -238,6 +409,7 @@ type VoiceOrbProps = Readonly<{
   effectsConfig?: OrbEffectsConfig;
   micAnalyserRef?: RefObject<AnalyserNode | null>;
   ttsAnalyserRef?: RefObject<AnalyserNode | null>;
+  metricsRef?: RefObject<OrbMetrics>;
 }>;
 
 export function VoiceOrb({
@@ -250,6 +422,7 @@ export function VoiceOrb({
   effectsConfig,
   micAnalyserRef,
   ttsAnalyserRef,
+  metricsRef,
 }: VoiceOrbProps) {
   const effectiveState: VoiceOrbState = disabled ? "offline" : state;
   const visual = ORB_VISUALS[effectiveState];
@@ -263,6 +436,7 @@ export function VoiceOrb({
     coreTexture: true,
     particles: true,
     stateLabel: true,
+    orbMetricsBars: false,
   };
 
   // Audio level is computed here so the parent does not re-render at 60fps.
@@ -404,6 +578,10 @@ export function VoiceOrb({
               />
             );
           })}
+
+        {cfg.orbMetricsBars && metricsRef && !reducedMotion && (
+          <OrbMetricsBars2D metricsRef={metricsRef} orbSize={ORB_SIZE} colorMode />
+        )}
       </div>
 
       {cfg.stateLabel && (

--- a/web-next/components/voice/voice-orb.tsx
+++ b/web-next/components/voice/voice-orb.tsx
@@ -281,7 +281,7 @@ function OrbMetricsBars2D({ metricsRef, orbSize, colorMode }: OrbMetricsBars2DPr
       const vals = [m.cpu, m.gpu, m.net, m.ram];
 
       currents.current = currents.current.map((c, i) => {
-        const pct = Number.isFinite(vals[i] ?? NaN) ? (vals[i] as number) : 0;
+        const pct = Number.isFinite(vals[i] ?? Number.NaN) ? (vals[i] as number) : 0;
         const tgt = MIN_R + (pct / 100) * (MAX_R - MIN_R);
         return c + (tgt - c) * 0.06;
       });
@@ -289,7 +289,7 @@ function OrbMetricsBars2D({ metricsRef, orbSize, colorMode }: OrbMetricsBars2DPr
       currents.current.forEach((r, i) => {
         const def = ARC_DEFS[i];
         if (!def) return;
-        const pctValue = Number.isFinite(vals[i] ?? NaN) ? (vals[i] as number) : 0;
+        const pctValue = Number.isFinite(vals[i] ?? Number.NaN) ? (vals[i] as number) : 0;
         const loadPct = Math.max(0, Math.min(1, pctValue / 100));
         const pct = Math.max(0, Math.min(1, (r - MIN_R) / (MAX_R - MIN_R)));
         const breathPhase = t * 2.1 + (PHASES[i] ?? 0);

--- a/web-next/components/voice/voice-orb.tsx
+++ b/web-next/components/voice/voice-orb.tsx
@@ -286,14 +286,15 @@ function OrbMetricsBars2D({ metricsRef, orbSize, colorMode }: OrbMetricsBars2DPr
       });
 
       currents.current.forEach((r, i) => {
-        const def         = ARC_DEFS[i]!;
-        const pct         = Math.max(0, Math.min(1, (r - MIN_R) / (MAX_R - MIN_R)));
+        const def = ARC_DEFS[i];
+        if (!def) return;
+        const pct = Math.max(0, Math.min(1, (r - MIN_R) / (MAX_R - MIN_R)));
         const breathPhase = t * 2.1 + (PHASES[i] ?? 0);
-        const breathe     = Math.sin(breathPhase);
-        const effR        = r + breathe * orbSize * 0.012;
-        const sw          = 1.8 + 3.8 * pct + breathe * (0.8 + 1.2 * pct);
-        const opa         = 0.35 + 0.65 * pct;
-        const d           = arcPath(cx, cy, Math.max(MIN_R * 0.95, effR), def.startDeg, def.endDeg);
+        const breathe = Math.sin(breathPhase);
+        const effR = r + breathe * orbSize * 0.012;
+        const sw = 1.8 + 3.8 * pct + breathe * (0.8 + 1.2 * pct);
+        const opa = 0.35 + 0.65 * pct;
+        const d = arcPath(cx, cy, Math.max(MIN_R * 0.95, effR), def.startDeg, def.endDeg);
 
         const core = coreRefs.current[i];
         if (core) {
@@ -306,14 +307,14 @@ function OrbMetricsBars2D({ metricsRef, orbSize, colorMode }: OrbMetricsBars2DPr
         if (glow) {
           glow.setAttribute("d",            d);
           glow.setAttribute("stroke-width", String(Math.max(4, sw * 3.5).toFixed(2)));
-          glow.setAttribute("opacity",      String((0.10 + 0.22 * pct).toFixed(3)));
+          glow.setAttribute("opacity",      String((0.1 + 0.22 * pct).toFixed(3)));
         }
 
         // Ripple arc: spawns when radius spikes (load surge)
         const prev = prevRadii.current[i] ?? MIN_R;
         const rp   = rippleSt.current[i] ?? 0;
         if (r - prev > (MAX_R - MIN_R) * 0.06 && pct > 0.15 && rp === 0) {
-          rippleSt.current[i] = 1.0;
+          rippleSt.current[i] = 1;
         }
         prevRadii.current[i] = r;
 
@@ -322,7 +323,7 @@ function OrbMetricsBars2D({ metricsRef, orbSize, colorMode }: OrbMetricsBars2DPr
           if (rp > 0) {
             const rOuter = effR + (1 - rp) * orbSize * 0.28;
             ripple.setAttribute("d",            arcPath(cx, cy, Math.max(MIN_R, rOuter), def.startDeg, def.endDeg));
-            ripple.setAttribute("stroke-width", "2.0");
+            ripple.setAttribute("stroke-width", "2");
             ripple.setAttribute("opacity",      String((rp * 0.65).toFixed(3)));
             rippleSt.current[i] = Math.max(0, rp - 0.018);
           } else {

--- a/web-next/components/voice/voice-orb.tsx
+++ b/web-next/components/voice/voice-orb.tsx
@@ -281,19 +281,22 @@ function OrbMetricsBars2D({ metricsRef, orbSize, colorMode }: OrbMetricsBars2DPr
       const vals = [m.cpu, m.gpu, m.net, m.ram];
 
       currents.current = currents.current.map((c, i) => {
-        const tgt = MIN_R + ((vals[i] ?? 0) / 100) * (MAX_R - MIN_R);
+        const pct = Number.isFinite(vals[i] ?? NaN) ? (vals[i] as number) : 0;
+        const tgt = MIN_R + (pct / 100) * (MAX_R - MIN_R);
         return c + (tgt - c) * 0.06;
       });
 
       currents.current.forEach((r, i) => {
         const def = ARC_DEFS[i];
         if (!def) return;
+        const pctValue = Number.isFinite(vals[i] ?? NaN) ? (vals[i] as number) : 0;
+        const loadPct = Math.max(0, Math.min(1, pctValue / 100));
         const pct = Math.max(0, Math.min(1, (r - MIN_R) / (MAX_R - MIN_R)));
         const breathPhase = t * 2.1 + (PHASES[i] ?? 0);
         const breathe = Math.sin(breathPhase);
         const effR = r + breathe * orbSize * 0.012;
         const sw = 1.8 + 3.8 * pct + breathe * (0.8 + 1.2 * pct);
-        const opa = 0.35 + 0.65 * pct;
+        const opa = 0.35 + 0.65 * Math.max(pct, loadPct);
         const d = arcPath(cx, cy, Math.max(MIN_R * 0.95, effR), def.startDeg, def.endDeg);
 
         const core = coreRefs.current[i];
@@ -307,13 +310,13 @@ function OrbMetricsBars2D({ metricsRef, orbSize, colorMode }: OrbMetricsBars2DPr
         if (glow) {
           glow.setAttribute("d",            d);
           glow.setAttribute("stroke-width", String(Math.max(4, sw * 3.5).toFixed(2)));
-          glow.setAttribute("opacity",      String((0.1 + 0.22 * pct).toFixed(3)));
+          glow.setAttribute("opacity",      String((0.1 + 0.22 * Math.max(pct, loadPct)).toFixed(3)));
         }
 
         // Ripple arc: spawns when radius spikes (load surge)
         const prev = prevRadii.current[i] ?? MIN_R;
         const rp   = rippleSt.current[i] ?? 0;
-        if (r - prev > (MAX_R - MIN_R) * 0.06 && pct > 0.15 && rp === 0) {
+        if (r - prev > (MAX_R - MIN_R) * 0.06 && Math.max(pct, loadPct) > 0.15 && rp === 0) {
           rippleSt.current[i] = 1;
         }
         prevRadii.current[i] = r;

--- a/web-next/components/voice/voice-status-sidebar.tsx
+++ b/web-next/components/voice/voice-status-sidebar.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import type { VoiceStatusUpdate } from "@/components/voice/voice-command-center";
+
+type VoiceStatusSidebarProps = Readonly<{
+  status: VoiceStatusUpdate | null;
+}>;
+
+function getProbeTone(status?: string | null): "success" | "warning" | "danger" | "neutral" {
+  if (status === "verified") return "success";
+  if (status === "failed") return "danger";
+  if (status === "metadata_only") return "warning";
+  return "neutral";
+}
+
+function ReadyDot({ ready }: { ready?: boolean | null }) {
+  return (
+    <span
+      className={`inline-block h-1.5 w-1.5 rounded-full ${ready ? "bg-emerald-400" : "bg-zinc-600"}`}
+    />
+  );
+}
+
+function Row({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-2 py-1 border-b border-white/[0.04] last:border-0">
+      <span className="text-caption shrink-0">{label}</span>
+      <span className="text-white text-right truncate max-w-[60%]">{value}</span>
+    </div>
+  );
+}
+
+export function VoiceStatusSidebar({ status }: VoiceStatusSidebarProps) {
+  if (!status) {
+    return (
+      <div className="space-y-3">
+        <StatusCard title="STT / TTS">
+          <p className="text-hint text-xs py-2">Oczekiwanie na połączenie…</p>
+        </StatusCard>
+        <StatusCard title="Runtime">
+          <p className="text-hint text-xs py-2">Brak danych</p>
+        </StatusCard>
+      </div>
+    );
+  }
+
+  const runtime = status.runtime_snapshot;
+  const pipeline = runtime?.voice_pipeline;
+  const caps = runtime?.runtime_capabilities;
+  const probeStatus = caps?.probe_status;
+  const deps = status.dependencies ?? {};
+  const depKeys = Object.keys(deps);
+
+  return (
+    <div className="space-y-3">
+      {/* STT / TTS box */}
+      <StatusCard title="STT / TTS">
+        <Row
+          label="STT"
+          value={
+            <span className="flex items-center gap-1.5">
+              <ReadyDot ready={status.stt_ready} />
+              <span>{status.whisper_model_size ?? status.stt_backend ?? "—"}</span>
+            </span>
+          }
+        />
+        <Row
+          label="TTS"
+          value={
+            <span className="flex items-center gap-1.5">
+              <ReadyDot ready={status.tts_ready} />
+              <span>
+                {status.tts_backend ?? "—"}
+                {status.tts_fallback ? " (fallback)" : ""}
+              </span>
+            </span>
+          }
+        />
+        {status.vad_threshold != null && (
+          <Row label="VAD" value={status.vad_threshold} />
+        )}
+        {depKeys.length > 0 && (
+          <Row
+            label="Zależności"
+            value={
+              <span className="flex flex-wrap gap-x-2 gap-y-0.5 justify-end">
+                {depKeys.map((k) => (
+                  <span key={k} className={`text-[10px] ${deps[k] ? "text-emerald-400" : "text-rose-400"}`}>
+                    {k}
+                  </span>
+                ))}
+              </span>
+            }
+          />
+        )}
+      </StatusCard>
+
+      {/* Runtime box */}
+      <StatusCard title="Runtime">
+        {runtime ? (
+          <>
+            <div className="flex items-center justify-between gap-2 mb-2">
+              <span className="text-sm font-semibold text-white truncate">
+                {runtime.model_name ?? "—"}
+              </span>
+              {probeStatus && (
+                <Badge tone={getProbeTone(probeStatus)} className="shrink-0 text-[10px]">
+                  {probeStatus}
+                </Badge>
+              )}
+            </div>
+            {runtime.provider && (
+              <Row label="Provider" value={runtime.provider} />
+            )}
+            {caps?.compatibility_profile && (
+              <Row label="Profil" value={caps.compatibility_profile} />
+            )}
+            {pipeline?.stt && <Row label="STT" value={pipeline.stt} />}
+            {pipeline?.reasoning && <Row label="Reasoning" value={pipeline.reasoning} />}
+            {pipeline?.tts && <Row label="TTS" value={pipeline.tts} />}
+            {runtime.error && (
+              <p className="mt-1 text-[11px] text-rose-300">{runtime.error}</p>
+            )}
+          </>
+        ) : (
+          <p className="text-hint text-xs py-2">Brak snapshot runtime</p>
+        )}
+      </StatusCard>
+    </div>
+  );
+}
+
+function StatusCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-2xl border border-white/[0.07] bg-white/[0.03] p-3 text-xs text-zinc-300">
+      <p className="eyebrow mb-2">{title}</p>
+      {children}
+    </div>
+  );
+}

--- a/web-next/components/voice/voice-status-sidebar.tsx
+++ b/web-next/components/voice/voice-status-sidebar.tsx
@@ -2,6 +2,7 @@
 
 import { Badge } from "@/components/ui/badge";
 import type { VoiceStatusUpdate } from "@/components/voice/voice-command-center";
+import { useTranslation } from "@/lib/i18n";
 
 type VoiceStatusSidebarProps = Readonly<{
   status: VoiceStatusUpdate | null;
@@ -32,14 +33,16 @@ function Row({ label, value }: Readonly<{ label: string; value: React.ReactNode 
 }
 
 export function VoiceStatusSidebar({ status }: VoiceStatusSidebarProps) {
+  const t = useTranslation();
+
   if (!status) {
     return (
       <div className="space-y-3">
-        <StatusCard title="STT / TTS">
-          <p className="text-hint text-xs py-2">Oczekiwanie na połączenie…</p>
+        <StatusCard title={`${t("voice.controls.stt")} / ${t("voice.controls.tts")}`}>
+          <p className="text-hint text-xs py-2">{t("voice.status.channelConnecting")}</p>
         </StatusCard>
-        <StatusCard title="Runtime">
-          <p className="text-hint text-xs py-2">Brak danych</p>
+        <StatusCard title={t("voice.controls.runtime")}>
+          <p className="text-hint text-xs py-2">{t("voice.status.noData")}</p>
         </StatusCard>
       </div>
     );
@@ -55,9 +58,9 @@ export function VoiceStatusSidebar({ status }: VoiceStatusSidebarProps) {
   return (
     <div className="space-y-3">
       {/* STT / TTS box */}
-      <StatusCard title="STT / TTS">
+      <StatusCard title={`${t("voice.controls.stt")} / ${t("voice.controls.tts")}`}>
         <Row
-          label="STT"
+          label={t("voice.controls.stt")}
           value={
             <span className="flex items-center gap-1.5">
               <ReadyDot ready={status.stt_ready} />
@@ -66,27 +69,30 @@ export function VoiceStatusSidebar({ status }: VoiceStatusSidebarProps) {
           }
         />
         <Row
-          label="TTS"
+          label={t("voice.controls.tts")}
           value={
             <span className="flex items-center gap-1.5">
               <ReadyDot ready={status.tts_ready} />
               <span>
                 {status.tts_backend ?? "—"}
-                {status.tts_fallback ? " (fallback)" : ""}
+                {status.tts_fallback ? ` (${t("voice.controls.ttsFallback")})` : ""}
               </span>
             </span>
           }
         />
         {status.vad_threshold != null && (
-          <Row label="VAD" value={status.vad_threshold} />
+          <Row label={t("voice.controls.vad")} value={status.vad_threshold} />
         )}
         {depKeys.length > 0 && (
           <Row
-            label="Zależności"
+            label={t("voice.controls.dependencies")}
             value={
               <span className="flex flex-wrap gap-x-2 gap-y-0.5 justify-end">
                 {depKeys.map((k) => (
-                  <span key={k} className={`text-[10px] ${deps[k] ? "text-emerald-400" : "text-rose-400"}`}>
+                  <span
+                    key={k}
+                    className={`text-[10px] ${deps[k] ? "text-emerald-400" : "text-rose-400"}`}
+                  >
                     {k}
                   </span>
                 ))}
@@ -97,12 +103,12 @@ export function VoiceStatusSidebar({ status }: VoiceStatusSidebarProps) {
       </StatusCard>
 
       {/* Runtime box */}
-      <StatusCard title="Runtime">
+      <StatusCard title={t("voice.controls.runtime")}>
         {runtime ? (
           <>
             <div className="flex items-center justify-between gap-2 mb-2">
               <span className="text-sm font-semibold text-white truncate">
-                {runtime.model_name ?? "—"}
+                {runtime.model_name ?? t("voice.controls.unknownModel")}
               </span>
               {probeStatus && (
                 <Badge tone={getProbeTone(probeStatus)} className="shrink-0 text-[10px]">
@@ -111,20 +117,20 @@ export function VoiceStatusSidebar({ status }: VoiceStatusSidebarProps) {
               )}
             </div>
             {runtime.provider && (
-              <Row label="Provider" value={runtime.provider} />
+              <Row label={t("voice.controls.provider")} value={runtime.provider} />
             )}
             {caps?.compatibility_profile && (
-              <Row label="Profil" value={caps.compatibility_profile} />
+              <Row label={t("voice.controls.profile")} value={caps.compatibility_profile} />
             )}
-            {pipeline?.stt && <Row label="STT" value={pipeline.stt} />}
-            {pipeline?.reasoning && <Row label="Reasoning" value={pipeline.reasoning} />}
-            {pipeline?.tts && <Row label="TTS" value={pipeline.tts} />}
+            {pipeline?.stt && <Row label={t("voice.controls.stt")} value={pipeline.stt} />}
+            {pipeline?.reasoning && <Row label={t("voice.controls.pipeline")} value={pipeline.reasoning} />}
+            {pipeline?.tts && <Row label={t("voice.controls.tts")} value={pipeline.tts} />}
             {runtime.error && (
               <p className="mt-1 text-[11px] text-rose-300">{runtime.error}</p>
             )}
           </>
         ) : (
-          <p className="text-hint text-xs py-2">Brak snapshot runtime</p>
+          <p className="text-hint text-xs py-2">{t("voice.controls.noRuntimeSnapshot")}</p>
         )}
       </StatusCard>
     </div>

--- a/web-next/components/voice/voice-status-sidebar.tsx
+++ b/web-next/components/voice/voice-status-sidebar.tsx
@@ -14,7 +14,7 @@ function getProbeTone(status?: string | null): "success" | "warning" | "danger" 
   return "neutral";
 }
 
-function ReadyDot({ ready }: { ready?: boolean | null }) {
+function ReadyDot({ ready }: Readonly<{ ready?: boolean | null }>) {
   return (
     <span
       className={`inline-block h-1.5 w-1.5 rounded-full ${ready ? "bg-emerald-400" : "bg-zinc-600"}`}
@@ -22,7 +22,7 @@ function ReadyDot({ ready }: { ready?: boolean | null }) {
   );
 }
 
-function Row({ label, value }: { label: string; value: React.ReactNode }) {
+function Row({ label, value }: Readonly<{ label: string; value: React.ReactNode }>) {
   return (
     <div className="flex items-center justify-between gap-2 py-1 border-b border-white/[0.04] last:border-0">
       <span className="text-caption shrink-0">{label}</span>
@@ -134,10 +134,10 @@ export function VoiceStatusSidebar({ status }: VoiceStatusSidebarProps) {
 function StatusCard({
   title,
   children,
-}: {
+}: Readonly<{
   title: string;
   children: React.ReactNode;
-}) {
+}>) {
   return (
     <div className="rounded-2xl border border-white/[0.07] bg-white/[0.03] p-3 text-xs text-zinc-300">
       <p className="eyebrow mb-2">{title}</p>

--- a/web-next/lib/i18n/locales/voice/de.ts
+++ b/web-next/lib/i18n/locales/voice/de.ts
@@ -13,6 +13,7 @@ export const voice = {
     replay: "Wiederholen",
     refresh: "Aktualisieren",
     refreshing: "Wird aktualisiert…",
+    diagnostics: "Dev-Diagnose",
     pushToTalk: "Gedrückt halten und sprechen",
     recording: "Aufnahme läuft...",
     voiceChat: "Sprachchat",

--- a/web-next/lib/i18n/locales/voice/en.ts
+++ b/web-next/lib/i18n/locales/voice/en.ts
@@ -13,6 +13,7 @@ export const voice = {
     replay: "Replay",
     refresh: "Refresh",
     refreshing: "Refreshing…",
+    diagnostics: "Dev diagnostics",
     pushToTalk: "Hold to talk",
     recording: "Recording...",
     voiceChat: "Voice chat",

--- a/web-next/lib/i18n/locales/voice/pl.ts
+++ b/web-next/lib/i18n/locales/voice/pl.ts
@@ -13,6 +13,7 @@ export const voice = {
     replay: "Odtwórz",
     refresh: "Odśwież",
     refreshing: "Odświeżam…",
+    diagnostics: "Diagnostyka dev",
     pushToTalk: "Przytrzymaj i mów",
     recording: "Nagrywanie...",
     voiceChat: "Czat głosowy",

--- a/web-next/package-lock.json
+++ b/web-next/package-lock.json
@@ -13,6 +13,9 @@
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
+        "@react-three/drei": "^10.7.7",
+        "@react-three/fiber": "^9.6.1",
+        "@react-three/postprocessing": "^3.0.4",
         "@xyflow/react": "^12.10.0",
         "chart.js": "^4.5.1",
         "clsx": "^2.1.1",
@@ -29,7 +32,8 @@
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-zoom-pan-pinch": "^3.7.0",
-        "tailwind-merge": "^3.4.0"
+        "tailwind-merge": "^3.4.0",
+        "three": "^0.184.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -41,6 +45,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/three": "^0.184.1",
         "eslint": "^9",
         "eslint-config-next": "^16.1.6",
         "jsdom": "^28.1.0",
@@ -357,7 +362,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -591,6 +595,12 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.7.1",
@@ -1782,12 +1792,30 @@
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="
     },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@mermaid-js/parser": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.0.0.tgz",
       "integrity": "sha512-vvK0Hi/VWndxoh03Mmz6wa1KDriSPjS2XMZL/1l19HFwygiObEEoEwSDxOqyLzzAI6J2PU3261JjTMTO7x+BPw==",
       "dependencies": {
         "langium": "^4.0.0"
+      }
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -2688,6 +2716,184 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@react-three/drei": {
+      "version": "10.7.7",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.7.tgz",
+      "integrity": "sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^3.1.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.8.3",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.4",
+        "tunnel-rat": "^0.1.2",
+        "use-sync-external-store": "^1.4.0",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^9.0.0",
+        "react": "^19",
+        "react-dom": "^19",
+        "three": ">=0.159"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/drei/node_modules/zustand": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
+      "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.27.0",
+        "suspend-react": "^0.1.3",
+        "use-sync-external-store": "^1.4.0",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=19 <19.3",
+        "react-dom": ">=19 <19.3",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@react-three/fiber/node_modules/zustand": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/postprocessing": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@react-three/postprocessing/-/postprocessing-3.0.4.tgz",
+      "integrity": "sha512-e4+F5xtudDYvhxx3y0NtWXpZbwvQ0x1zdOXWTbXMK6fFLVDd4qucN90YaaStanZGS4Bd5siQm0lGL/5ogf8iDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "maath": "^0.6.0",
+        "n8ao": "^1.9.4",
+        "postprocessing": "^6.36.6"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^9.0.0",
+        "react": "^19.0",
+        "three": ">= 0.156.0"
+      }
+    },
+    "node_modules/@react-three/postprocessing/node_modules/maath": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.6.0.tgz",
+      "integrity": "sha512-dSb2xQuP7vDnaYqfoKzlApeRcR2xtN8/f7WV/TMAkBC8552TwTLtOO0JTcSygkYMjNDPoo6V01jTw/aPi4JrMw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.144.0",
+        "three": ">=0.144.0"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3076,6 +3282,12 @@
         }
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -3328,6 +3540,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3360,11 +3578,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
-      "devOptional": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3378,11 +3601,46 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.184.1",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.1.tgz",
+      "integrity": "sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "optional": true
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.0",
@@ -3901,6 +4159,24 @@
         "win32"
       ]
     },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
+    },
     "node_modules/@xyflow/react": {
       "version": "12.10.0",
       "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.0.tgz",
@@ -4236,6 +4512,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -4251,7 +4547,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -4312,6 +4607,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -4366,6 +4685,19 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camera-controls": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.0.tgz",
+      "integrity": "sha512-w5oULNpijgTRH0ARFJJ0R5ct1nUM3R3WP7/b8A6j9uTGpRfnsypc/RBMPQV8JQDPayUe37p/TZZY1PcUr4czOQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.11.0",
+        "npm": ">=10.8.2"
+      },
+      "peerDependencies": {
+        "three": ">=0.126.1"
       }
     },
     "node_modules/caniuse-lite": {
@@ -4508,11 +4840,28 @@
         "layout-base": "^1.0.0"
       }
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4565,8 +4914,7 @@
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
     },
     "node_modules/cytoscape": {
       "version": "3.33.1",
@@ -5188,6 +5536,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -5229,6 +5586,12 @@
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5997,6 +6360,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -6281,6 +6650,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -6415,6 +6790,12 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -6467,6 +6848,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -6475,6 +6876,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -6767,6 +7174,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -6912,8 +7325,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
@@ -6930,6 +7342,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
       }
     },
     "node_modules/jiti": {
@@ -7144,6 +7568,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -7466,6 +7899,16 @@
         "lz-string": "bin/bin.js"
       }
     },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -7538,6 +7981,21 @@
         "uuid": "^11.1.0"
       }
     },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "license": "MIT"
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -7601,6 +8059,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
+    },
+    "node_modules/n8ao": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/n8ao/-/n8ao-1.10.1.tgz",
+      "integrity": "sha512-hhI1pC+BfOZBV1KMwynBrVlIm8wqLxj/abAWhF2nZ0qQKyzTSQa1QtLVS2veRiuoBQXojxobcnp0oe+PUoxf/w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "postprocessing": ">=6.30.0",
+        "three": ">=0.137"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -7952,7 +8420,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -8076,6 +8543,21 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postprocessing": {
+      "version": "6.39.1",
+      "resolved": "https://registry.npmjs.org/postprocessing/-/postprocessing-6.39.1.tgz",
+      "integrity": "sha512-R2dG2zy+BAx3USl5EHw+PvnrlbT5PKnZVp3se0HCR0pWH8WQdh742yNG4YWOsq6c0bFpffk0Gd2RqPeoP/wKng==",
+      "license": "Zlib",
+      "peerDependencies": {
+        "three": ">= 0.168.0 < 0.185.0"
+      }
+    },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -8119,6 +8601,16 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
+      }
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -8251,6 +8743,21 @@
         }
       }
     },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-zoom-pan-pinch": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/react-zoom-pan-pinch/-/react-zoom-pan-pinch-3.7.0.tgz",
@@ -8310,7 +8817,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8589,7 +9095,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -8601,7 +9106,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -8691,6 +9195,32 @@
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true
+    },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -8884,6 +9414,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -8927,6 +9466,44 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.8.3.tgz",
+      "integrity": "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.0.2",
@@ -9039,6 +9616,36 @@
         "node": ">=20"
       }
     },
+    "node_modules/troika-three-text": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.4",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
@@ -9107,6 +9714,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
       }
     },
     "node_modules/type-check": {
@@ -9393,6 +10009,15 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/uuid": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
@@ -9461,6 +10086,17 @@
         "node": ">=18"
       }
     },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
+    },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -9500,7 +10136,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },

--- a/web-next/package-lock.json
+++ b/web-next/package-lock.json
@@ -29,6 +29,7 @@
         "marked": "15.0.12",
         "mermaid": "^11.12.3",
         "next": "^16.1.6",
+        "postprocessing": "^6.39.1",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-zoom-pan-pinch": "^3.7.0",
@@ -56,7 +57,7 @@
         "typescript": "^5"
       },
       "engines": {
-        "node": ">=20.9.0",
+        "node": ">=20.11.0",
         "npm": ">=10.0.0"
       }
     },

--- a/web-next/package.json
+++ b/web-next/package.json
@@ -3,7 +3,7 @@
   "version": "1.8.0",
   "private": true,
   "engines": {
-    "node": ">=20.9.0",
+    "node": ">=20.11.0",
     "npm": ">=10.0.0"
   },
   "scripts": {
@@ -62,6 +62,7 @@
     "marked": "15.0.12",
     "mermaid": "^11.12.3",
     "next": "^16.1.6",
+    "postprocessing": "^6.39.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-zoom-pan-pinch": "^3.7.0",

--- a/web-next/package.json
+++ b/web-next/package.json
@@ -46,6 +46,9 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.6.1",
+    "@react-three/postprocessing": "^3.0.4",
     "@xyflow/react": "^12.10.0",
     "chart.js": "^4.5.1",
     "clsx": "^2.1.1",
@@ -62,7 +65,8 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-zoom-pan-pinch": "^3.7.0",
-    "tailwind-merge": "^3.4.0"
+    "tailwind-merge": "^3.4.0",
+    "three": "^0.184.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -74,6 +78,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/three": "^0.184.1",
     "eslint": "^9",
     "eslint-config-next": "^16.1.6",
     "jsdom": "^28.1.0",


### PR DESCRIPTION
# [codex] voice screen redesign 3d and react-three orb stack

## What changed
- Moved the voice orb stack toward a dedicated `react-three` path in `VoiceOrb3D` and kept the CSS orb as fallback.
- Added orb metrics plumbing via `use-orb-metrics.ts` and wired the voice UI to use the new state/metrics flow.
- Tightened the orb dialog, zone, and command-center wiring around the new visual stack.
- Added `net_usage_percent` to backend model metrics.
- Updated EN/PL documentation to describe `/voice`, the `react-three` orb stack, and the relevant frontend scripts/tests.

## Why
- The branch already renders the voice experience as a dedicated orbital UI system, not a loose widget, so the code and docs needed to match the actual architecture.
- The docs now point to the real frontend scripts and the voice smoke test that cover this surface.

## Validation
- `make pr-fast`
- Frontend gate passed: lint + `test:unit:ci-lite`
