### PR TITLE
[codex] PR 210 Gemma 4 native audio runtime service

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -93,6 +93,26 @@ VLLM_START_COMMAND=bash ./scripts/llm/vllm_service.sh start
 VLLM_STOP_COMMAND=bash ./scripts/llm/vllm_service.sh stop
 VLLM_RESTART_COMMAND=bash ./scripts/llm/vllm_service.sh restart
 
+# Gemma 4 Audio Native Runtime Service (eksperymentalnie)
+GEMMA4_AUDIO_ENABLED=false
+GEMMA4_AUDIO_MODEL_ID=google/gemma-4-E2B-it
+GEMMA4_AUDIO_ENDPOINT=http://localhost:8014/v1
+GEMMA4_AUDIO_HOST=127.0.0.1
+GEMMA4_AUDIO_PORT=8014
+GEMMA4_AUDIO_CACHE_DIR=models_cache/hf
+GEMMA4_AUDIO_DEVICE=auto
+GEMMA4_AUDIO_MAX_NEW_TOKENS=128
+GEMMA4_AUDIO_MAX_CONCURRENCY=1
+GEMMA4_AUDIO_STARTUP_TIMEOUT_SECONDS=600
+GEMMA4_AUDIO_START_COMMAND=bash ./scripts/llm/gemma4_audio_service.sh start
+GEMMA4_AUDIO_STOP_COMMAND=bash ./scripts/llm/gemma4_audio_service.sh stop
+GEMMA4_AUDIO_RESTART_COMMAND=bash ./scripts/llm/gemma4_audio_service.sh restart
+GEMMA4_AUDIO_SUPPORTS_AUDIO=true
+GEMMA4_AUDIO_SUPPORTS_TEXT=true
+GEMMA4_AUDIO_LOG_PATH=logs/gemma4_audio_service.log
+GEMMA4_AUDIO_PID_PATH=.venom_runtime/gemma4_audio.pid
+LAST_MODEL_GEMMA4_AUDIO=google/gemma-4-E2B-it
+
 # Wspólny profil generacji (vLLM + Ollama)
 MODEL_GENERATION_OVERRIDES={"vllm":{"gemma-3-4b-it":{"temperature":0.3,"top_p":0.9,"max_tokens":800}},"ollama":{"gemma3:4b":{"temperature":0.3,"top_p":0.9,"num_predict":800,"num_ctx":1024}}}
 # Strategia streszczeń: llm_with_fallback lub heuristic_only

--- a/config/pytest-groups/fast.txt
+++ b/config/pytest-groups/fast.txt
@@ -11,6 +11,9 @@ tests/api/test_memory_openapi_contract.py
 tests/api/test_system_api.py
 tests/api/test_system_api_dynamic.py
 tests/security/test_autonomy_enforcement.py
+tests/test_204a_canonical_control_state.py
+tests/test_academy_202c_signing_coverage.py
+tests/test_academy_202d_lora_onnx_deploy.py
 tests/test_academy_adapter_runtime_service.py
 tests/test_academy_api.py
 tests/test_academy_api_contracts.py
@@ -18,6 +21,7 @@ tests/test_academy_api_dataset_edge_cases.py
 tests/test_academy_api_dataset_routes.py
 tests/test_academy_api_edges_contract.py
 tests/test_academy_conversion_contracts.py
+tests/test_academy_conversion_light_coverage.py
 tests/test_academy_dataset_conversion.py
 tests/test_academy_file_resolution_service.py
 tests/test_academy_history_module.py
@@ -27,6 +31,7 @@ tests/test_academy_route_helpers_modules.py
 tests/test_academy_self_learning_routes.py
 tests/test_academy_self_learning_service.py
 tests/test_academy_training_service.py
+tests/test_adapter_audit_service.py
 tests/test_admin_audit.py
 tests/test_agent_improvements.py
 tests/test_agents.py
@@ -46,7 +51,6 @@ tests/test_architect_agent.py
 tests/test_artifact_strategy.py
 tests/test_assistant_skill.py
 tests/test_audio_engine.py
-tests/test_audio_smoke_script.py
 tests/test_audio_stream_handler_roi.py
 tests/test_audit_stream_api.py
 tests/test_audit_stream_service.py
@@ -56,6 +60,7 @@ tests/test_benchmark_routes_guard.py
 tests/test_benchmark_service.py
 tests/test_benchmark_service_activation.py
 tests/test_benchmark_service_runtime_selection.py
+tests/test_boot_id.py
 tests/test_bootstrap_routes_contracts.py
 tests/test_bootstrap_runtime_stack_modules.py
 tests/test_brain_graph_view_modes.py
@@ -120,6 +125,7 @@ tests/test_ensure_env_file_script.py
 tests/test_env_audit.py
 tests/test_env_cleanup.py
 tests/test_env_contract_sh.py
+tests/test_env_contracts.py
 tests/test_env_report_diff.py
 tests/test_environment_policy.py
 tests/test_error_mappings.py
@@ -140,6 +146,7 @@ tests/test_forge_flow.py
 tests/test_generation_params_adapter.py
 tests/test_generation_schema.py
 tests/test_ghost_agent.py
+tests/test_ghost_agent_hil.py
 tests/test_git_routes_logic.py
 tests/test_git_skill.py
 tests/test_git_skill_roi.py
@@ -193,6 +200,7 @@ tests/test_knowledge_hygiene.py
 tests/test_knowledge_hygiene_api.py
 tests/test_knowledge_ttl.py
 tests/test_launchpad_agents.py
+tests/test_learning.py
 tests/test_learning_logs.py
 tests/test_lessons_governance.py
 tests/test_lessons_manager.py
@@ -284,6 +292,7 @@ tests/test_platform_skill.py
 tests/test_policy_autonomy_contract.py
 tests/test_policy_engine.py
 tests/test_policy_gate.py
+tests/test_policy_gate_runtime_contract.py
 tests/test_port_authority.py
 tests/test_port_pids_script.py
 tests/test_preprod_mutation_guards.py

--- a/config/pytest-groups/long.txt
+++ b/config/pytest-groups/long.txt
@@ -8,13 +8,13 @@ tests/ollama_bench/test_scheduler.py
 tests/test_agents_release_integration_contracts.py
 tests/test_agents_routes_integration_regression.py
 tests/test_architecture_contracts_guard.py
+tests/test_audio_smoke_script.py
 tests/test_audit_lite_deps.py
 tests/test_browser_skill.py
 tests/test_external_discovery_integration.py
 tests/test_file_operations_integration.py
 tests/test_forge_integration.py
 tests/test_generation_params_integration.py
-tests/test_ghost_agent_hil.py
 tests/test_knowledge_memory_tasks_integration.py
 tests/test_lesson_management_api.py
 tests/test_motor_cortex_integration.py

--- a/config/testing/test_catalog.json
+++ b/config/testing/test_catalog.json
@@ -53,7 +53,7 @@
   "tests": [
     {
       "path": "tests/api/test_academy_openapi_contract.py",
-      "domain": "core",
+      "domain": "api",
       "test_type": "route_contract",
       "intent": "contract",
       "primary_lane": "release",
@@ -65,7 +65,7 @@
     },
     {
       "path": "tests/api/test_memory_api_pruning.py",
-      "domain": "core",
+      "domain": "api",
       "test_type": "route_contract",
       "intent": "contract",
       "primary_lane": "release",
@@ -298,13 +298,14 @@
     },
     {
       "path": "tests/test_204a_canonical_control_state.py",
-      "domain": "workflow",
-      "test_type": "route_contract",
+      "domain": "runtime",
+      "test_type": "service_contract",
       "intent": "contract",
       "primary_lane": "new-code",
       "allowed_lanes": [
         "new-code",
-        "ci-lite"
+        "ci-lite",
+        "release"
       ],
       "legacy_targeted": false,
       "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
@@ -312,14 +313,16 @@
     {
       "path": "tests/test_academy_202c_signing_coverage.py",
       "domain": "academy",
-      "test_type": "gate",
-      "intent": "legacy_coverage",
+      "test_type": "route_contract",
+      "intent": "contract",
       "primary_lane": "new-code",
       "allowed_lanes": [
-        "new-code"
+        "new-code",
+        "ci-lite",
+        "release"
       ],
       "legacy_targeted": true,
-      "rationale": "202C signing/coverage PR gate kept in fast-lane new-code checks only."
+      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
     },
     {
       "path": "tests/test_academy_202d_lora_onnx_deploy.py",
@@ -328,10 +331,12 @@
       "intent": "contract",
       "primary_lane": "new-code",
       "allowed_lanes": [
-        "new-code"
+        "new-code",
+        "ci-lite",
+        "release"
       ],
       "legacy_targeted": false,
-      "rationale": "202D ONNX direct deploy contract/regression coverage for new-code lane."
+      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
     },
     {
       "path": "tests/test_academy_adapter_runtime_service.py",
@@ -439,10 +444,11 @@
       "primary_lane": "ci-lite",
       "allowed_lanes": [
         "ci-lite",
-        "new-code"
+        "new-code",
+        "release"
       ],
       "legacy_targeted": true,
-      "rationale": "Fast deterministic regression check used by mandatory CI-lite and Sonar new-code lanes."
+      "rationale": "Fast deterministic regression check used by mandatory CI-lite lane."
     },
     {
       "path": "tests/test_academy_dataset_conversion.py",
@@ -576,10 +582,11 @@
       "primary_lane": "new-code",
       "allowed_lanes": [
         "new-code",
-        "ci-lite"
+        "ci-lite",
+        "release"
       ],
       "legacy_targeted": false,
-      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane and CI-lite routing."
+      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
     },
     {
       "path": "tests/test_admin_audit.py",
@@ -836,7 +843,7 @@
     },
     {
       "path": "tests/test_artifact_strategy.py",
-      "domain": "core",
+      "domain": "environment",
       "test_type": "unit",
       "intent": "regression",
       "primary_lane": "release",
@@ -876,35 +883,21 @@
     },
     {
       "path": "tests/test_audio_smoke_script.py",
-      "domain": "misc",
-      "test_type": "unit",
-      "intent": "regression",
+      "domain": "runtime",
+      "test_type": "gate",
+      "intent": "gate",
       "primary_lane": "new-code",
       "allowed_lanes": [
         "new-code",
         "ci-lite",
         "release"
       ],
-      "legacy_targeted": false,
-      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
+      "legacy_targeted": true,
+      "rationale": "Audio runtime validation for Gemma 4 service; legacy targeted for expanded coverage."
     },
     {
       "path": "tests/test_audio_stream_handler_roi.py",
-      "domain": "core",
-      "test_type": "unit",
-      "intent": "regression",
-      "primary_lane": "new-code",
-      "allowed_lanes": [
-        "new-code",
-        "ci-lite",
-        "release"
-      ],
-      "legacy_targeted": false,
-      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
-    },
-    {
-      "path": "tests/test_piper_voice_assets.py",
-      "domain": "misc",
+      "domain": "api",
       "test_type": "unit",
       "intent": "regression",
       "primary_lane": "new-code",
@@ -1033,6 +1026,20 @@
       "rationale": "Default release-lane regression coverage."
     },
     {
+      "path": "tests/test_boot_id.py",
+      "domain": "misc",
+      "test_type": "unit",
+      "intent": "regression",
+      "primary_lane": "new-code",
+      "allowed_lanes": [
+        "new-code",
+        "ci-lite",
+        "release"
+      ],
+      "legacy_targeted": false,
+      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
+    },
+    {
       "path": "tests/test_bootstrap_routes_contracts.py",
       "domain": "bootstrap",
       "test_type": "route_contract",
@@ -1056,19 +1063,6 @@
         "new-code",
         "ci-lite",
         "release"
-      ],
-      "legacy_targeted": false,
-      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
-    },
-    {
-      "path": "tests/test_boot_id.py",
-      "domain": "core",
-      "test_type": "unit",
-      "intent": "regression",
-      "primary_lane": "new-code",
-      "allowed_lanes": [
-        "new-code",
-        "ci-lite"
       ],
       "legacy_targeted": false,
       "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
@@ -1938,6 +1932,18 @@
       "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
     },
     {
+      "path": "tests/test_env_contracts.py",
+      "domain": "environment",
+      "test_type": "unit",
+      "intent": "regression",
+      "primary_lane": "release",
+      "allowed_lanes": [
+        "release"
+      ],
+      "legacy_targeted": false,
+      "rationale": "Default release-lane regression coverage."
+    },
+    {
       "path": "tests/test_env_report_diff.py",
       "domain": "environment",
       "test_type": "unit",
@@ -1980,9 +1986,9 @@
     },
     {
       "path": "tests/test_execution_mode_planner.py",
-      "domain": "orchestrator",
-      "test_type": "unit",
-      "intent": "regression",
+      "domain": "api",
+      "test_type": "service_contract",
+      "intent": "contract",
       "primary_lane": "new-code",
       "allowed_lanes": [
         "new-code",
@@ -2266,14 +2272,14 @@
     {
       "path": "tests/test_ghost_agent_hil.py",
       "domain": "agents",
-      "test_type": "integration",
-      "intent": "integration",
+      "test_type": "unit",
+      "intent": "regression",
       "primary_lane": "release",
       "allowed_lanes": [
         "release"
       ],
       "legacy_targeted": false,
-      "rationale": "Manual hardware-in-loop desktop scenarios for Ghost runtime."
+      "rationale": "Default release-lane regression coverage."
     },
     {
       "path": "tests/test_git_routes_logic.py",
@@ -2987,7 +2993,8 @@
       "primary_lane": "new-code",
       "allowed_lanes": [
         "new-code",
-        "ci-lite"
+        "ci-lite",
+        "release"
       ],
       "legacy_targeted": false,
       "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
@@ -3210,7 +3217,7 @@
     },
     {
       "path": "tests/test_main_internal_helpers.py",
-      "domain": "core",
+      "domain": "environment",
       "test_type": "service_contract",
       "intent": "contract",
       "primary_lane": "new-code",
@@ -3887,20 +3894,6 @@
       "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
     },
     {
-      "path": "tests/test_ollama_tuning.py",
-      "domain": "misc",
-      "test_type": "unit",
-      "intent": "regression",
-      "primary_lane": "new-code",
-      "allowed_lanes": [
-        "new-code",
-        "ci-lite",
-        "release"
-      ],
-      "legacy_targeted": false,
-      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
-    },
-    {
       "path": "tests/test_ollama_runtime_capabilities.py",
       "domain": "runtime",
       "test_type": "unit",
@@ -3923,6 +3916,20 @@
       ],
       "legacy_targeted": false,
       "rationale": "Default release-lane regression coverage."
+    },
+    {
+      "path": "tests/test_ollama_tuning.py",
+      "domain": "misc",
+      "test_type": "unit",
+      "intent": "regression",
+      "primary_lane": "new-code",
+      "allowed_lanes": [
+        "new-code",
+        "ci-lite",
+        "release"
+      ],
+      "legacy_targeted": false,
+      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
     },
     {
       "path": "tests/test_onnx_llm_client.py",
@@ -4203,10 +4210,24 @@
         "release"
       ],
       "legacy_targeted": false,
-      "rationale": "Permission guard regression and changed-scope coverage reinforcement for Sonar new-code lane."
+      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
     },
     {
       "path": "tests/test_persona_factory.py",
+      "domain": "misc",
+      "test_type": "unit",
+      "intent": "regression",
+      "primary_lane": "new-code",
+      "allowed_lanes": [
+        "new-code",
+        "ci-lite",
+        "release"
+      ],
+      "legacy_targeted": false,
+      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
+    },
+    {
+      "path": "tests/test_piper_voice_assets.py",
       "domain": "misc",
       "test_type": "unit",
       "intent": "regression",
@@ -4301,15 +4322,16 @@
     {
       "path": "tests/test_policy_gate_runtime_contract.py",
       "domain": "governance",
-      "test_type": "unit",
+      "test_type": "service_contract",
       "intent": "contract",
       "primary_lane": "new-code",
       "allowed_lanes": [
         "new-code",
-        "ci-lite"
+        "ci-lite",
+        "release"
       ],
       "legacy_targeted": false,
-      "rationale": "Runtime-only global policy checkpoint contract coverage for fast lanes."
+      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
     },
     {
       "path": "tests/test_port_authority.py",
@@ -4327,7 +4349,7 @@
     },
     {
       "path": "tests/test_port_pids_script.py",
-      "domain": "environment",
+      "domain": "system",
       "test_type": "unit",
       "intent": "legacy_coverage",
       "primary_lane": "new-code",
@@ -4337,7 +4359,7 @@
         "release"
       ],
       "legacy_targeted": true,
-      "rationale": "Legacy-targeted environment diagnostics coverage for fast lanes."
+      "rationale": "System-level port and process validation; legacy targeted for infrastructure coverage."
     },
     {
       "path": "tests/test_preprod_mutation_guards.py",

--- a/requirements-academy.txt
+++ b/requirements-academy.txt
@@ -12,7 +12,7 @@ accelerate>=1.12.0,<2.0       # Runtime treningu (HF accelerate)
 datasets>=4.6.0,<5.0          # Hugging Face Datasets library
 trl>=0.8.6,<0.9.0             # TRL (SFTTrainer) - pin kompatybilny z obecnym kodem
 peft>=0.18.0,<0.19.0          # Parameter-Efficient Fine-Tuning (LoRA)
-transformers>=4.57.0,<5.0.0   # Modele/tokenizacja HF (jawnie, nie tylko tranzytywnie)
+transformers>=5.0.0,<6.0.0    # Modele/tokenizacja HF (zgodnie ze stosem Gemma 4 runtime)
 torch==2.8.0                  # Pin kompatybilny z obecnym stosem runtime (vllm/torchvision/torchaudio/xformers)
 pypandoc>=1.14,<2.0           # Wrapper Pandoc do konwersji dokumentów
 pypdf>=4.0.0                  # Ekstrakcja tekstu z PDF

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -64,11 +64,13 @@ openapi-core<0.20,>=0.18    # Nowe wymagania (kompatybilność z werkzeug>=3.1.6
 
 # --- VENOM FRONTAL LOBE & EYES: MODELE I WZROK ---
 
-transformers>=4.57.6,<5.0.0  # Obsługa modeli HF / Tokenizacja (pin <5 zgodny z huggingface_hub 0.35.x)
+transformers>=5.0.0,<6.0.0  # Gemma 4 native audio runtime + modele HF nowej generacji
 sentence-transformers   # Embeddingi do RAG
 pillow                  # Przetwarzanie obrazów
 timm                    # Modele wizyjne (zależność dla Florence-2)
 opencv-python-headless  # Wersja "headless" jest bezpieczniejsza dla WSL2/Server (brak zależności X11)
+soundfile               # Odczyt WAV/PCM dla gemma4_audio runtime
+scipy                   # Resampling audio do 16 kHz mono
 
 
 # --- VENOM ANTENNA: DOSTĘP DO SIECI ---

--- a/requirements-profile-onnx.txt
+++ b/requirements-profile-onnx.txt
@@ -16,4 +16,4 @@ onnx>=1.14.0
 onnx-ir>=0.1.16
 optimum
 accelerate
-transformers>=4.57.6,<5.0.0
+transformers>=5.0.0,<6.0.0

--- a/scripts/dev/gemma4_audio_direct_ingest_probe.py
+++ b/scripts/dev/gemma4_audio_direct_ingest_probe.py
@@ -70,6 +70,15 @@ def _parse_args() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--task",
+        choices=("transcribe", "question", "math-5x5"),
+        default="transcribe",
+        help=(
+            "Preset for the prompt. math-5x5 asks the model how much 5 times 5 is "
+            "based on the audio content."
+        ),
+    )
+    parser.add_argument(
         "--max-new-tokens",
         type=int,
         default=128,
@@ -198,7 +207,13 @@ def _build_messages(audio_path: Path, prompt: str) -> list[dict[str, Any]]:
     ]
 
 
-def _build_prompt(prompt: str, question: str) -> str:
+def _build_prompt(prompt: str, question: str, task: str) -> str:
+    if task == "math-5x5":
+        return (
+            "Listen to the audio and answer the question using only the audio as evidence. "
+            "Return only the answer, no explanation, no extra words.\n"
+            "Question: Ile to jest 5 razy 5?"
+        )
     if not question.strip():
         return prompt
     return (
@@ -252,6 +267,16 @@ def _run_inference(
     )
 
 
+def _normalize_answer(text: str, task: str) -> str:
+    cleaned = _clean_generated_text(text)
+    if task == "math-5x5":
+        match = re.search(r"\b25\b", cleaned)
+        if match:
+            return "25"
+        return cleaned
+    return cleaned
+
+
 def main() -> int:
     args = _parse_args()
     source_path = (
@@ -283,7 +308,7 @@ def main() -> int:
                     duration_sec=normalized.duration_sec,
                     sample_count=normalized.sample_count,
                 )
-            effective_prompt = _build_prompt(args.prompt, args.question)
+            effective_prompt = _build_prompt(args.prompt, args.question, args.task)
             model, processor, model_class_name = _load_model(args.model_id)
             messages = _build_messages(normalized.normalized_path, effective_prompt)
             generated_text = _run_inference(
@@ -292,7 +317,7 @@ def main() -> int:
                 messages=messages,
                 max_new_tokens=args.max_new_tokens,
             )
-            generated_text = _clean_generated_text(generated_text)
+            generated_text = _normalize_answer(generated_text, args.task)
             report = {
                 "ok": True,
                 "model_id": args.model_id,
@@ -303,6 +328,7 @@ def main() -> int:
                 "channels": normalized.channels,
                 "duration_sec": round(normalized.duration_sec, 3),
                 "sample_count": normalized.sample_count,
+                "task": args.task,
                 "prompt": effective_prompt,
                 "generated_text": generated_text,
             }
@@ -316,6 +342,7 @@ def main() -> int:
                 "channels": normalized.channels,
                 "duration_sec": round(normalized.duration_sec, 3),
                 "sample_count": normalized.sample_count,
+                "task": args.task,
                 "prompt": effective_prompt
                 if "effective_prompt" in locals()
                 else args.prompt,
@@ -334,6 +361,7 @@ def main() -> int:
                 f"sr={report['sample_rate']}Hz, channels={report['channels']}, "
                 f"duration={report['duration_sec']}s, samples={report['sample_count']}"
             )
+            print(f"  task: {report['task']}")
             if report.get("prompt"):
                 print(f"  prompt: {report['prompt']}")
             if report.get("ok"):

--- a/scripts/dev/gemma4_audio_direct_ingest_probe.py
+++ b/scripts/dev/gemma4_audio_direct_ingest_probe.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import re
 import subprocess
 import sys
 import tempfile
@@ -59,6 +60,14 @@ def _parse_args() -> argparse.Namespace:
             "Return only the transcription, with no bullets and no extra commentary."
         ),
         help="Instruction sent together with the audio.",
+    )
+    parser.add_argument(
+        "--question",
+        default="",
+        help=(
+            "Optional question to answer from the audio instead of transcription. "
+            "The script will ask the model to answer only from what can be heard."
+        ),
     )
     parser.add_argument(
         "--max-new-tokens",
@@ -189,6 +198,22 @@ def _build_messages(audio_path: Path, prompt: str) -> list[dict[str, Any]]:
     ]
 
 
+def _build_prompt(prompt: str, question: str) -> str:
+    if not question.strip():
+        return prompt
+    return (
+        "Listen to the audio and answer the question using only the audio as evidence. "
+        "If the answer is not clear from the audio, say so briefly.\n"
+        f"Question: {question.strip()}"
+    )
+
+
+def _clean_generated_text(text: str) -> str:
+    cleaned = text.replace("<bos>", "").replace("<turn|>", "").replace("<|turn>", "")
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
+    return cleaned
+
+
 def _run_inference(
     *,
     model: Any,
@@ -206,12 +231,25 @@ def _run_inference(
     if hasattr(inputs, "to"):
         inputs = inputs.to(model.device)
     outputs = model.generate(**inputs, max_new_tokens=max_new_tokens)
-    decoded = processor.batch_decode(
-        outputs,
+    input_len = 0
+    if hasattr(inputs, "input_ids"):
+        try:
+            input_len = int(inputs.input_ids.shape[-1])
+        except Exception:
+            input_len = 0
+    if hasattr(outputs, "__getitem__") and len(outputs) > 0 and input_len > 0:
+        output_ids = outputs[0][input_len:]
+    else:
+        output_ids = (
+            outputs[0]
+            if hasattr(outputs, "__getitem__") and len(outputs) > 0
+            else outputs
+        )
+    return processor.decode(
+        output_ids,
         skip_special_tokens=False,
         clean_up_tokenization_spaces=False,
     )
-    return decoded[0] if decoded else ""
 
 
 def main() -> int:
@@ -245,14 +283,16 @@ def main() -> int:
                     duration_sec=normalized.duration_sec,
                     sample_count=normalized.sample_count,
                 )
+            effective_prompt = _build_prompt(args.prompt, args.question)
             model, processor, model_class_name = _load_model(args.model_id)
-            messages = _build_messages(normalized.normalized_path, args.prompt)
+            messages = _build_messages(normalized.normalized_path, effective_prompt)
             generated_text = _run_inference(
                 model=model,
                 processor=processor,
                 messages=messages,
                 max_new_tokens=args.max_new_tokens,
             )
+            generated_text = _clean_generated_text(generated_text)
             report = {
                 "ok": True,
                 "model_id": args.model_id,
@@ -263,6 +303,7 @@ def main() -> int:
                 "channels": normalized.channels,
                 "duration_sec": round(normalized.duration_sec, 3),
                 "sample_count": normalized.sample_count,
+                "prompt": effective_prompt,
                 "generated_text": generated_text,
             }
         except Exception as exc:
@@ -275,6 +316,9 @@ def main() -> int:
                 "channels": normalized.channels,
                 "duration_sec": round(normalized.duration_sec, 3),
                 "sample_count": normalized.sample_count,
+                "prompt": effective_prompt
+                if "effective_prompt" in locals()
+                else args.prompt,
                 "error": f"{type(exc).__name__}: {exc}",
             }
 
@@ -290,6 +334,8 @@ def main() -> int:
                 f"sr={report['sample_rate']}Hz, channels={report['channels']}, "
                 f"duration={report['duration_sec']}s, samples={report['sample_count']}"
             )
+            if report.get("prompt"):
+                print(f"  prompt: {report['prompt']}")
             if report.get("ok"):
                 print(f"  model_class: {report['model_class']}")
                 print("  generated_text:")

--- a/scripts/dev/gemma4_audio_direct_ingest_probe.py
+++ b/scripts/dev/gemma4_audio_direct_ingest_probe.py
@@ -23,14 +23,9 @@ if str(ROOT_DIR) not in sys.path:
 
 import transformers  # noqa: E402
 
-try:
-    import torch  # noqa: E402
-except Exception as exc:  # pragma: no cover - hard dependency in practice
-    raise SystemExit(f"PyTorch is required for this probe: {exc}") from exc
-
-
 DEFAULT_MODEL_ID = "google/gemma-4-E2B-it"
 TARGET_SAMPLE_RATE = 16_000
+CACHE_DIR = ROOT_DIR / "models_cache" / "hf"
 
 
 @dataclass(slots=True)
@@ -166,13 +161,18 @@ def _resolve_model_class() -> type[Any]:
 
 
 def _load_model(model_id: str) -> tuple[Any, Any, str]:
-    processor = transformers.AutoProcessor.from_pretrained(model_id)
+    processor = transformers.AutoProcessor.from_pretrained(
+        model_id,
+        cache_dir=str(CACHE_DIR),
+        local_files_only=True,
+    )
     model_class = _resolve_model_class()
-    torch_dtype = torch.bfloat16 if torch.cuda.is_available() else torch.float32
     model = model_class.from_pretrained(
         model_id,
-        torch_dtype=torch_dtype,
+        dtype="auto",
         device_map="auto",
+        cache_dir=str(CACHE_DIR),
+        local_files_only=True,
     )
     return model, processor, model_class.__name__
 

--- a/scripts/dev/gemma4_audio_direct_ingest_probe.py
+++ b/scripts/dev/gemma4_audio_direct_ingest_probe.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Experimental direct-audio probe for Gemma 4 via Hugging Face Transformers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import soundfile as sf
+from scipy.signal import resample_poly
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+import transformers  # noqa: E402
+
+try:
+    import torch  # noqa: E402
+except Exception as exc:  # pragma: no cover - hard dependency in practice
+    raise SystemExit(f"PyTorch is required for this probe: {exc}") from exc
+
+
+DEFAULT_MODEL_ID = "google/gemma-4-E2B-it"
+TARGET_SAMPLE_RATE = 16_000
+
+
+@dataclass(slots=True)
+class NormalizedAudio:
+    source_path: Path
+    normalized_path: Path
+    sample_rate: int
+    channels: int
+    duration_sec: float
+    sample_count: int
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Experimental Gemma 4 direct audio ingest probe"
+    )
+    parser.add_argument(
+        "--audio",
+        type=Path,
+        help="Local audio file to send to Gemma 4. Defaults to the newest voice session recording.",
+    )
+    parser.add_argument(
+        "--model-id",
+        default=DEFAULT_MODEL_ID,
+        help="Gemma checkpoint to load from Hugging Face.",
+    )
+    parser.add_argument(
+        "--prompt",
+        default=(
+            "Transcribe the speech in the audio. "
+            "Return only the transcription, with no bullets and no extra commentary."
+        ),
+        help="Instruction sent together with the audio.",
+    )
+    parser.add_argument(
+        "--max-new-tokens",
+        type=int,
+        default=128,
+        help="Generation budget for the model.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a JSON report instead of the human-readable summary.",
+    )
+    parser.add_argument(
+        "--normalized-output",
+        type=Path,
+        help="Optional path where the normalized WAV should be preserved.",
+    )
+    return parser.parse_args()
+
+
+def _find_latest_audio() -> Path | None:
+    candidates = sorted(
+        (
+            p
+            for p in (ROOT_DIR / "data" / "audio" / "voice_sessions").glob(
+                "**/recording.wav"
+            )
+        ),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+    return candidates[0] if candidates else None
+
+
+def _read_audio_fallback(path: Path) -> tuple[np.ndarray, int]:
+    try:
+        audio, sample_rate = sf.read(str(path), always_2d=True, dtype="float32")
+        return audio, int(sample_rate)
+    except Exception:
+        with tempfile.TemporaryDirectory(prefix="gemma4_audio_ffmpeg_") as tmpdir:
+            tmp_path = Path(tmpdir) / "decoded.wav"
+            cmd = [
+                "ffmpeg",
+                "-nostdin",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-y",
+                "-i",
+                str(path),
+                "-ac",
+                "1",
+                "-ar",
+                str(TARGET_SAMPLE_RATE),
+                "-c:a",
+                "pcm_f32le",
+                str(tmp_path),
+            ]
+            subprocess.run(cmd, check=True, capture_output=True)
+            audio, sample_rate = sf.read(str(tmp_path), always_2d=True, dtype="float32")
+            return audio, int(sample_rate)
+
+
+def _normalize_audio(source_path: Path, workdir: Path) -> NormalizedAudio:
+    audio, sample_rate = _read_audio_fallback(source_path)
+    channels = int(audio.shape[1]) if audio.ndim > 1 else 1
+    mono = audio.mean(axis=1) if audio.ndim > 1 else audio
+    mono = np.asarray(mono, dtype=np.float32)
+    if sample_rate != TARGET_SAMPLE_RATE:
+        gcd = math.gcd(sample_rate, TARGET_SAMPLE_RATE)
+        up = TARGET_SAMPLE_RATE // gcd
+        down = sample_rate // gcd
+        mono = resample_poly(mono, up, down).astype(np.float32, copy=False)
+        sample_rate = TARGET_SAMPLE_RATE
+    mono = np.clip(mono, -1.0, 1.0).astype(np.float32, copy=False)
+
+    normalized_path = workdir / f"{source_path.stem}.gemma4_16k_mono.wav"
+    sf.write(str(normalized_path), mono, sample_rate, subtype="FLOAT")
+    duration_sec = float(len(mono)) / float(sample_rate) if sample_rate else 0.0
+    return NormalizedAudio(
+        source_path=source_path,
+        normalized_path=normalized_path,
+        sample_rate=sample_rate,
+        channels=channels,
+        duration_sec=duration_sec,
+        sample_count=int(len(mono)),
+    )
+
+
+def _resolve_model_class() -> type[Any]:
+    model_cls = getattr(transformers, "AutoModelForMultimodalLM", None)
+    if model_cls is not None:
+        return model_cls
+    model_cls = getattr(transformers, "AutoModelForImageTextToText", None)
+    if model_cls is not None:
+        return model_cls
+    raise RuntimeError(
+        "No compatible multimodal model class found in installed transformers."
+    )
+
+
+def _load_model(model_id: str) -> tuple[Any, Any, str]:
+    processor = transformers.AutoProcessor.from_pretrained(model_id)
+    model_class = _resolve_model_class()
+    torch_dtype = torch.bfloat16 if torch.cuda.is_available() else torch.float32
+    model = model_class.from_pretrained(
+        model_id,
+        torch_dtype=torch_dtype,
+        device_map="auto",
+    )
+    return model, processor, model_class.__name__
+
+
+def _build_messages(audio_path: Path, prompt: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "role": "user",
+            "content": [
+                {"type": "audio", "path": str(audio_path)},
+                {"type": "text", "text": prompt},
+            ],
+        }
+    ]
+
+
+def _run_inference(
+    *,
+    model: Any,
+    processor: Any,
+    messages: list[dict[str, Any]],
+    max_new_tokens: int,
+) -> str:
+    inputs = processor.apply_chat_template(
+        messages,
+        add_generation_prompt=True,
+        tokenize=True,
+        return_dict=True,
+        return_tensors="pt",
+    )
+    if hasattr(inputs, "to"):
+        inputs = inputs.to(model.device)
+    outputs = model.generate(**inputs, max_new_tokens=max_new_tokens)
+    decoded = processor.batch_decode(
+        outputs,
+        skip_special_tokens=False,
+        clean_up_tokenization_spaces=False,
+    )
+    return decoded[0] if decoded else ""
+
+
+def main() -> int:
+    args = _parse_args()
+    source_path = (
+        args.audio.expanduser().resolve() if args.audio else _find_latest_audio()
+    )
+    if source_path is None:
+        print(
+            "No audio file found. Pass --audio or add a recording under data/audio/voice_sessions.",
+            file=sys.stderr,
+        )
+        return 2
+    if not source_path.exists():
+        print(f"Audio file not found: {source_path}", file=sys.stderr)
+        return 2
+
+    with tempfile.TemporaryDirectory(prefix="gemma4_audio_probe_") as tmpdir_name:
+        tmpdir = Path(tmpdir_name)
+        try:
+            normalized = _normalize_audio(source_path, tmpdir)
+            if args.normalized_output:
+                output_path = args.normalized_output.expanduser().resolve()
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_bytes(normalized.normalized_path.read_bytes())
+                normalized = NormalizedAudio(
+                    source_path=normalized.source_path,
+                    normalized_path=output_path,
+                    sample_rate=normalized.sample_rate,
+                    channels=normalized.channels,
+                    duration_sec=normalized.duration_sec,
+                    sample_count=normalized.sample_count,
+                )
+            model, processor, model_class_name = _load_model(args.model_id)
+            messages = _build_messages(normalized.normalized_path, args.prompt)
+            generated_text = _run_inference(
+                model=model,
+                processor=processor,
+                messages=messages,
+                max_new_tokens=args.max_new_tokens,
+            )
+            report = {
+                "ok": True,
+                "model_id": args.model_id,
+                "model_class": model_class_name,
+                "source_audio": str(normalized.source_path),
+                "normalized_audio": str(normalized.normalized_path),
+                "sample_rate": normalized.sample_rate,
+                "channels": normalized.channels,
+                "duration_sec": round(normalized.duration_sec, 3),
+                "sample_count": normalized.sample_count,
+                "generated_text": generated_text,
+            }
+        except Exception as exc:
+            report = {
+                "ok": False,
+                "model_id": args.model_id,
+                "source_audio": str(normalized.source_path),
+                "normalized_audio": str(normalized.normalized_path),
+                "sample_rate": normalized.sample_rate,
+                "channels": normalized.channels,
+                "duration_sec": round(normalized.duration_sec, 3),
+                "sample_count": normalized.sample_count,
+                "error": f"{type(exc).__name__}: {exc}",
+            }
+
+        if args.json:
+            print(json.dumps(report, ensure_ascii=False, indent=2))
+        else:
+            print("Gemma 4 direct audio ingest probe")
+            print(f"  model_id: {report['model_id']}")
+            print(f"  source_audio: {report['source_audio']}")
+            print(f"  normalized_audio: {report['normalized_audio']}")
+            print(
+                "  audio_stats: "
+                f"sr={report['sample_rate']}Hz, channels={report['channels']}, "
+                f"duration={report['duration_sec']}s, samples={report['sample_count']}"
+            )
+            if report.get("ok"):
+                print(f"  model_class: {report['model_class']}")
+                print("  generated_text:")
+                print(report["generated_text"])
+            else:
+                print(f"  error: {report['error']}")
+
+        return 0 if report.get("ok") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/gemma4_audio_service_smoke.py
+++ b/scripts/dev/gemma4_audio_service_smoke.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Smoke test for Gemma 4 Audio Runtime Service.
+
+Tests basic functionality:
+- Health check
+- Status endpoint
+- Model info
+- Simple text-to-text inference
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import httpx
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+
+# Configuration
+SERVICE_HOST = "127.0.0.1"
+SERVICE_PORT = 8014
+BASE_URL = f"http://{SERVICE_HOST}:{SERVICE_PORT}"
+TIMEOUT = 120.0  # 2 minutes for model loading
+HEALTH_CHECK_TIMEOUT = 5.0
+
+
+class Gemma4AudioSmokeTester:
+    """Smoke tester for Gemma4 Audio Runtime."""
+
+    def __init__(self, base_url: str = BASE_URL, timeout: float = TIMEOUT):
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.health_check_timeout = HEALTH_CHECK_TIMEOUT
+        self.results: Dict[str, Any] = {}
+
+    async def run(self) -> int:
+        """Run all smoke tests.
+
+        Returns:
+            0 if all tests pass, 1 otherwise
+        """
+        print("=" * 60)
+        print("Gemma 4 Audio Runtime Service - Smoke Tests")
+        print("=" * 60)
+        print(f"Target: {self.base_url}\n")
+
+        tests = [
+            ("Health Check", self.test_health),
+            ("Status Endpoint", self.test_status),
+            ("Models List", self.test_models_list),
+            ("Text Response", self.test_text_response),
+            ("Math Question", self.test_math_question),
+        ]
+
+        passed = 0
+        failed = 0
+
+        for test_name, test_func in tests:
+            try:
+                print(f"\n[TEST] {test_name}...")
+                result = await test_func()
+                if result:
+                    print("  ✓ PASS")
+                    passed += 1
+                else:
+                    print("  ✗ FAIL")
+                    failed += 1
+            except Exception as e:
+                print(f"  ✗ ERROR: {e}")
+                failed += 1
+
+        print("\n" + "=" * 60)
+        print(f"Results: {passed} passed, {failed} failed")
+        print("=" * 60)
+
+        return 0 if failed == 0 else 1
+
+    async def test_health(self) -> bool:
+        """Test health endpoint."""
+        async with httpx.AsyncClient(timeout=self.health_check_timeout) as client:
+            try:
+                response = await client.get(f"{self.base_url}/health")
+                if response.status_code != 200:
+                    print(f"  Status code: {response.status_code}")
+                    return False
+                data = response.json()
+                print(f"  Status: {data.get('status')}")
+                print(f"  Message: {data.get('message')}")
+                return data.get("status") in ("ok", "warming")
+            except Exception as e:
+                print(f"  Failed to reach service: {e}")
+                return False
+
+    async def test_status(self) -> bool:
+        """Test status endpoint."""
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            try:
+                response = await client.get(f"{self.base_url}/status")
+                if response.status_code != 200:
+                    print(f"  Status code: {response.status_code}")
+                    return False
+                data = response.json()
+                print(f"  Service: {data.get('service')}")
+                print(f"  Status: {data.get('status')}")
+                print(f"  Model loaded: {data.get('model_loaded')}")
+                if data.get("model_info"):
+                    print(f"  Model ID: {data['model_info'].get('model_id')}")
+                return data.get("model_loaded") in (True, None)
+            except Exception as e:
+                print(f"  Error: {e}")
+                return False
+
+    async def test_models_list(self) -> bool:
+        """Test models list endpoint."""
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            try:
+                response = await client.get(f"{self.base_url}/v1/models")
+                if response.status_code != 200:
+                    print(f"  Status code: {response.status_code}")
+                    return False
+                data = response.json()
+                models = data.get("data", [])
+                print(f"  Available models: {len(models)}")
+                for model in models:
+                    print(f"    - {model.get('id')}")
+                return len(models) > 0
+            except Exception as e:
+                print(f"  Error: {e}")
+                return False
+
+    async def test_text_response(self) -> bool:
+        """Test text-only response."""
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            try:
+                payload = {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "Say hello",
+                                }
+                            ],
+                        }
+                    ],
+                    "max_new_tokens": 50,
+                }
+                response = await client.post(
+                    f"{self.base_url}/v1/respond",
+                    json=payload,
+                )
+                if response.status_code != 200:
+                    print(f"  Status code: {response.status_code}")
+                    print(f"  Response: {response.text}")
+                    return False
+                data = response.json()
+                text = data.get("text", "")
+                duration_ms = data.get("duration_ms", 0)
+                print(f"  Generated: {text[:100]}...")
+                print(f"  Duration: {duration_ms}ms")
+                return len(text) > 0
+            except Exception as e:
+                print(f"  Error: {e}")
+                return False
+
+    async def test_math_question(self) -> bool:
+        """Test math question task."""
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            try:
+                payload = {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": "What is 5 times 5?",
+                                }
+                            ],
+                        }
+                    ],
+                    "task": "math-5x5",
+                    "max_new_tokens": 20,
+                }
+                response = await client.post(
+                    f"{self.base_url}/v1/respond",
+                    json=payload,
+                )
+                if response.status_code != 200:
+                    print(f"  Status code: {response.status_code}")
+                    return False
+                data = response.json()
+                text = data.get("text", "").strip()
+                print(f"  Response: {text}")
+                # Check if response contains "25"
+                contains_answer = "25" in text
+                print(f"  Contains '25': {contains_answer}")
+                return contains_answer
+            except Exception as e:
+                print(f"  Error: {e}")
+                return False
+
+
+async def main():
+    """Main entry point."""
+    tester = Gemma4AudioSmokeTester()
+    return await tester.run()
+
+
+if __name__ == "__main__":
+    exit_code = asyncio.run(main())
+    sys.exit(exit_code)

--- a/scripts/dev/gemma4_audio_voice_session_replay.py
+++ b/scripts/dev/gemma4_audio_voice_session_replay.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Replay a recorded voice session against the Gemma 4 Audio runtime.
+
+The script reuses the latest saved voice session by default and sends its
+`recording.wav` path to the local Gemma 4 audio daemon.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from venom_core.api.audio_stream import (  # noqa: E402
+    VOICE_SESSION_ROOT,
+    collect_latest_voice_session_record,
+)
+from venom_core.config import SETTINGS  # noqa: E402
+
+
+def _resolve_audio_path(session_dir: Path | None, audio_path: Path | None) -> Path:
+    if audio_path is not None:
+        return audio_path
+
+    if session_dir is not None:
+        candidate = session_dir / "recording.wav"
+        if candidate.exists():
+            return candidate
+        raise FileNotFoundError(f"Missing recording.wav in {session_dir}")
+
+    latest = collect_latest_voice_session_record(VOICE_SESSION_ROOT)
+    if not latest:
+        raise FileNotFoundError("No voice session found in data/audio/voice_sessions")
+
+    candidate = VOICE_SESSION_ROOT / str(latest["session_id"]) / "recording.wav"
+    if not candidate.exists():
+        raise FileNotFoundError(f"Missing recording.wav in {candidate.parent}")
+    return candidate
+
+
+def _build_payload(
+    audio_path: Path,
+    *,
+    task: str | None,
+    question: str | None,
+    system_prompt: str | None,
+    max_new_tokens: int,
+) -> dict[str, Any]:
+    content: list[dict[str, Any]] = [{"type": "audio", "path": str(audio_path)}]
+    if question:
+        content.append({"type": "text", "text": question})
+    return {
+        "messages": [{"role": "user", "content": content}],
+        "task": task,
+        "question": question,
+        "system_prompt": system_prompt,
+        "max_new_tokens": max_new_tokens,
+    }
+
+
+async def _run(args: argparse.Namespace) -> int:
+    session_dir = Path(args.session_dir) if args.session_dir else None
+    audio_path = Path(args.audio) if args.audio else None
+    resolved_audio_path = _resolve_audio_path(session_dir, audio_path)
+
+    base_url = args.base_url.rstrip("/")
+    payload = _build_payload(
+        resolved_audio_path,
+        task=args.task,
+        question=args.question,
+        system_prompt=args.system_prompt,
+        max_new_tokens=args.max_new_tokens,
+    )
+
+    print(f"Session audio: {resolved_audio_path}")
+    print(f"POST {base_url}/respond")
+
+    timeout = httpx.Timeout(args.timeout, connect=min(5.0, args.timeout))
+    with resolved_audio_path.open("rb") as audio_handle:
+        files = {"audio": (resolved_audio_path.name, audio_handle, "audio/wav")}
+        data = {"request": json.dumps(payload, ensure_ascii=False)}
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            response = await client.post(f"{base_url}/respond", data=data, files=files)
+
+    if response.status_code >= 400:
+        print(f"HTTP {response.status_code}")
+        print(response.text)
+        return 1
+
+    data = response.json()
+    print(json.dumps(data, ensure_ascii=False, indent=2))
+    return 0
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default=SETTINGS.GEMMA4_AUDIO_ENDPOINT)
+    parser.add_argument("--session-dir", default="")
+    parser.add_argument("--audio", default="")
+    parser.add_argument("--task", default="question")
+    parser.add_argument("--question", default="")
+    parser.add_argument("--system-prompt", default="")
+    parser.add_argument("--max-new-tokens", type=int, default=128)
+    parser.add_argument("--timeout", type=float, default=120.0)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    args.session_dir = args.session_dir or None
+    args.audio = args.audio or None
+    args.question = args.question or None
+    args.system_prompt = args.system_prompt or None
+    return asyncio.run(_run(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/llm/gemma4_audio_service.sh
+++ b/scripts/llm/gemma4_audio_service.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTION="${1:-}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=../lib/env_contract.sh
+source "$ROOT_DIR/scripts/lib/env_contract.sh"
+
+VENV_BIN="$ROOT_DIR/.venv/bin"
+PYTHON_BIN="$VENV_BIN/python"
+RUNTIME_DIR="$ROOT_DIR/.venom_runtime"
+LOG_DIR="$ROOT_DIR/logs"
+PID_FILE="$RUNTIME_DIR/gemma4_audio.pid"
+LOG_FILE="$LOG_DIR/gemma4_audio_service.log"
+ENV_FILE_RAW="${ENV_FILE:-.env.dev}"
+ENV_FILE="$(env_contract_resolve_file "$ENV_FILE_RAW" "$ROOT_DIR")"
+
+# Configuration from env
+MODEL_ID="$(env_contract_get GEMMA4_AUDIO_MODEL_ID "google/gemma-4-E2B-it" "$ENV_FILE")"
+HOST="$(env_contract_get GEMMA4_AUDIO_HOST "127.0.0.1" "$ENV_FILE")"
+PORT="$(env_contract_get GEMMA4_AUDIO_PORT "8014" "$ENV_FILE")"
+CACHE_DIR="$(env_contract_get GEMMA4_AUDIO_CACHE_DIR "models_cache/hf" "$ENV_FILE")"
+DEVICE="$(env_contract_get GEMMA4_AUDIO_DEVICE "auto" "$ENV_FILE")"
+MAX_NEW_TOKENS="$(env_contract_get GEMMA4_AUDIO_MAX_NEW_TOKENS "128" "$ENV_FILE")"
+STARTUP_TIMEOUT_SECONDS="$(env_contract_get GEMMA4_AUDIO_STARTUP_TIMEOUT_SECONDS "600" "$ENV_FILE")"
+
+# Detect systemd
+SYSTEMCTL_BIN="$(command -v systemctl || true)"
+SYSTEMD_UNIT="$(env_contract_get GEMMA4_AUDIO_SYSTEMD_UNIT "gemma4-audio.service" "$ENV_FILE")"
+SYSTEMD_SCOPE="$(env_contract_get GEMMA4_AUDIO_SYSTEMD_SCOPE "system" "$ENV_FILE")"
+SYSTEMD_SCOPE_ARGS=()
+if [[ "$SYSTEMD_SCOPE" == "user" ]]; then
+  SYSTEMD_SCOPE_ARGS=(--user)
+fi
+
+USE_SYSTEMD=false
+if [[ -n "$SYSTEMCTL_BIN" ]] && (
+  "$SYSTEMCTL_BIN" "${SYSTEMD_SCOPE_ARGS[@]}" list-unit-files "$SYSTEMD_UNIT" >/dev/null 2>&1 || \
+  "$SYSTEMCTL_BIN" "${SYSTEMD_SCOPE_ARGS[@]}" status "$SYSTEMD_UNIT" >/dev/null 2>&1
+); then
+  USE_SYSTEMD=true
+fi
+
+health_status() {
+  local response
+  response="$(curl -fsS "http://${HOST}:${PORT}/health" 2>/dev/null || true)"
+  if [[ -z "$response" ]]; then
+    echo "unreachable"
+    return 1
+  fi
+
+  printf '%s' "$response" | "$PYTHON_BIN" -c 'import json, sys
+try:
+    data = json.load(sys.stdin)
+    print(data.get("status", "unknown"))
+except Exception:
+    print("unknown")'
+}
+
+is_ready() {
+  [[ "$(health_status)" == "ok" ]]
+}
+
+is_warming() {
+  [[ "$(health_status)" == "warming" ]]
+}
+
+start() {
+  echo "🧭 Gemma4 Audio config: model=${MODEL_ID}, host=${HOST}, port=${PORT}, device=${DEVICE}, env_file=${ENV_FILE}"
+
+  if [[ "$USE_SYSTEMD" == "true" ]]; then
+    echo "Starting systemd unit ${SYSTEMD_UNIT}"
+    "$SYSTEMCTL_BIN" "${SYSTEMD_SCOPE_ARGS[@]}" start "$SYSTEMD_UNIT"
+    return 0
+  fi
+
+  if [[ ! -x "$PYTHON_BIN" ]]; then
+    echo "Python binary not found at $PYTHON_BIN" >&2
+    exit 1
+  fi
+
+  mkdir -p "$RUNTIME_DIR" "$LOG_DIR"
+
+  if [[ -f "$PID_FILE" ]]; then
+    local existing_pid
+    existing_pid="$(cat "$PID_FILE")"
+    if kill -0 "$existing_pid" 2>/dev/null; then
+      echo "Gemma4 Audio already running (PID $existing_pid)"
+      if is_ready; then
+        echo "Service is healthy at http://${HOST}:${PORT}/health"
+      fi
+      exit 0
+    else
+      rm -f "$PID_FILE"
+    fi
+  fi
+
+  # Check if model cache directory exists and is accessible
+  if [[ ! -d "$ROOT_DIR/$CACHE_DIR" ]]; then
+    echo "WARNING: Cache directory does not exist yet: $ROOT_DIR/$CACHE_DIR"
+    echo "Model will be downloaded on first startup."
+    mkdir -p "$ROOT_DIR/$CACHE_DIR"
+  fi
+
+  echo "Starting Gemma4 Audio Runtime daemon (port ${PORT}, log: $LOG_FILE)"
+
+  # Export environment for the daemon
+  export GEMMA4_AUDIO_MODEL_ID="$MODEL_ID"
+  export GEMMA4_AUDIO_CACHE_DIR="$ROOT_DIR/$CACHE_DIR"
+  export GEMMA4_AUDIO_DEVICE="$DEVICE"
+  export GEMMA4_AUDIO_MAX_NEW_TOKENS="$MAX_NEW_TOKENS"
+  export GEMMA4_AUDIO_HOST="$HOST"
+  export GEMMA4_AUDIO_PORT="$PORT"
+  export GEMMA4_AUDIO_LOG_PATH="$LOG_FILE"
+  export GEMMA4_AUDIO_PID_PATH="$PID_FILE"
+  export PYTHONUNBUFFERED=1
+
+  # Start daemon
+  nohup "$PYTHON_BIN" -m services.gemma4_audio_runtime.main >>"$LOG_FILE" 2>&1 &
+  echo $! >"$PID_FILE"
+  local pid
+  pid="$(cat "$PID_FILE")"
+
+  # Quick liveness check to fail fast on immediate startup errors
+  sleep 2
+  if ! kill -0 "$pid" 2>/dev/null; then
+    echo "Gemma4 Audio crashed immediately after startup (PID $pid)." >&2
+    echo "Last logs:" >&2
+    tail -n 40 "$LOG_FILE" >&2 || true
+    rm -f "$PID_FILE"
+    exit 1
+  fi
+
+  # Wait for health check (up to configured timeout for model loading)
+  local max_wait="$STARTUP_TIMEOUT_SECONDS"
+  local waited=0
+  echo "Waiting for service health check (up to ${max_wait}s)..."
+  while [[ $waited -lt $max_wait ]]; do
+    local status
+    status="$(health_status)"
+    if [[ "$status" == "ok" ]]; then
+      echo "Gemma4 Audio is healthy!"
+      echo "Service started successfully at http://${HOST}:${PORT}"
+      echo "Log file: $LOG_FILE"
+      echo "PID file: $PID_FILE"
+      return 0
+    fi
+
+    if [[ "$status" == "error" ]]; then
+      echo "Service reported startup error." >&2
+      echo "Last logs:" >&2
+      tail -n 40 "$LOG_FILE" >&2 || true
+      rm -f "$PID_FILE"
+      exit 1
+    fi
+
+    sleep 2
+    ((waited += 2))
+
+    # Check if process is still running
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "Service process died during startup." >&2
+      echo "Last logs:" >&2
+      tail -n 40 "$LOG_FILE" >&2 || true
+      rm -f "$PID_FILE"
+      exit 1
+    fi
+
+    echo "Service still warming up... (${waited}s elapsed, status=${status})"
+  done
+
+  echo "WARNING: Service did not report health after ${max_wait}s."
+  echo "Process is running (PID $pid), but health check is not responding."
+  echo "Check logs at: $LOG_FILE"
+  return 1
+}
+
+stop() {
+  if [[ "$USE_SYSTEMD" == "true" ]]; then
+    echo "Stopping systemd unit ${SYSTEMD_UNIT}"
+    "$SYSTEMCTL_BIN" "${SYSTEMD_SCOPE_ARGS[@]}" stop "$SYSTEMD_UNIT"
+    return 0
+  fi
+
+  if [[ -f "$PID_FILE" ]]; then
+    local pid
+    pid="$(cat "$PID_FILE")"
+    if kill -0 "$pid" 2>/dev/null; then
+      echo "Stopping Gemma4 Audio (PID $pid)"
+      kill "$pid" 2>/dev/null || true
+
+      # Wait for graceful shutdown (up to 10 seconds)
+      local waited=0
+      while kill -0 "$pid" 2>/dev/null && [[ $waited -lt 10 ]]; do
+        sleep 1
+        ((waited += 1))
+      done
+
+      # Force kill if still running
+      if kill -0 "$pid" 2>/dev/null; then
+        echo "Forcing kill of Gemma4 Audio (PID $pid)"
+        kill -9 "$pid" 2>/dev/null || true
+      fi
+    fi
+    rm -f "$PID_FILE"
+  fi
+
+  # Cleanup stray processes
+  pkill -f "services.gemma4_audio_runtime" 2>/dev/null || true
+
+  echo "Gemma4 Audio stopped"
+  return 0
+}
+
+restart() {
+  stop
+  sleep 1
+  start
+  return 0
+}
+
+status() {
+  if [[ -f "$PID_FILE" ]]; then
+    local pid
+    pid="$(cat "$PID_FILE")"
+    if kill -0 "$pid" 2>/dev/null; then
+      echo "Gemma4 Audio is running (PID $pid)"
+      local status
+      status="$(health_status)"
+      if [[ "$status" == "ok" ]]; then
+        echo "Health: OK (http://${HOST}:${PORT}/health)"
+      elif [[ "$status" == "warming" ]]; then
+        echo "Health: WARMING (http://${HOST}:${PORT}/health)"
+      else
+        echo "Health: UNKNOWN (health endpoint not responding)"
+      fi
+      echo "Log: $LOG_FILE"
+      echo "Config: model=${MODEL_ID}, host=${HOST}, port=${PORT}"
+      return 0
+    fi
+  fi
+  echo "Gemma4 Audio is not running"
+  return 1
+}
+
+health() {
+  local status
+  status="$(health_status)"
+  if [[ "$status" == "ok" ]]; then
+    echo "Gemma4 Audio is healthy (http://${HOST}:${PORT}/health)"
+    return 0
+  elif [[ "$status" == "warming" ]]; then
+    echo "Gemma4 Audio is warming up (http://${HOST}:${PORT}/health)"
+    return 2
+  else
+    echo "Gemma4 Audio health check failed (http://${HOST}:${PORT}/health)"
+    return 1
+  fi
+}
+
+show_logs() {
+  if [[ -f "$LOG_FILE" ]]; then
+    echo "=== Gemma4 Audio Service Logs ==="
+    tail -n "${1:-50}" "$LOG_FILE"
+  else
+    echo "No log file found: $LOG_FILE"
+  fi
+}
+
+usage() {
+  echo "Usage: $0 {start|stop|restart|status|health|logs}" >&2
+  echo "" >&2
+  echo "Commands:" >&2
+  echo "  start     - Start the Gemma4 Audio daemon" >&2
+  echo "  stop      - Stop the daemon" >&2
+  echo "  restart   - Restart the daemon" >&2
+  echo "  status    - Show daemon status" >&2
+  echo "  health    - Check daemon health" >&2
+  echo "  logs      - Show recent logs (default: 50 lines)" >&2
+}
+
+case "$ACTION" in
+  start) start ;;
+  stop) stop ;;
+  restart) restart ;;
+  status) status ;;
+  health) health ;;
+  logs) show_logs "${2:-50}" ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/services/gemma4_audio_runtime/__init__.py
+++ b/services/gemma4_audio_runtime/__init__.py
@@ -1,0 +1,6 @@
+"""Gemma 4 Audio Native Runtime Service.
+
+Provides multimodal audio/text input to Gemma 4 models via local HTTP daemon.
+"""
+
+__version__ = "0.1.0"

--- a/services/gemma4_audio_runtime/audio.py
+++ b/services/gemma4_audio_runtime/audio.py
@@ -1,0 +1,188 @@
+"""Audio normalization and processing utilities."""
+
+from __future__ import annotations
+
+import io
+import math
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Optional, Tuple
+
+import numpy as np
+import soundfile as sf
+from scipy.signal import resample_poly
+
+TARGET_SAMPLE_RATE = 16_000
+
+
+class AudioNormalizationError(Exception):
+    """Raised when audio normalization fails."""
+
+    pass
+
+
+def read_audio_file(path: Path) -> Tuple[np.ndarray, int]:
+    """Read audio file using soundfile with ffmpeg fallback."""
+    try:
+        audio, sample_rate = sf.read(str(path), always_2d=True, dtype="float32")
+        return audio, int(sample_rate)
+    except Exception as e:
+        # Fallback to ffmpeg
+        try:
+            with tempfile.TemporaryDirectory(prefix="gemma4_audio_ffmpeg_") as tmpdir:
+                tmp_path = Path(tmpdir) / "decoded.wav"
+                cmd = [
+                    "ffmpeg",
+                    "-nostdin",
+                    "-hide_banner",
+                    "-loglevel",
+                    "error",
+                    "-y",
+                    "-i",
+                    str(path),
+                    "-ac",
+                    "1",
+                    "-ar",
+                    str(TARGET_SAMPLE_RATE),
+                    "-c:a",
+                    "pcm_f32le",
+                    str(tmp_path),
+                ]
+                subprocess.run(cmd, check=True, capture_output=True, timeout=30)
+                audio, sample_rate = sf.read(
+                    str(tmp_path), always_2d=True, dtype="float32"
+                )
+                return audio, int(sample_rate)
+        except Exception as ffmpeg_err:
+            raise AudioNormalizationError(
+                f"Failed to read audio with soundfile ({e}) and ffmpeg ({ffmpeg_err})"
+            ) from e
+
+
+def read_audio_bytes(
+    file_bytes: bytes, sample_rate_hint: Optional[int] = None
+) -> Tuple[np.ndarray, int]:
+    """Read audio from bytes using soundfile with ffmpeg fallback."""
+    try:
+        with io.BytesIO(file_bytes) as buf:
+            audio, sample_rate = sf.read(buf, always_2d=True, dtype="float32")
+        return audio, int(sample_rate)
+    except Exception as e:
+        # Fallback to ffmpeg
+        try:
+            with tempfile.TemporaryDirectory(prefix="gemma4_audio_ffmpeg_") as tmpdir:
+                input_path = Path(tmpdir) / "input.audio"
+                output_path = Path(tmpdir) / "decoded.wav"
+
+                input_path.write_bytes(file_bytes)
+
+                cmd = [
+                    "ffmpeg",
+                    "-nostdin",
+                    "-hide_banner",
+                    "-loglevel",
+                    "error",
+                    "-y",
+                    "-i",
+                    str(input_path),
+                    "-ac",
+                    "1",
+                    "-ar",
+                    str(TARGET_SAMPLE_RATE),
+                    "-c:a",
+                    "pcm_f32le",
+                    str(output_path),
+                ]
+                subprocess.run(cmd, check=True, capture_output=True, timeout=30)
+                audio, sample_rate = sf.read(
+                    str(output_path), always_2d=True, dtype="float32"
+                )
+                return audio, int(sample_rate)
+        except Exception as ffmpeg_err:
+            raise AudioNormalizationError(
+                f"Failed to read audio from bytes with soundfile ({e}) "
+                f"and ffmpeg ({ffmpeg_err})"
+            ) from e
+
+
+def normalize_audio(
+    audio: np.ndarray, sample_rate: int, target_sr: int = TARGET_SAMPLE_RATE
+) -> Tuple[np.ndarray, int]:
+    """Normalize audio to mono float32 at target sample rate.
+
+    Args:
+        audio: Audio array (can be multi-channel)
+        sample_rate: Current sample rate
+        target_sr: Target sample rate (default 16000 Hz)
+
+    Returns:
+        Tuple of (normalized_audio, target_sample_rate)
+
+    Raises:
+        AudioNormalizationError: If normalization fails
+    """
+    try:
+        # Convert to mono
+        if audio.ndim > 1:
+            mono = audio.mean(axis=1)
+        else:
+            mono = audio
+
+        mono = np.asarray(mono, dtype=np.float32)
+
+        # Resample if needed
+        if sample_rate != target_sr:
+            gcd = math.gcd(sample_rate, target_sr)
+            up = target_sr // gcd
+            down = sample_rate // gcd
+            mono = resample_poly(mono, up, down).astype(np.float32, copy=False)
+            sample_rate = target_sr
+
+        # Clip to [-1.0, 1.0] range
+        mono = np.clip(mono, -1.0, 1.0).astype(np.float32, copy=False)
+
+        return mono, sample_rate
+    except Exception as e:
+        raise AudioNormalizationError(f"Failed to normalize audio: {e}") from e
+
+
+def audio_from_file(path: Path) -> Tuple[np.ndarray, int]:
+    """Load and normalize audio from file path.
+
+    Args:
+        path: Path to audio file
+
+    Returns:
+        Tuple of (normalized_audio_array, sample_rate)
+
+    Raises:
+        AudioNormalizationError: If file reading or normalization fails
+    """
+    audio, sample_rate = read_audio_file(path)
+    normalized, sr = normalize_audio(audio, sample_rate)
+    return normalized, sr
+
+
+def audio_from_bytes(file_bytes: bytes) -> Tuple[np.ndarray, int]:
+    """Load and normalize audio from bytes.
+
+    Args:
+        file_bytes: Audio file content as bytes
+
+    Returns:
+        Tuple of (normalized_audio_array, sample_rate)
+
+    Raises:
+        AudioNormalizationError: If file reading or normalization fails
+    """
+    audio, sample_rate = read_audio_bytes(file_bytes)
+    normalized, sr = normalize_audio(audio, sample_rate)
+    return normalized, sr
+
+
+def get_audio_duration(audio: np.ndarray, sample_rate: int) -> float:
+    """Get audio duration in seconds."""
+    if sample_rate <= 0:
+        return 0.0
+    return float(len(audio)) / float(sample_rate)

--- a/services/gemma4_audio_runtime/engine.py
+++ b/services/gemma4_audio_runtime/engine.py
@@ -1,0 +1,276 @@
+"""Gemma 4 model engine and inference logic."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+import numpy as np
+import transformers
+
+from .audio import get_audio_duration, normalize_audio
+
+
+class ModelLoadError(Exception):
+    """Raised when model fails to load."""
+
+    pass
+
+
+class InferenceError(Exception):
+    """Raised when inference fails."""
+
+    pass
+
+
+class Gemma4AudioEngine:
+    """Engine for Gemma 4 audio inference using processor_model approach."""
+
+    def __init__(
+        self,
+        model_id: str,
+        cache_dir: str,
+        device: str = "auto",
+        max_new_tokens: int = 128,
+    ):
+        """Initialize the engine.
+
+        Args:
+            model_id: Hugging Face model ID (e.g., 'google/gemma-4-E2B-it')
+            cache_dir: Cache directory for model download
+            device: Device to load model on ('auto', 'cuda', 'cpu')
+            max_new_tokens: Default max new tokens for generation
+        """
+        self.model_id = model_id
+        self.cache_dir = cache_dir
+        self.device = device
+        self.default_max_new_tokens = max_new_tokens
+
+        self.model: Optional[Any] = None
+        self.processor: Optional[Any] = None
+        self.model_class_name: Optional[str] = None
+
+    def load(self) -> None:
+        """Load model and processor from Hugging Face."""
+        try:
+            self.processor = transformers.AutoProcessor.from_pretrained(
+                self.model_id,
+                cache_dir=self.cache_dir,
+                local_files_only=True,
+            )
+
+            model_class = self._resolve_model_class()
+            self.model = model_class.from_pretrained(
+                self.model_id,
+                dtype="auto",
+                device_map=self.device,
+                cache_dir=self.cache_dir,
+                local_files_only=True,
+            )
+            self.model_class_name = model_class.__name__
+
+        except Exception as e:
+            raise ModelLoadError(f"Failed to load model {self.model_id}: {e}") from e
+
+    def unload(self) -> None:
+        """Unload model and free resources."""
+        self.model = None
+        self.processor = None
+
+    def is_loaded(self) -> bool:
+        """Check if model is currently loaded."""
+        return self.model is not None and self.processor is not None
+
+    @staticmethod
+    def _resolve_model_class() -> type[Any]:
+        """Resolve the correct multimodal model class from transformers."""
+        model_cls = getattr(transformers, "AutoModelForMultimodalLM", None)
+        if model_cls is not None:
+            return model_cls
+
+        model_cls = getattr(transformers, "AutoModelForImageTextToText", None)
+        if model_cls is not None:
+            return model_cls
+
+        raise ModelLoadError(
+            "No compatible multimodal model class found in installed transformers. "
+            "Ensure transformers >= 5.0 is installed."
+        )
+
+    def _build_prompt_for_task(
+        self, task: Optional[str], question: Optional[str], default_prompt: str
+    ) -> str:
+        """Build the prompt instruction based on task or question."""
+        if task == "math-5x5":
+            return (
+                "Listen to the audio and answer the question using only the audio as evidence. "
+                "Return only the answer, no explanation, no extra words.\n"
+                "Question: Ile to jest 5 razy 5?"
+            )
+        if task == "transcribe":
+            return (
+                "Transcribe the speech in the audio. "
+                "Return only the transcription, with no bullets and no extra commentary."
+            )
+        if question and question.strip():
+            return (
+                "Listen to the audio and answer the question using only the audio as evidence. "
+                "If the answer is not clear from the audio, say so briefly.\n"
+                f"Question: {question.strip()}"
+            )
+        return default_prompt
+
+    def respond(
+        self,
+        audio_array: np.ndarray,
+        sample_rate: int,
+        prompt: str = "Transcribe the speech in the audio.",
+        task: Optional[str] = None,
+        question: Optional[str] = None,
+        system_prompt: Optional[str] = None,
+        max_new_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        do_sample: Optional[bool] = None,
+    ) -> tuple[str, float]:
+        """Run inference on audio with optional text.
+
+        Args:
+            audio_array: Audio array (should be normalized to 16kHz mono float32)
+            sample_rate: Sample rate of audio
+            prompt: Default prompt if task/question not set
+            task: Preset task ('transcribe', 'question', 'math-5x5')
+            question: Question to answer about audio
+            system_prompt: System message override
+            max_new_tokens: Generation budget (uses default if None)
+            temperature: Sampling temperature
+            top_p: Top-p sampling parameter
+            do_sample: Whether to use sampling
+
+        Returns:
+            Tuple of (generated_text, duration_sec)
+
+        Raises:
+            InferenceError: If inference fails
+        """
+        if not self.is_loaded():
+            raise InferenceError("Model is not loaded. Call load() first.")
+
+        # Normalize audio once more to ensure consistency
+        try:
+            audio_normalized, sr = normalize_audio(audio_array, sample_rate)
+        except Exception as e:
+            raise InferenceError(f"Failed to normalize audio: {e}") from e
+
+        # Build the effective prompt
+        effective_prompt = self._build_prompt_for_task(task, question, prompt)
+
+        # Build messages in the format expected by Gemma processor
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "audio", "array": audio_normalized, "sample_rate": sr},
+                    {"type": "text", "text": effective_prompt},
+                ],
+            }
+        ]
+
+        if system_prompt:
+            messages.insert(
+                0,
+                {
+                    "role": "system",
+                    "content": [{"type": "text", "text": system_prompt}],
+                },
+            )
+
+        try:
+            # Apply chat template and tokenize
+            inputs = self.processor.apply_chat_template(
+                messages,
+                add_generation_prompt=True,
+                tokenize=True,
+                return_dict=True,
+                return_tensors="pt",
+            )
+
+            # Move inputs to model device if necessary
+            if hasattr(inputs, "to"):
+                inputs = inputs.to(self.model.device)
+
+            # Generate
+            outputs = self.model.generate(
+                **inputs,
+                max_new_tokens=max_new_tokens or self.default_max_new_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                do_sample=do_sample if do_sample is not None else False,
+            )
+
+            # Decode output
+            input_len = 0
+            if hasattr(inputs, "input_ids"):
+                try:
+                    input_len = int(inputs.input_ids.shape[-1])
+                except Exception:
+                    pass
+
+            if hasattr(outputs, "__getitem__") and len(outputs) > 0 and input_len > 0:
+                output_ids = outputs[0][input_len:]
+            else:
+                output_ids = (
+                    outputs[0]
+                    if hasattr(outputs, "__getitem__") and len(outputs) > 0
+                    else outputs
+                )
+
+            generated_text = self.processor.decode(
+                output_ids,
+                skip_special_tokens=False,
+                clean_up_tokenization_spaces=False,
+            )
+
+            # Clean up special tokens
+            generated_text = self._clean_generated_text(generated_text)
+
+            duration_sec = get_audio_duration(audio_normalized, sr)
+
+            return generated_text, duration_sec
+
+        except Exception as e:
+            raise InferenceError(f"Inference failed: {e}") from e
+
+    @staticmethod
+    def _clean_generated_text(text: str) -> str:
+        """Clean generated text by removing special tokens."""
+        cleaned = (
+            text.replace("<bos>", "").replace("<turn|>", "").replace("<|turn>", "")
+        )
+        cleaned = re.sub(r"\s+", " ", cleaned).strip()
+        return cleaned
+
+    def transcribe(
+        self,
+        audio_array: np.ndarray,
+        sample_rate: int,
+        max_new_tokens: int = 256,
+    ) -> str:
+        """Transcribe audio to text.
+
+        Args:
+            audio_array: Audio array
+            sample_rate: Sample rate
+            max_new_tokens: Generation budget
+
+        Returns:
+            Transcribed text
+        """
+        text, _ = self.respond(
+            audio_array,
+            sample_rate,
+            prompt="Transcribe the speech in the audio. Return only the transcription.",
+            task="transcribe",
+            max_new_tokens=max_new_tokens,
+        )
+        return text

--- a/services/gemma4_audio_runtime/main.py
+++ b/services/gemma4_audio_runtime/main.py
@@ -1,0 +1,470 @@
+"""FastAPI application for Gemma 4 Audio Runtime Service."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+import time
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import uvicorn
+from fastapi import FastAPI, File, HTTPException, Request, UploadFile
+
+from .audio import audio_from_bytes, audio_from_file, get_audio_duration
+from .engine import Gemma4AudioEngine, InferenceError
+from .schemas import (
+    AudioMetadata,
+    Capabilities,
+    GenerationConfig,
+    HealthResponse,
+    ModelInfo,
+    RespondRequest,
+    RespondResponse,
+    StatusResponse,
+    TranscribeResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Global engine instance
+_engine: Optional[Gemma4AudioEngine] = None
+_start_time: float = 0
+_warming: bool = False
+_startup_error: Optional[str] = None
+
+
+def get_engine() -> Gemma4AudioEngine:
+    """Get the global engine instance."""
+    global _engine
+    if _engine is None:
+        raise RuntimeError("Engine not initialized")
+    return _engine
+
+
+async def initialize_engine(
+    model_id: str, cache_dir: str, device: str = "auto", max_new_tokens: int = 128
+) -> None:
+    """Initialize the engine with model loading."""
+    global _engine, _warming, _startup_error
+
+    _warming = True
+    _startup_error = None
+    try:
+        logger.info(f"Initializing Gemma 4 Audio Engine with model {model_id}")
+        _engine = Gemma4AudioEngine(
+            model_id=model_id,
+            cache_dir=cache_dir,
+            device=device,
+            max_new_tokens=max_new_tokens,
+        )
+        logger.info("Loading model...")
+        await asyncio.to_thread(_engine.load)
+        logger.info(f"Model loaded successfully. Class: {_engine.model_class_name}")
+        _warming = False
+    except Exception as e:
+        logger.error(f"Failed to initialize engine: {e}")
+        _startup_error = str(e)
+        _warming = False
+
+
+async def _startup_model_loader() -> None:
+    """Background model loader that keeps the API server available during warmup."""
+    model_id = os.getenv("GEMMA4_AUDIO_MODEL_ID", "google/gemma-4-E2B-it")
+    cache_dir = os.getenv("GEMMA4_AUDIO_CACHE_DIR", "models_cache/hf")
+    device = os.getenv("GEMMA4_AUDIO_DEVICE", "auto")
+    max_tokens = int(os.getenv("GEMMA4_AUDIO_MAX_NEW_TOKENS", "128"))
+    await initialize_engine(model_id, cache_dir, device, max_tokens)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """FastAPI lifespan context manager."""
+    global _start_time
+    _start_time = time.time()
+
+    # Startup: keep API available while the model is loading in background.
+    asyncio.create_task(_startup_model_loader())
+
+    yield
+
+    # Shutdown
+    if _engine is not None:
+        _engine.unload()
+        logger.info("Engine unloaded")
+
+
+async def _parse_respond_request(
+    request: Request,
+) -> tuple[RespondRequest, bytes | None]:
+    """Parse /v1/respond input from JSON or multipart form."""
+    content_type = request.headers.get("content-type", "").lower()
+    if "multipart/form-data" in content_type:
+        form = await request.form()
+        raw_request = form.get("request")
+        if not raw_request:
+            raise HTTPException(status_code=400, detail="Missing request form field")
+        request_payload = RespondRequest.model_validate_json(str(raw_request))
+        audio_file = form.get("audio")
+        audio_bytes = None
+        if isinstance(audio_file, UploadFile):
+            audio_bytes = await audio_file.read()
+        return request_payload, audio_bytes
+
+    payload = await request.json()
+    return RespondRequest.model_validate(payload), None
+
+
+app = FastAPI(
+    title="Gemma 4 Audio Runtime Service",
+    description="Local native audio inference daemon for Gemma 4 models",
+    version="0.1.0",
+    lifespan=lifespan,
+)
+
+
+@app.get("/health", response_model=HealthResponse)
+async def health() -> HealthResponse:
+    """Health check endpoint."""
+    try:
+        engine = get_engine()
+        if _warming:
+            return HealthResponse(
+                status="warming",
+                message="Model is warming up, please wait...",
+            )
+        if not engine.is_loaded():
+            return HealthResponse(
+                status="error",
+                message="Model is not loaded",
+            )
+        return HealthResponse(
+            status="ok",
+            message="Service is healthy and ready",
+        )
+    except RuntimeError:
+        if _startup_error:
+            return HealthResponse(
+                status="error",
+                message=f"Startup failed: {_startup_error}",
+            )
+        if _warming:
+            return HealthResponse(
+                status="warming",
+                message="Service is initializing...",
+            )
+        return HealthResponse(
+            status="error",
+            message="Service not initialized",
+        )
+
+
+@app.get("/status", response_model=StatusResponse)
+async def status() -> StatusResponse:
+    """Get service status."""
+    try:
+        engine = get_engine()
+        is_loaded = engine.is_loaded()
+
+        model_info = None
+        if is_loaded:
+            model_info = ModelInfo(
+                model_id=engine.model_id,
+                instruction_tuned=True,
+                supports_text_input=True,
+                supports_audio_input=True,
+                supports_image_input=False,
+                supports_text_output=True,
+                runtime_mode="processor_model",
+                status="loaded",
+            )
+
+        status_val = "warming" if _warming else ("running" if is_loaded else "error")
+
+        return StatusResponse(
+            service="gemma4_audio",
+            status=status_val,
+            model_loaded=is_loaded,
+            model_info=model_info,
+            timestamp_ms=int(time.time() * 1000),
+        )
+    except RuntimeError:
+        return StatusResponse(
+            service="gemma4_audio",
+            status="warming" if _warming else "error",
+            model_loaded=False,
+            timestamp_ms=int(time.time() * 1000),
+        )
+
+
+@app.get("/v1/models")
+async def list_models():
+    """List available models."""
+    try:
+        engine = get_engine()
+        return {
+            "object": "list",
+            "data": [
+                {
+                    "id": engine.model_id,
+                    "object": "model",
+                    "owned_by": "google",
+                    "instruction_tuned": True,
+                    "supports_text_input": True,
+                    "supports_audio_input": True,
+                    "supports_image_input": False,
+                    "supports_text_output": True,
+                    "runtime_mode": "processor_model",
+                    "status": "loaded" if engine.is_loaded() else "warming",
+                }
+            ],
+        }
+    except RuntimeError:
+        raise HTTPException(status_code=503, detail="Service not initialized")
+
+
+@app.post("/v1/respond", response_model=RespondResponse)
+async def respond(
+    request: Request,
+) -> RespondResponse:
+    """Generate response from multimodal input (audio and/or text)."""
+    try:
+        engine = get_engine()
+
+        if not engine.is_loaded():
+            raise HTTPException(status_code=503, detail="Model not loaded")
+
+        request_payload, audio_bytes = await _parse_respond_request(request)
+
+        start_time = time.time()
+
+        # Extract audio and text from messages
+        audio_array = None
+        sample_rate = 16000
+        text_content = None
+
+        if audio_bytes is not None:
+            try:
+                audio_array, sample_rate = audio_from_bytes(audio_bytes)
+            except Exception as e:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Failed to process uploaded audio: {e}",
+                )
+        else:
+            for message in request_payload.messages:
+                for content in message.content:
+                    if content.type == "audio" and content.path:
+                        # Audio referenced by path - load from file
+                        audio_path = Path(content.path)
+                        try:
+                            audio_array, sample_rate = audio_from_file(audio_path)
+                        except Exception as e:
+                            raise HTTPException(
+                                status_code=400,
+                                detail=f"Failed to load audio from {content.path}: {e}",
+                            )
+                    elif content.type == "text" and content.text:
+                        text_content = content.text
+
+        if audio_array is None and not text_content:
+            raise HTTPException(
+                status_code=400, detail="No audio or text content provided"
+            )
+
+        # Use provided prompt or build from task
+        prompt = text_content or request_payload.system_prompt or "Respond to the audio"
+
+        # Run inference
+        try:
+            generated_text, duration = engine.respond(
+                audio_array
+                if audio_array is not None
+                else np.zeros(16000, dtype=np.float32),
+                sample_rate=sample_rate,
+                prompt=prompt,
+                task=request_payload.task,
+                question=request_payload.question,
+                system_prompt=request_payload.system_prompt,
+                max_new_tokens=request_payload.max_new_tokens,
+                temperature=request_payload.temperature,
+                top_p=request_payload.top_p,
+                do_sample=request_payload.do_sample,
+            )
+        except InferenceError as e:
+            raise HTTPException(status_code=500, detail=f"Inference failed: {e}")
+
+        total_duration_ms = int((time.time() - start_time) * 1000)
+
+        return RespondResponse(
+            model=engine.model_id,
+            task=request_payload.task,
+            text=generated_text,
+            duration_ms=total_duration_ms,
+            audio=AudioMetadata(
+                sample_rate=sample_rate,
+                duration_sec=duration,
+            ),
+            input_modalities=["text", "audio"] if audio_array is not None else ["text"],
+            output_modalities=["text"],
+            runtime_mode="processor_model",
+            capabilities=Capabilities(
+                audio_input="verified" if audio_array is not None else "unknown",
+                audio_reasoning="verified" if audio_array is not None else "unknown",
+                audio_transcription="verified"
+                if audio_array is not None
+                else "unknown",
+            ),
+            generation_config=GenerationConfig(
+                max_new_tokens=request_payload.max_new_tokens,
+                temperature=request_payload.temperature,
+                top_p=request_payload.top_p,
+                do_sample=request_payload.do_sample,
+            ),
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Respond endpoint error: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Internal error: {e}")
+
+
+@app.post("/audio/transcribe", response_model=TranscribeResponse)
+async def transcribe(
+    audio: UploadFile = File(...),
+) -> TranscribeResponse:
+    """Transcribe audio file."""
+    try:
+        engine = get_engine()
+
+        if not engine.is_loaded():
+            raise HTTPException(status_code=503, detail="Model not loaded")
+
+        start_time = time.time()
+
+        # Read uploaded file
+        try:
+            file_bytes = await audio.read()
+            audio_array, sample_rate = audio_from_bytes(file_bytes)
+        except Exception as e:
+            raise HTTPException(
+                status_code=400, detail=f"Failed to process audio file: {e}"
+            )
+
+        # Transcribe
+        try:
+            text = engine.transcribe(audio_array, sample_rate)
+        except InferenceError as e:
+            raise HTTPException(status_code=500, detail=f"Transcription failed: {e}")
+
+        duration_sec = get_audio_duration(audio_array, sample_rate)
+        duration_ms = int((time.time() - start_time) * 1000)
+
+        return TranscribeResponse(
+            text=text,
+            duration_ms=duration_ms,
+            audio=AudioMetadata(
+                sample_rate=sample_rate,
+                duration_sec=duration_sec,
+            ),
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Transcribe endpoint error: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Internal error: {e}")
+
+
+@app.post("/warmup")
+async def warmup():
+    """Warmup the model by running a dummy inference."""
+    try:
+        engine = get_engine()
+
+        if not engine.is_loaded():
+            raise HTTPException(status_code=503, detail="Model not loaded")
+
+        # Run a small dummy inference to warm up
+        dummy_audio = np.zeros(16000, dtype=np.float32)  # 1 second of silence
+        try:
+            text, _ = engine.respond(
+                dummy_audio,
+                sample_rate=16000,
+                prompt="Say hello",
+                max_new_tokens=10,
+            )
+            return {"status": "warmed", "sample_output": text}
+        except InferenceError as e:
+            raise HTTPException(status_code=500, detail=f"Warmup failed: {e}")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Warmup error: {e}")
+        raise HTTPException(status_code=500, detail=f"Warmup failed: {e}")
+
+
+@app.get("/")
+async def root():
+    """Root endpoint."""
+    return {
+        "service": "Gemma 4 Audio Runtime",
+        "version": "0.1.0",
+        "status": "running",
+    }
+
+
+def configure_logging(log_file: Optional[str] = None, level: int = logging.INFO):
+    """Configure logging for the service."""
+    root_logger = logging.getLogger()
+    root_logger.setLevel(level)
+
+    # Console handler
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setLevel(level)
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+    console_handler.setFormatter(formatter)
+    root_logger.addHandler(console_handler)
+
+    # File handler if specified
+    if log_file:
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setLevel(level)
+        file_handler.setFormatter(formatter)
+        root_logger.addHandler(file_handler)
+
+    logger.info(f"Logging configured. Level: {logging.getLevelName(level)}")
+
+
+def run_server(
+    host: str = "127.0.0.1",
+    port: int = 8014,
+    log_file: Optional[str] = None,
+):
+    """Run the FastAPI server."""
+    configure_logging(log_file)
+
+    logger.info(f"Starting Gemma 4 Audio Runtime Service on {host}:{port}")
+
+    uvicorn.run(
+        "services.gemma4_audio_runtime.main:app",
+        host=host,
+        port=port,
+        log_level="info",
+        reload=False,
+    )
+
+
+if __name__ == "__main__":
+    # Get configuration from environment
+    host = os.getenv("GEMMA4_AUDIO_HOST", "127.0.0.1")
+    port = int(os.getenv("GEMMA4_AUDIO_PORT", "8014"))
+    log_file = os.getenv("GEMMA4_AUDIO_LOG_PATH", "logs/gemma4_audio_service.log")
+
+    run_server(host, port, log_file)

--- a/services/gemma4_audio_runtime/schemas.py
+++ b/services/gemma4_audio_runtime/schemas.py
@@ -1,0 +1,148 @@
+"""Request/response schemas for Gemma 4 Audio Runtime Service."""
+
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class AudioMetadata(BaseModel):
+    """Metadata about audio input."""
+
+    sample_rate: int = Field(..., description="Audio sample rate in Hz")
+    duration_sec: float = Field(..., description="Audio duration in seconds")
+
+
+class ContentItem(BaseModel):
+    """Individual content item in a message (text or audio reference)."""
+
+    type: Literal["text", "audio"] = Field(..., description="Content type")
+    text: Optional[str] = Field(None, description="Text content (for type='text')")
+    path: Optional[str] = Field(
+        None, description="Audio file path (for type='audio', sent via multipart)"
+    )
+
+
+class MessageItem(BaseModel):
+    """Single message in conversation history."""
+
+    role: Literal["system", "user", "assistant"] = Field(
+        ..., description="Message role"
+    )
+    content: list[ContentItem] = Field(..., description="List of content items")
+
+
+class RespondRequest(BaseModel):
+    """Request to generate text response from multimodal input."""
+
+    model: Optional[str] = Field(
+        None, description="Model ID override; if not set, uses current runtime model"
+    )
+    messages: list[MessageItem] = Field(..., description="Messages with content")
+    task: Optional[str] = Field(
+        None,
+        description="Preset task: 'transcribe', 'question', 'math-5x5', or None for generic",
+    )
+    question: Optional[str] = Field(None, description="Question to answer from audio")
+    system_prompt: Optional[str] = Field(None, description="System message override")
+    max_new_tokens: int = Field(128, description="Generation budget")
+    temperature: Optional[float] = Field(None, description="Sampling temperature")
+    top_p: Optional[float] = Field(None, description="Top-p sampling")
+    do_sample: Optional[bool] = Field(None, description="Use sampling vs greedy")
+
+
+class Capabilities(BaseModel):
+    """Runtime capabilities for this inference."""
+
+    audio_input: Literal["verified", "failed", "unknown"] = Field(
+        ..., description="Audio input capability status"
+    )
+    audio_reasoning: Literal["verified", "failed", "unknown"] = Field(
+        ..., description="Audio reasoning capability status"
+    )
+    audio_transcription: Literal["verified", "failed", "unknown"] = Field(
+        ..., description="Audio transcription capability status"
+    )
+
+
+class GenerationConfig(BaseModel):
+    """Configuration used for generation."""
+
+    max_new_tokens: int
+    temperature: Optional[float] = None
+    top_p: Optional[float] = None
+    do_sample: Optional[bool] = None
+
+
+class RespondResponse(BaseModel):
+    """Response from Gemma 4 Audio Runtime."""
+
+    model: str = Field(..., description="Model ID used for inference")
+    task: Optional[str] = Field(None, description="Task executed")
+    text: str = Field(..., description="Generated text response")
+    duration_ms: int = Field(..., description="Total request duration in milliseconds")
+    audio: AudioMetadata = Field(..., description="Input audio metadata")
+    input_modalities: list[str] = Field(
+        default_factory=lambda: ["text", "audio"],
+        description="Input modalities used",
+    )
+    output_modalities: list[str] = Field(
+        default_factory=lambda: ["text"], description="Output modalities produced"
+    )
+    runtime_mode: str = Field(
+        default="processor_model", description="Inference mode used (processor_model)"
+    )
+    capabilities: Capabilities = Field(..., description="Verified capabilities")
+    generation_config: GenerationConfig = Field(
+        ..., description="Configuration used for generation"
+    )
+    warnings: list[str] = Field(default_factory=list, description="Any warnings")
+    trace_id: Optional[str] = Field(None, description="Request trace ID")
+
+
+class TranscribeRequest(BaseModel):
+    """Request to transcribe audio only."""
+
+    model: Optional[str] = Field(None, description="Model ID override")
+    task: Literal["transcribe"] = Field("transcribe")
+
+
+class TranscribeResponse(BaseModel):
+    """Response from transcription."""
+
+    text: str = Field(..., description="Transcribed text")
+    duration_ms: int = Field(..., description="Processing duration")
+    audio: AudioMetadata = Field(..., description="Input audio metadata")
+
+
+class ModelInfo(BaseModel):
+    """Information about available model."""
+
+    model_id: str = Field(..., description="Model identifier")
+    instruction_tuned: bool = Field(
+        True, description="Whether model is instruction-tuned"
+    )
+    supports_text_input: bool = Field(True)
+    supports_audio_input: bool = Field(True)
+    supports_image_input: bool = Field(False)
+    supports_text_output: bool = Field(True)
+    runtime_mode: str = Field("processor_model")
+    status: Literal["loaded", "warming", "error"] = Field("loaded")
+
+
+class StatusResponse(BaseModel):
+    """Service status response."""
+
+    service: str = Field("gemma4_audio")
+    status: Literal["running", "warming", "error"] = Field("running")
+    model_loaded: bool = Field(..., description="Whether model is currently loaded")
+    model_info: Optional[ModelInfo] = Field(None, description="Loaded model info")
+    timestamp_ms: int = Field(..., description="Server timestamp in ms")
+
+
+class HealthResponse(BaseModel):
+    """Health check response."""
+
+    status: Literal["ok", "warming", "error"] = Field("ok")
+    message: str = Field(...)

--- a/tests/test_academy_adapter_runtime_service.py
+++ b/tests/test_academy_adapter_runtime_service.py
@@ -614,6 +614,16 @@ def test_resolve_limits_fall_back_to_defaults(monkeypatch) -> None:
     ) == pytest.approx(0.25)
 
 
+def test_resolve_limits_use_defaults_for_non_positive_values(monkeypatch) -> None:
+    monkeypatch.setenv("ACADEMY_ADAPTER_MERGE_MAX_RSS_MB", "0")
+    monkeypatch.setenv("ACADEMY_ADAPTER_MEMORY_MONITOR_INTERVAL_SEC", "-1")
+
+    assert ars._resolve_merge_memory_limit_mb(settings_obj=SimpleNamespace()) == 15360
+    assert ars._resolve_memory_monitor_interval_sec(
+        settings_obj=SimpleNamespace()
+    ) == pytest.approx(0.25)
+
+
 def test_read_process_rss_mb_returns_zero_for_missing_pid() -> None:
     assert ars._read_process_rss_mb(pid=999_999_999) == pytest.approx(0.0)
 
@@ -696,6 +706,23 @@ def test_build_hf_cache_env_sets_local_cache_paths(tmp_path: Path) -> None:
     )
     assert env["TRANSFORMERS_CACHE"] == str(
         (tmp_path / "models" / "cache" / "huggingface" / "hub").resolve()
+    )
+
+
+def test_build_hf_cache_env_warns_when_cache_dirs_cannot_be_created(
+    tmp_path: Path, monkeypatch
+) -> None:
+    settings = SimpleNamespace(REPO_ROOT=str(tmp_path))
+    warning = MagicMock()
+
+    monkeypatch.setattr(ars.logger, "warning", warning)
+    monkeypatch.setattr(ars.Path, "mkdir", MagicMock(side_effect=OSError("denied")))
+
+    env = ars._build_hf_cache_env(base_env={}, settings_obj=settings)
+
+    assert env["HF_HOME"].endswith("models/cache/huggingface")
+    warning.assert_called_once_with(
+        "Failed to ensure local Hugging Face cache directories."
     )
 
 
@@ -949,6 +976,35 @@ def test_deploy_adapter_to_vllm_runtime_raises_for_non_runtime_model_dir(
             )
 
 
+def test_deploy_adapter_to_vllm_runtime_rejects_missing_adapter_and_empty_base_model(
+    tmp_path: Path,
+) -> None:
+    settings = SimpleNamespace(ACADEMY_MODELS_DIR=str(tmp_path / "models"))
+
+    with pytest.raises(FileNotFoundError, match="Adapter not found"):
+        ars._deploy_adapter_to_vllm_runtime(
+            adapter_id="missing-adapter",
+            settings_obj=settings,
+        )
+
+    adapter_dir = Path(settings.ACADEMY_MODELS_DIR) / "adapter-empty-base"
+    (adapter_dir / "adapter").mkdir(parents=True, exist_ok=True)
+
+    with (
+        patch.object(ars, "_require_trusted_adapter_base_model", return_value=""),
+        patch.object(
+            ars, "_resolve_local_training_base_model_for_merge", return_value=""
+        ),
+    ):
+        with pytest.raises(
+            RuntimeError, match="Adapter base model is empty; cannot deploy to vLLM"
+        ):
+            ars._deploy_adapter_to_vllm_runtime(
+                adapter_id="adapter-empty-base",
+                settings_obj=settings,
+            )
+
+
 def test_runtime_helper_paths_and_onnx_export_cmd(tmp_path: Path) -> None:
     root = tmp_path / "repo"
     root.mkdir(parents=True, exist_ok=True)
@@ -981,6 +1037,23 @@ def test_runtime_helper_paths_and_onnx_export_cmd(tmp_path: Path) -> None:
     assert runtime_tmp.exists()
     ars._cleanup_optional_dir(runtime_tmp)
     assert not runtime_tmp.exists()
+    ars._cleanup_optional_dir(None)
+
+
+def test_runtime_path_helpers_reject_unsafe_targets_and_cleanup_optional_dir() -> None:
+    with pytest.raises(ValueError, match="Invalid file name"):
+        ars._resolve_safe_child_file_path(
+            parent_dir=Path("/tmp"),
+            file_name="../escape.json",
+        )
+
+    with pytest.raises(ValueError, match="Invalid file name"):
+        ars._write_json_file_in_dir(
+            directory=Path("/tmp"),
+            file_name="../escape.json",
+            payload={"ok": False},
+        )
+
     ars._cleanup_optional_dir(None)
 
 
@@ -1027,3 +1100,80 @@ def test_subprocess_guard_helpers_timeout_and_memory_exceeded(monkeypatch) -> No
     )
     assert state["exceeded"] is True
     assert terminate_called["value"] is True
+
+
+def test_process_termination_helpers_cover_error_paths(monkeypatch) -> None:
+    class _KillErrorProcess:
+        def kill(self):
+            raise OSError("nope")
+
+    ars._kill_process_safely(process=_KillErrorProcess())
+
+    class _GraceProcess:
+        def __init__(self):
+            self.poll_calls = 0
+            self.sent = False
+
+        def send_signal(self, _sig):
+            self.sent = True
+            raise OSError("sigterm failed")
+
+        def poll(self):
+            self.poll_calls += 1
+            return None if self.poll_calls < 2 else None
+
+    kill_called = {"value": False}
+    monkeypatch.setattr(
+        ars,
+        "_kill_process_safely",
+        lambda **_kwargs: kill_called.__setitem__("value", True),
+    )
+    monkeypatch.setattr(ars.time, "sleep", lambda _seconds: None)
+
+    process = _GraceProcess()
+    ars._terminate_process_with_grace(
+        process=process,
+        stop_event=threading.Event(),
+    )
+
+    assert process.sent is True
+    assert kill_called["value"] is True
+
+
+def test_restart_vllm_runtime_runs_service_and_surfaces_failures(
+    tmp_path: Path,
+) -> None:
+    scripts_dir = tmp_path / "scripts" / "llm"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    service_script = scripts_dir / "vllm_service.sh"
+    service_script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+
+    with patch.object(
+        ars.subprocess,
+        "run",
+        return_value=SimpleNamespace(returncode=0, stdout="ok", stderr=""),
+    ) as mocked_run:
+        ars._restart_vllm_runtime(
+            resolve_repo_root_fn=lambda **_kwargs: tmp_path,
+            settings_obj=SimpleNamespace(),
+        )
+
+    mocked_run.assert_called_once_with(
+        ["bash", str(service_script), "restart"],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+    with patch.object(
+        ars.subprocess,
+        "run",
+        return_value=SimpleNamespace(returncode=1, stdout="", stderr="broken"),
+    ):
+        with pytest.raises(
+            RuntimeError, match="Failed to restart vLLM runtime: broken"
+        ):
+            ars._restart_vllm_runtime(
+                resolve_repo_root_fn=lambda **_kwargs: tmp_path,
+                settings_obj=SimpleNamespace(),
+            )

--- a/tests/test_audio_stream_handler_roi.py
+++ b/tests/test_audio_stream_handler_roi.py
@@ -942,8 +942,36 @@ async def test_invoke_gemma4_audio_runtime_builds_request_and_validates_response
     monkeypatch.setattr(
         handler, "_gemma4_audio_respond_url", lambda: "http://runtime/v1/respond"
     )
+    monkeypatch.setattr(
+        audio_stream_mod.Path,
+        "open",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("sync Path.open() should not be used")
+        ),
+    )
 
     calls = {}
+
+    class _AsyncBinaryFile:
+        def __init__(self, path: str):
+            self.path = path
+
+    class _AsyncOpenContext:
+        def __init__(self, path, mode):
+            self.path = path
+            self.mode = mode
+
+        async def __aenter__(self):
+            return _AsyncBinaryFile(str(self.path))
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    async def _fake_open_file(path, mode):
+        calls["open_file"] = (str(path), mode)
+        return _AsyncOpenContext(path, mode)
+
+    monkeypatch.setattr(audio_stream_mod.anyio, "open_file", _fake_open_file)
 
     class _AsyncClient:
         def __init__(self, *args, **kwargs):
@@ -976,6 +1004,7 @@ async def test_invoke_gemma4_audio_runtime_builds_request_and_validates_response
     assert result["text"] == "25"
     assert result["response_text"] == "25"
     assert result["connection_id"] == 17
+    assert calls["open_file"] == (str(wav_path), "rb")
     assert calls["url"] == "http://runtime/v1/respond"
     request_payload = json.loads(calls["data"]["request"])
     assert request_payload["task"] == "question"

--- a/tests/test_audio_stream_handler_roi.py
+++ b/tests/test_audio_stream_handler_roi.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import json
 import os
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
@@ -270,6 +271,40 @@ async def test_handle_websocket_registers_and_cleans_up_connection():
 
     websocket.accept.assert_awaited_once()
     assert handler.active_connections == {}
+
+
+@pytest.mark.asyncio
+async def test_handle_websocket_routes_text_and_bytes(monkeypatch):
+    """handle_websocket should dispatch text commands and raw bytes."""
+    handler = _make_handler()
+    websocket = MagicMock()
+    websocket.accept = AsyncMock()
+    websocket.receive = AsyncMock(
+        side_effect=[
+            {"text": json.dumps({"command": "ping"})},
+            {"bytes": b"pcm-data"},
+            audio_stream_mod.WebSocketDisconnect(),
+        ]
+    )
+
+    control_calls = []
+    byte_calls = []
+
+    async def fake_control(connection_id, message, operator_agent):
+        control_calls.append((connection_id, message, operator_agent))
+
+    def fake_audio(connection_id, payload, operator_agent):
+        byte_calls.append((connection_id, payload, operator_agent))
+
+    monkeypatch.setattr(handler, "_handle_control_message", fake_control)
+    monkeypatch.setattr(handler, "_handle_audio_data", fake_audio)
+
+    await handler.handle_websocket(websocket, operator_agent="agent")
+
+    assert control_calls
+    assert control_calls[0][1] == json.dumps({"command": "ping"})
+    assert byte_calls
+    assert byte_calls[0][1] == b"pcm-data"
 
 
 @pytest.mark.asyncio
@@ -676,6 +711,56 @@ def test_collect_latest_voice_session_record_returns_none_for_missing_root(tmp_p
     )
 
 
+def test_is_voice_session_eligible_handles_invalid_metadata():
+    """Eligibility helper should be tolerant to malformed metadata."""
+    assert audio_stream_mod._is_voice_session_eligible(
+        {"duration_sec": "bad", "samples": object()}
+    )
+    assert not audio_stream_mod._is_voice_session_eligible(
+        {"duration_sec": 0.1, "samples": 999999}
+    )
+    assert not audio_stream_mod._is_voice_session_eligible(
+        {"duration_sec": 1.0, "samples": 10}
+    )
+
+
+def test_build_voice_session_record_includes_runtime_fields(tmp_path):
+    """Collected record should expose added runtime metadata fields."""
+    record = audio_stream_mod._build_voice_session_record(
+        tmp_path / "session-a",
+        {
+            "created_at": "2026-05-11T08:00:00Z",
+            "duration_sec": 1.25,
+            "sample_rate": 16000,
+            "input_format": "mediarecorder",
+            "mime_type": "audio/webm",
+            "voice_mode": "summary",
+            "timings_ms": {"stt_ms": 12.0},
+            "runtime": {"provider": "gemma4_audio"},
+            "pipeline_id": "gemma4_audio_piper",
+            "audio_runtime_provider": "gemma4_audio",
+            "audio_runtime_model": "google/gemma-4-E2B-it",
+            "audio_input_status": "verified",
+            "fallback_reason": None,
+            "native_audio_ms": 111.0,
+            "runtime_log_path": "logs/gemma4_audio_service.log",
+            "transcription": "piec razy piec",
+            "response_text": "25",
+        },
+    )
+
+    assert record["session_id"] == "session-a"
+    assert record["voice_mode"] == "summary"
+    assert record["runtime"] == {"provider": "gemma4_audio"}
+    assert record["pipeline_id"] == "gemma4_audio_piper"
+    assert record["audio_runtime_provider"] == "gemma4_audio"
+    assert record["audio_runtime_model"] == "google/gemma-4-E2B-it"
+    assert record["audio_input_status"] == "verified"
+    assert record["runtime_log_path"] == "logs/gemma4_audio_service.log"
+    assert record["transcription"] == "piec razy piec"
+    assert record["response_text"] == "25"
+
+
 def test_create_voice_session_dir_uses_unique_names(monkeypatch, tmp_path):
     """Voice session directories should not collide for rapid consecutive calls."""
     monkeypatch.setattr(audio_stream_mod, "VOICE_SESSION_ROOT", tmp_path)
@@ -688,6 +773,27 @@ def test_create_voice_session_dir_uses_unique_names(monkeypatch, tmp_path):
     assert first != second
     assert first.parent == tmp_path
     assert second.parent == tmp_path
+
+
+def test_create_voice_session_dir_retries_after_collision(monkeypatch, tmp_path):
+    """Directory creation should retry on FileExistsError."""
+    monkeypatch.setattr(audio_stream_mod, "VOICE_SESSION_ROOT", tmp_path)
+
+    original_mkdir = audio_stream_mod.Path.mkdir
+    calls = {"count": 0}
+
+    def flaky_mkdir(path_obj, parents=False, exist_ok=False):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise FileExistsError
+        return original_mkdir(path_obj, parents=parents, exist_ok=exist_ok)
+
+    monkeypatch.setattr(audio_stream_mod.Path, "mkdir", flaky_mkdir)
+
+    created = audio_stream_mod._create_voice_session_dir(18)
+
+    assert created.exists()
+    assert calls["count"] >= 2
 
 
 def test_get_latest_voice_session_falls_back_to_filesystem(monkeypatch, tmp_path):
@@ -739,6 +845,301 @@ def test_build_runtime_metadata_and_tts_sample_rate():
 
     handler.audio_engine.voice.output_sample_rate = None
     assert handler._get_tts_sample_rate() == 22050
+
+
+def test_gemma4_audio_helper_urls_and_selection(monkeypatch):
+    """Gemma4 helper URLs should normalize /v1 origin and selected state."""
+    handler = _make_handler()
+
+    monkeypatch.setattr(
+        audio_stream_mod.SETTINGS,
+        "GEMMA4_AUDIO_ENDPOINT",
+        "http://localhost:8014/v1/",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        audio_stream_mod.SETTINGS, "GEMMA4_AUDIO_ENABLED", True, raising=False
+    )
+    monkeypatch.setattr(
+        audio_stream_mod.SETTINGS, "ACTIVE_LLM_SERVER", "gemma4_audio", raising=False
+    )
+
+    assert handler._gemma4_audio_service_origin() == "http://localhost:8014"
+    assert handler._gemma4_audio_respond_url() == "http://localhost:8014/v1/respond"
+    assert handler._gemma4_audio_health_url() == "http://localhost:8014/health"
+    assert handler._gemma4_audio_runtime_selected() is True
+
+    monkeypatch.setattr(
+        audio_stream_mod.SETTINGS, "ACTIVE_LLM_SERVER", "ollama", raising=False
+    )
+    assert handler._gemma4_audio_runtime_selected() is False
+
+
+@pytest.mark.asyncio
+async def test_gemma4_audio_health_ok_handles_success_and_failures(monkeypatch):
+    """Health check should accept ok/warming and reject invalid responses."""
+    handler = _make_handler()
+    monkeypatch.setattr(
+        handler, "_gemma4_audio_health_url", lambda: "http://runtime/health"
+    )
+
+    responses = iter(
+        [
+            SimpleNamespace(status_code=200, json=lambda: {"status": "warming"}),
+            SimpleNamespace(status_code=503, json=lambda: {"status": "down"}),
+        ]
+    )
+
+    class _AsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, _url):
+            return next(responses)
+
+    monkeypatch.setattr(audio_stream_mod.httpx, "AsyncClient", _AsyncClient)
+
+    assert await handler._gemma4_audio_health_ok() is True
+    assert await handler._gemma4_audio_health_ok() is False
+
+    monkeypatch.setattr(handler, "_gemma4_audio_health_url", lambda: "")
+    assert await handler._gemma4_audio_health_ok() is False
+
+
+@pytest.mark.asyncio
+async def test_invoke_gemma4_audio_runtime_builds_request_and_validates_response(
+    monkeypatch, tmp_path
+):
+    """Gemma4 runtime request should send multipart payload and parse text result."""
+    handler = _make_handler()
+    wav_path = tmp_path / "recording.wav"
+    wav_path.write_bytes(b"RIFF....WAVEfmt ")
+
+    monkeypatch.setattr(
+        audio_stream_mod.SETTINGS,
+        "SIMPLE_MODE_SYSTEM_PROMPT",
+        "system prompt",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        audio_stream_mod.SETTINGS,
+        "GEMMA4_AUDIO_MAX_NEW_TOKENS",
+        77,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        audio_stream_mod.SETTINGS,
+        "GEMMA4_AUDIO_MODEL_ID",
+        "google/gemma-4-E2B-it",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        handler, "_gemma4_audio_respond_url", lambda: "http://runtime/v1/respond"
+    )
+
+    calls = {}
+
+    class _AsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, data=None, files=None):
+            calls["url"] = url
+            calls["data"] = data
+            calls["files"] = files
+            return SimpleNamespace(
+                status_code=200,
+                json=lambda: {
+                    "text": "25",
+                    "model": "google/gemma-4-E2B-it",
+                    "duration_ms": 123,
+                },
+                text="",
+            )
+
+    monkeypatch.setattr(audio_stream_mod.httpx, "AsyncClient", _AsyncClient)
+
+    result = await handler._invoke_gemma4_audio_runtime(wav_path, 17)
+
+    assert result["text"] == "25"
+    assert result["response_text"] == "25"
+    assert result["connection_id"] == 17
+    assert calls["url"] == "http://runtime/v1/respond"
+    request_payload = json.loads(calls["data"]["request"])
+    assert request_payload["task"] == "question"
+    assert request_payload["max_new_tokens"] == 77
+    assert request_payload["messages"][0]["content"][0] == {
+        "type": "audio",
+        "path": "recording.wav",
+    }
+    assert calls["files"]["audio"][0] == "recording.wav"
+
+
+@pytest.mark.asyncio
+async def test_invoke_gemma4_audio_runtime_raises_for_http_and_empty_text(
+    monkeypatch, tmp_path
+):
+    """Gemma4 runtime should reject HTTP errors and empty text payloads."""
+    handler = _make_handler()
+    wav_path = tmp_path / "recording.wav"
+    wav_path.write_bytes(b"RIFF....WAVEfmt ")
+    monkeypatch.setattr(
+        handler, "_gemma4_audio_respond_url", lambda: "http://runtime/v1/respond"
+    )
+
+    class _HttpErrorClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def post(self, url, data=None, files=None):
+            return SimpleNamespace(status_code=503, json=lambda: {}, text="down")
+
+    monkeypatch.setattr(audio_stream_mod.httpx, "AsyncClient", _HttpErrorClient)
+
+    with pytest.raises(RuntimeError, match="Gemma4 audio runtime HTTP 503: down"):
+        await handler._invoke_gemma4_audio_runtime(wav_path, 7)
+
+    class _EmptyTextClient(_HttpErrorClient):
+        async def post(self, url, data=None, files=None):
+            return SimpleNamespace(status_code=200, json=lambda: {"text": ""}, text="")
+
+    monkeypatch.setattr(audio_stream_mod.httpx, "AsyncClient", _EmptyTextClient)
+
+    with pytest.raises(RuntimeError, match="returned an empty response"):
+        await handler._invoke_gemma4_audio_runtime(wav_path, 8)
+
+
+@pytest.mark.asyncio
+async def test_process_native_gemma4_audio_pipeline_handles_selection_and_fallbacks(
+    monkeypatch, tmp_path
+):
+    """Native pipeline should short-circuit cleanly before whisper fallback."""
+    handler = _make_handler()
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    wav_path = session_dir / "recording.wav"
+    wav_path.write_bytes(b"wav")
+    timings_ms = {}
+
+    monkeypatch.setattr(handler, "_gemma4_audio_runtime_selected", lambda: False)
+    assert (
+        await handler._process_native_gemma4_audio_pipeline(
+            1, session_dir, wav_path, timings_ms, 0.0, MagicMock()
+        )
+        is False
+    )
+
+    handler.audio_engine = MagicMock()
+    monkeypatch.setattr(handler, "_gemma4_audio_runtime_selected", lambda: True)
+    monkeypatch.setattr(
+        handler,
+        "_gemma4_audio_runtime_snapshot",
+        lambda: {"audio_runtime_provider": "gemma4_audio"},
+    )
+    monkeypatch.setattr(
+        handler, "_gemma4_audio_health_ok", AsyncMock(return_value=False)
+    )
+    update_calls = []
+    monkeypatch.setattr(
+        handler,
+        "_update_voice_session_metadata",
+        lambda _dir, payload: update_calls.append(payload),
+    )
+    monkeypatch.setattr(handler, "_build_runtime_metadata", lambda _agent: {"llm": "x"})
+    monkeypatch.setattr(handler, "_connection_voice_mode", lambda _cid: "standard")
+
+    assert (
+        await handler._process_native_gemma4_audio_pipeline(
+            2, session_dir, wav_path, timings_ms, 0.0, MagicMock()
+        )
+        is False
+    )
+    assert update_calls[-1]["pipeline_id"] == "whisper_llm_piper"
+    assert update_calls[-1]["fallback_reason"] == "gemma4_audio health check failed"
+
+
+@pytest.mark.asyncio
+async def test_process_native_gemma4_audio_pipeline_success(monkeypatch, tmp_path):
+    """Native pipeline success should update metadata and send TTS response."""
+    handler = _make_handler()
+    handler.audio_engine = MagicMock()
+    handler.audio_engine.speak = AsyncMock(
+        return_value=np.array([1, 2], dtype=np.int16)
+    )
+    session_dir = tmp_path / "session"
+    session_dir.mkdir()
+    wav_path = session_dir / "recording.wav"
+    wav_path.write_bytes(b"wav")
+    timings_ms = {}
+    sent_json = []
+    sent_audio = []
+    update_calls = []
+
+    monkeypatch.setattr(handler, "_gemma4_audio_runtime_selected", lambda: True)
+    monkeypatch.setattr(
+        handler,
+        "_gemma4_audio_runtime_snapshot",
+        lambda: {"audio_runtime_provider": "gemma4_audio"},
+    )
+    monkeypatch.setattr(
+        handler, "_gemma4_audio_health_ok", AsyncMock(return_value=True)
+    )
+    monkeypatch.setattr(
+        handler,
+        "_invoke_gemma4_audio_runtime",
+        AsyncMock(return_value={"text": "piec razy piec", "response_text": "25"}),
+    )
+    monkeypatch.setattr(
+        handler,
+        "_update_voice_session_metadata",
+        lambda _dir, payload: update_calls.append(payload),
+    )
+    monkeypatch.setattr(handler, "_build_runtime_metadata", lambda _agent: {"llm": "x"})
+    monkeypatch.setattr(handler, "_connection_voice_mode", lambda _cid: "summary")
+    monkeypatch.setattr(
+        handler,
+        "_send_json",
+        AsyncMock(side_effect=lambda cid, payload: sent_json.append(payload)),
+    )
+    monkeypatch.setattr(
+        handler,
+        "_send_audio",
+        AsyncMock(side_effect=lambda cid, audio: sent_audio.append(audio)),
+    )
+    monkeypatch.setattr(handler, "_elapsed_ms", lambda _started: 12.5)
+
+    result = await handler._process_native_gemma4_audio_pipeline(
+        3, session_dir, wav_path, timings_ms, 0.0, MagicMock()
+    )
+
+    assert result is True
+    assert sent_json[0] == {"type": "processing", "status": "native_audio"}
+    assert sent_json[1]["type"] == "transcription"
+    assert sent_json[1]["text"] == "piec razy piec"
+    assert sent_json[2] == {"type": "response_text", "text": "25"}
+    assert sent_json[-1] == {"type": "complete"}
+    assert len(sent_audio) == 1
+    assert update_calls[0]["pipeline_id"] == "gemma4_audio_piper"
+    assert update_calls[0]["transcription"] == "piec razy piec"
+    assert update_calls[1]["pipeline_id"] == "gemma4_audio_piper"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_env_contracts.py
+++ b/tests/test_env_contracts.py
@@ -1,0 +1,28 @@
+import os
+
+
+def _read_env_keys(path: str) -> dict:
+    data = {}
+    if not os.path.isfile(path):
+        return data
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            data[k.strip()] = v.strip()
+    return data
+
+
+def test_gemma4_keys_present_in_env_dev():
+    example = _read_env_keys(".env.dev.example")
+    dev = _read_env_keys(".env.dev")
+
+    gemma_keys = [k for k in example.keys() if k.startswith("GEMMA4_AUDIO_")]
+    assert gemma_keys, "No GEMMA4_AUDIO_ keys found in .env.dev.example"
+
+    missing = [k for k in gemma_keys if k not in dev]
+    assert not missing, f"Missing GEMMA4_AUDIO keys in .env.dev: {missing}"

--- a/tests/test_llm_runtime_options_api.py
+++ b/tests/test_llm_runtime_options_api.py
@@ -473,7 +473,7 @@ async def test_local_models_by_runtime_reports_unknown_provider_issue(
             local_models=local_models,
         )
 
-    assert grouped == {"ollama": [], "vllm": [], "onnx": []}
+    assert grouped == {"ollama": [], "vllm": [], "onnx": [], "gemma4_audio": []}
     assert audit == [
         {
             "name": "mystery-model",

--- a/tests/test_llm_runtime_utils.py
+++ b/tests/test_llm_runtime_utils.py
@@ -32,6 +32,10 @@ def test_infer_local_provider_variants():
     assert llm_runtime.infer_local_provider("") == "local"
     assert llm_runtime.infer_local_provider(LOCALHOST_11434) == "ollama"
     assert llm_runtime.infer_local_provider(http_url("vllm.local")) == "vllm"
+    assert (
+        llm_runtime.infer_local_provider("http://gemma4.local:8014/v1")
+        == "gemma4_audio"
+    )
     assert llm_runtime.infer_local_provider(http_url("onnx.local")) == "onnx"
     assert llm_runtime.infer_local_provider(http_url("lmstudio.local")) == "lmstudio"
     assert llm_runtime.infer_local_provider(LOCALHOST_8001) == "vllm"
@@ -144,6 +148,18 @@ def test_format_runtime_label_and_health_url():
             )
         )
         is None
+    )
+    assert (
+        llm_runtime._build_health_url(
+            llm_runtime.LLMRuntimeInfo(
+                provider="gemma4_audio",
+                model_name="x",
+                endpoint="http://localhost:8014/v1",
+                service_type="local",
+                mode="LOCAL",
+            )
+        )
+        == "http://localhost:8014/health"
     )
 
 

--- a/tests/test_llm_server_controller.py
+++ b/tests/test_llm_server_controller.py
@@ -18,6 +18,10 @@ def _dummy_settings(**kwargs):
         "OLLAMA_START_COMMAND": "",
         "OLLAMA_STOP_COMMAND": "",
         "OLLAMA_RESTART_COMMAND": "",
+        "GEMMA4_AUDIO_ENDPOINT": "http://localhost:8014/v1",
+        "GEMMA4_AUDIO_START_COMMAND": "",
+        "GEMMA4_AUDIO_STOP_COMMAND": "",
+        "GEMMA4_AUDIO_RESTART_COMMAND": "",
         "LLM_SERVICE_TYPE": "local",
         "OPENAI_API_KEY": "",
         "ENABLE_SANDBOX": False,
@@ -33,6 +37,7 @@ def test_list_servers_contains_known_entries():
     assert "vllm" in names
     assert "ollama" in names
     assert "onnx" in names
+    assert "gemma4_audio" in names
 
 
 @pytest.mark.asyncio

--- a/tests/test_main_internal_helpers.py
+++ b/tests/test_main_internal_helpers.py
@@ -37,6 +37,16 @@ def test_extract_available_local_models_skips_missing_name_key():
     assert main_module._extract_available_local_models(models, "ollama") == {"ok"}
 
 
+def test_main_app_includes_runtime_and_system_routes():
+    """Main app should expose the expected runtime/system route prefixes."""
+    paths = {route.path for route in main_module.app.routes if hasattr(route, "path")}
+
+    assert "/api/v1/system/llm-servers" in paths
+    assert "/api/v1/system/llm-servers/active" in paths
+    assert "/api/v1/system/llm-runtime/options" in paths
+    assert "/api/v1/audio/status" in paths
+
+
 def test_select_startup_model_priority_chain():
     available = {"model-a", "model-b"}
     assert (

--- a/tests/test_model_registry_split_modules.py
+++ b/tests/test_model_registry_split_modules.py
@@ -219,6 +219,8 @@ async def test_runtime_paths(monkeypatch, tmp_path: Path):
         REPO_ROOT=str(tmp_path),
         LLM_MODEL_NAME="",
         ACTIVE_LLM_SERVER="",
+        LLM_LOCAL_ENDPOINT="http://localhost:8001/v1",
+        GEMMA4_AUDIO_ENDPOINT="http://localhost:8014/v1",
     )
     config_manager = SimpleNamespace(update_config=Mock())
 

--- a/tests/test_operator_agent.py
+++ b/tests/test_operator_agent.py
@@ -95,6 +95,17 @@ class TestOperatorAgent:
         assert agent._is_hardware_command("napisz kod w Python") is False
         assert agent._is_hardware_command("zrób research o AI") is False
 
+    def test_low_level_hardware_command_detectors(self, mock_kernel):
+        """Low-level helpers should classify GPIO/emergency commands correctly."""
+        agent = OperatorAgent(kernel=mock_kernel)
+
+        assert agent._is_gpio_disable_command("wyłącz gpio 21") is True
+        assert agent._is_gpio_disable_command("włącz gpio 21") is False
+        assert agent._is_emergency_command("procedura awaryjna reset gpio") is True
+        assert agent._is_emergency_command("zwykła komenda") is False
+        assert agent._extract_gpio_pin("wyłącz gpio 17") == 17
+        assert agent._extract_gpio_pin("wyłącz pin bez numeru") is None
+
     @pytest.mark.asyncio
     async def test_handle_hardware_command_no_bridge(self, mock_kernel):
         """Test obsługi komendy sprzętowej bez hardware bridge."""

--- a/tests/test_runtime_registry_contracts.py
+++ b/tests/test_runtime_registry_contracts.py
@@ -24,7 +24,7 @@ def test_module_registry_manifest_path_helpers():
     assert module_registry._looks_like_manifest_path("id|a.b:router") is False
 
 
-def test_onnx_helpers_and_model_runtime_branch(tmp_path):
+def test_onnx_helpers_and_model_runtime_branch(monkeypatch, tmp_path):
     assert OnnxLlmClient._normalize_execution_provider("unknown") == "cuda"
     assert OnnxLlmClient._provider_fallback_order("cpu") == ["cpu"]
     assert "DML" in OnnxLlmClient._provider_aliases("directml")
@@ -39,6 +39,28 @@ def test_onnx_helpers_and_model_runtime_branch(tmp_path):
         "model-x", meta, updates, settings
     )
     assert updates["VLLM_SERVED_MODEL_NAME"] == "model-x"
+
+    from venom_core import config as config_module
+    from venom_core.services.config_manager import config_manager
+
+    settings = config_module.SETTINGS
+    monkeypatch.setattr(
+        settings, "GEMMA4_AUDIO_ENDPOINT", "http://localhost:8014/v1", raising=False
+    )
+    monkeypatch.setattr(
+        settings, "LLM_LOCAL_ENDPOINT", "http://localhost:11434", raising=False
+    )
+    monkeypatch.setattr(settings, "LLM_MODEL_NAME", "old-model", raising=False)
+    monkeypatch.setattr(settings, "ACTIVE_LLM_SERVER", "ollama", raising=False)
+    monkeypatch.setattr(settings, "LLM_SERVICE_TYPE", "local", raising=False)
+    monkeypatch.setattr(config_manager, "update_config", MagicMock(), raising=False)
+
+    configured = model_registry_runtime.apply_model_activation_config(
+        "model-gemma4", "gemma4_audio", SimpleNamespace(local_path="")
+    )
+    assert configured.ACTIVE_LLM_SERVER == "gemma4_audio"
+    assert configured.LLM_LOCAL_ENDPOINT == "http://localhost:8014/v1"
+    assert configured.LAST_MODEL_GEMMA4_AUDIO == "model-gemma4"
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_registry_translation_contracts.py
+++ b/tests/test_runtime_registry_translation_contracts.py
@@ -769,6 +769,8 @@ async def test_runtime_module_branches_for_activation_and_restart(monkeypatch):
         REPO_ROOT=".",
         LLM_MODEL_NAME="",
         ACTIVE_LLM_SERVER="",
+        LLM_LOCAL_ENDPOINT="http://localhost:8001/v1",
+        GEMMA4_AUDIO_ENDPOINT="http://localhost:8014/v1",
     )
     with (
         pytest.MonkeyPatch.context() as mp,

--- a/tests/test_system_llm_service.py
+++ b/tests/test_system_llm_service.py
@@ -14,11 +14,13 @@ def test_runtime_profile_name_and_allowed_servers():
     assert svc.allowed_local_servers(profile="full", onnx_enabled=False) == {
         "ollama",
         "vllm",
+        "gemma4_audio",
     }
     assert svc.allowed_local_servers(profile="full", onnx_enabled=True) == {
         "ollama",
         "vllm",
         "onnx",
+        "gemma4_audio",
     }
 
 
@@ -27,7 +29,7 @@ def test_installed_local_servers_composition():
         ollama_installed=True,
         vllm_installed=False,
         onnx_installed=True,
-    ) == {"ollama", "onnx"}
+    ) == {"ollama", "onnx", "gemma4_audio"}
 
 
 def test_provider_and_model_key_helpers():

--- a/venom_core/api/audio_stream.py
+++ b/venom_core/api/audio_stream.py
@@ -13,6 +13,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TypedDict
 
+import anyio
 import httpx
 import numpy as np
 from fastapi import WebSocket, WebSocketDisconnect
@@ -667,7 +668,7 @@ class AudioStreamHandler:
         }
 
         timeout = httpx.Timeout(GEMMA4_AUDIO_REQUEST_TIMEOUT_SEC, connect=5.0)
-        with wav_path.open("rb") as audio_file:
+        async with await anyio.open_file(wav_path, "rb") as audio_file:
             files = {
                 "audio": (wav_path.name, audio_file, "audio/wav"),
             }

--- a/venom_core/api/audio_stream.py
+++ b/venom_core/api/audio_stream.py
@@ -13,6 +13,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, TypedDict
 
+import httpx
 import numpy as np
 from fastapi import WebSocket, WebSocketDisconnect
 
@@ -36,6 +37,8 @@ VOICE_SESSION_ROOT = PROJECT_ROOT / "data" / "audio" / "voice_sessions"
 MIN_VOICE_SESSION_DURATION_SEC = 0.25
 VOICE_SESSION_WAV_FILENAME = "recording.wav"
 VOICE_SESSION_METADATA_FILENAME = "metadata.json"
+GEMMA4_AUDIO_HEALTH_TIMEOUT_SEC = 5.0
+GEMMA4_AUDIO_REQUEST_TIMEOUT_SEC = 120.0
 
 
 def _load_voice_session_metadata(metadata_path: Path) -> dict[str, Any]:
@@ -85,6 +88,13 @@ def _build_voice_session_record(
         "peak_after_normalization": metadata.get("peak_after_normalization"),
         "timings_ms": metadata.get("timings_ms") or {},
         "runtime": metadata.get("runtime") or {},
+        "pipeline_id": metadata.get("pipeline_id"),
+        "audio_runtime_provider": metadata.get("audio_runtime_provider"),
+        "audio_runtime_model": metadata.get("audio_runtime_model"),
+        "audio_input_status": metadata.get("audio_input_status"),
+        "fallback_reason": metadata.get("fallback_reason"),
+        "native_audio_ms": metadata.get("native_audio_ms"),
+        "runtime_log_path": metadata.get("runtime_log_path"),
         "transcription": metadata.get("transcription") or "",
         "response_text": metadata.get("response_text") or "",
     }
@@ -225,6 +235,7 @@ class AudioStreamHandler:
             "tts_model_path": getattr(voice, "model_path", None),
             "tts_fallback": getattr(voice, "is_fallback_mode", None),
             "dependencies": dependencies,
+            **self._gemma4_audio_runtime_snapshot(),
         }
 
     def get_latest_voice_session(self) -> dict[str, object] | None:
@@ -554,6 +565,250 @@ class AudioStreamHandler:
         voice_mode = conn["voice_mode"]
         return str(voice_mode).strip() or "standard"
 
+    def _gemma4_audio_runtime_snapshot(self) -> dict[str, Any]:
+        endpoint = _coerce_str(getattr(SETTINGS, "GEMMA4_AUDIO_ENDPOINT", ""), "")
+        log_path = _coerce_str(getattr(SETTINGS, "GEMMA4_AUDIO_LOG_PATH", ""), "")
+        pid_path = _coerce_str(getattr(SETTINGS, "GEMMA4_AUDIO_PID_PATH", ""), "")
+        return {
+            "audio_runtime_provider": "gemma4_audio",
+            "audio_runtime_model": _coerce_str(
+                getattr(SETTINGS, "GEMMA4_AUDIO_MODEL_ID", ""), ""
+            ),
+            "audio_runtime_endpoint": endpoint,
+            "audio_runtime_enabled": bool(
+                getattr(SETTINGS, "GEMMA4_AUDIO_ENABLED", False)
+            ),
+            "audio_runtime_selected": self._gemma4_audio_runtime_selected(),
+            "audio_runtime_supports_audio": bool(
+                getattr(SETTINGS, "GEMMA4_AUDIO_SUPPORTS_AUDIO", True)
+            ),
+            "audio_runtime_supports_text": bool(
+                getattr(SETTINGS, "GEMMA4_AUDIO_SUPPORTS_TEXT", True)
+            ),
+            "audio_runtime_supports_unified_multimodal_respond": True,
+            "audio_runtime_runtime_mode": "processor_model",
+            "audio_runtime_log_path": log_path,
+            "audio_runtime_pid_path": pid_path,
+        }
+
+    def _gemma4_audio_service_origin(self) -> str:
+        endpoint = _coerce_str(getattr(SETTINGS, "GEMMA4_AUDIO_ENDPOINT", ""), "")
+        if not endpoint:
+            return ""
+        endpoint = endpoint.rstrip("/")
+        if endpoint.endswith("/v1"):
+            return endpoint[:-3].rstrip("/")
+        return endpoint
+
+    def _gemma4_audio_respond_url(self) -> str:
+        origin = self._gemma4_audio_service_origin()
+        return f"{origin}/v1/respond" if origin else ""
+
+    def _gemma4_audio_health_url(self) -> str:
+        origin = self._gemma4_audio_service_origin()
+        return f"{origin}/health" if origin else ""
+
+    def _gemma4_audio_runtime_enabled(self) -> bool:
+        return bool(getattr(SETTINGS, "GEMMA4_AUDIO_ENABLED", False))
+
+    def _gemma4_audio_runtime_selected(self) -> bool:
+        if not self._gemma4_audio_runtime_enabled():
+            return False
+        active_server = _coerce_str(getattr(SETTINGS, "ACTIVE_LLM_SERVER", ""), "")
+        return active_server == "gemma4_audio"
+
+    async def _gemma4_audio_health_ok(self) -> bool:
+        health_url = self._gemma4_audio_health_url()
+        if not health_url:
+            return False
+        try:
+            timeout = httpx.Timeout(GEMMA4_AUDIO_HEALTH_TIMEOUT_SEC, connect=2.0)
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                response = await client.get(health_url)
+            if response.status_code != 200:
+                return False
+            payload = response.json()
+            status = str(payload.get("status") or "").strip().lower()
+            return status in {"ok", "warming"}
+        except Exception:
+            return False
+
+    async def _invoke_gemma4_audio_runtime(
+        self,
+        wav_path: Path,
+        connection_id: int,
+    ) -> dict[str, Any]:
+        respond_url = self._gemma4_audio_respond_url()
+        if not respond_url:
+            raise RuntimeError("Gemma4 audio endpoint is not configured")
+
+        prompt = (
+            "Odpowiedz po polsku na wypowiedź użytkownika z nagrania. "
+            "Jeśli to polecenie, wykonaj je krótko i bez dodatkowych komentarzy."
+        )
+        payload = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "audio", "path": str(wav_path.name)},
+                        {"type": "text", "text": prompt},
+                    ],
+                }
+            ],
+            "task": "question",
+            "question": prompt,
+            "system_prompt": _coerce_str(
+                getattr(SETTINGS, "SIMPLE_MODE_SYSTEM_PROMPT", ""), ""
+            ),
+            "max_new_tokens": _coerce_int(
+                getattr(SETTINGS, "GEMMA4_AUDIO_MAX_NEW_TOKENS", 128), 128
+            ),
+        }
+
+        timeout = httpx.Timeout(GEMMA4_AUDIO_REQUEST_TIMEOUT_SEC, connect=5.0)
+        with wav_path.open("rb") as audio_file:
+            files = {
+                "audio": (wav_path.name, audio_file, "audio/wav"),
+            }
+            data = {
+                "request": json.dumps(payload, ensure_ascii=False),
+            }
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                response = await client.post(respond_url, data=data, files=files)
+
+        if response.status_code >= 400:
+            raise RuntimeError(
+                f"Gemma4 audio runtime HTTP {response.status_code}: {response.text}"
+            )
+
+        data = response.json()
+        text = _coerce_str(data.get("text"), "")
+        if not text:
+            raise RuntimeError("Gemma4 audio runtime returned an empty response")
+
+        return {
+            "text": text,
+            "response_text": text,
+            "model": _coerce_str(
+                data.get("model") or getattr(SETTINGS, "GEMMA4_AUDIO_MODEL_ID", ""),
+                "",
+            ),
+            "duration_ms": data.get("duration_ms"),
+            "connection_id": connection_id,
+        }
+
+    async def _process_native_gemma4_audio_pipeline(
+        self,
+        connection_id: int,
+        session_dir: Path,
+        wav_path: Path,
+        timings_ms: dict[str, float],
+        total_started_at: float,
+        operator_agent,
+    ) -> bool:
+        if not self._gemma4_audio_runtime_selected():
+            return False
+        if not self.audio_engine:
+            return False
+
+        snapshot = self._gemma4_audio_runtime_snapshot()
+        if not await self._gemma4_audio_health_ok():
+            self._update_voice_session_metadata(
+                session_dir,
+                {
+                    **snapshot,
+                    "pipeline_id": "whisper_llm_piper",
+                    "audio_input_status": "fallback",
+                    "fallback_reason": "gemma4_audio health check failed",
+                    "timings_ms": timings_ms,
+                    "runtime": self._build_runtime_metadata(operator_agent),
+                    "voice_mode": self._connection_voice_mode(connection_id),
+                },
+            )
+            return False
+
+        await self._send_json(
+            connection_id, {"type": "processing", "status": "native_audio"}
+        )
+
+        native_started_at = time.perf_counter()
+        try:
+            runtime_result = await self._invoke_gemma4_audio_runtime(
+                wav_path, connection_id
+            )
+        except Exception as exc:
+            timings_ms["native_audio_ms"] = self._elapsed_ms(native_started_at)
+            self._update_voice_session_metadata(
+                session_dir,
+                {
+                    **snapshot,
+                    "pipeline_id": "whisper_llm_piper",
+                    "audio_input_status": "fallback",
+                    "fallback_reason": str(exc),
+                    "native_audio_ms": timings_ms["native_audio_ms"],
+                    "timings_ms": timings_ms,
+                    "runtime": self._build_runtime_metadata(operator_agent),
+                    "voice_mode": self._connection_voice_mode(connection_id),
+                },
+            )
+            logger.warning(
+                "Gemma4 audio runtime failed for connection_id=%s: %s",
+                connection_id,
+                exc,
+            )
+            return False
+
+        timings_ms["native_audio_ms"] = self._elapsed_ms(native_started_at)
+        transcription = runtime_result["text"]
+        response_text = runtime_result.get("response_text") or transcription
+
+        self._update_voice_session_metadata(
+            session_dir,
+            {
+                **snapshot,
+                "pipeline_id": "gemma4_audio_piper",
+                "audio_input_status": "verified",
+                "fallback_reason": "",
+                "native_audio_ms": timings_ms["native_audio_ms"],
+                "transcription": transcription,
+                "transcription_length": len(transcription or ""),
+                "response_text": response_text,
+                "response_length": len(response_text or ""),
+                "timings_ms": timings_ms,
+                "runtime": self._build_runtime_metadata(operator_agent),
+                "voice_mode": self._connection_voice_mode(connection_id),
+            },
+        )
+
+        await self._send_json(
+            connection_id,
+            {"type": "transcription", "text": transcription, "confidence": 1.0},
+        )
+        await self._send_json(
+            connection_id, {"type": "response_text", "text": response_text}
+        )
+        await self._send_json(connection_id, {"type": "processing", "status": "tts"})
+
+        tts_started_at = time.perf_counter()
+        audio_response = await self.audio_engine.speak(response_text)
+        timings_ms["tts_ms"] = self._elapsed_ms(tts_started_at)
+        timings_ms["total_backend_ms"] = self._elapsed_ms(total_started_at)
+        self._update_voice_session_metadata(
+            session_dir,
+            {
+                "timings_ms": timings_ms,
+                "runtime": self._build_runtime_metadata(operator_agent),
+                "pipeline_id": "gemma4_audio_piper",
+            },
+        )
+
+        if audio_response is not None:
+            await self._send_audio(connection_id, audio_response)
+
+        await self._send_json(connection_id, {"type": "complete"})
+        return True
+
     async def _process_audio_buffer(
         self,
         connection_id: int,
@@ -592,6 +847,16 @@ class AudioStreamHandler:
             )
             logger.info(f"Zapisano sesję audio: {session_dir}")
 
+            if await self._process_native_gemma4_audio_pipeline(
+                connection_id,
+                session_dir,
+                session_dir / VOICE_SESSION_WAV_FILENAME,
+                timings_ms,
+                total_started_at,
+                operator_agent,
+            ):
+                return
+
             # STT
             if not self.audio_engine:
                 logger.warning("AudioEngine nie jest dostępny")
@@ -614,10 +879,16 @@ class AudioStreamHandler:
             self._update_voice_session_metadata(
                 session_dir,
                 {
+                    "pipeline_id": "whisper_llm_piper",
                     "transcription": transcription,
                     "transcription_length": len(transcription or ""),
                     "timings_ms": timings_ms,
                     "voice_mode": self._connection_voice_mode(connection_id),
+                    "audio_input_status": "verified",
+                    "fallback_reason": "",
+                    "runtime_log_path": _coerce_str(
+                        getattr(SETTINGS, "GEMMA4_AUDIO_LOG_PATH", ""), ""
+                    ),
                 },
             )
 
@@ -649,6 +920,7 @@ class AudioStreamHandler:
                 self._update_voice_session_metadata(
                     session_dir,
                     {
+                        "pipeline_id": "whisper_llm_piper",
                         "response_text": response_text,
                         "response_length": len(response_text or ""),
                         "timings_ms": timings_ms,
@@ -746,6 +1018,16 @@ class AudioStreamHandler:
             )
             logger.info(f"Zapisano sesję audio MediaRecorder: {session_dir}")
 
+            if await self._process_native_gemma4_audio_pipeline(
+                connection_id,
+                session_dir,
+                wav_path,
+                timings_ms,
+                total_started_at,
+                operator_agent,
+            ):
+                return
+
             if not self.audio_engine:
                 logger.warning("AudioEngine nie jest dostępny")
                 await self._send_json(
@@ -767,9 +1049,15 @@ class AudioStreamHandler:
             self._update_voice_session_metadata(
                 session_dir,
                 {
+                    "pipeline_id": "whisper_llm_piper",
                     "transcription": transcription,
                     "transcription_length": len(transcription or ""),
                     "timings_ms": timings_ms,
+                    "audio_input_status": "verified",
+                    "fallback_reason": "",
+                    "runtime_log_path": _coerce_str(
+                        getattr(SETTINGS, "GEMMA4_AUDIO_LOG_PATH", ""), ""
+                    ),
                 },
             )
 
@@ -798,6 +1086,7 @@ class AudioStreamHandler:
                 self._update_voice_session_metadata(
                     session_dir,
                     {
+                        "pipeline_id": "whisper_llm_piper",
                         "response_text": response_text,
                         "response_length": len(response_text or ""),
                         "timings_ms": timings_ms,
@@ -1039,6 +1328,7 @@ class AudioStreamHandler:
             "tts_model_path": getattr(voice, "model_path", None),
             "tts_fallback": getattr(voice, "is_fallback_mode", None),
             "tts_sample_rate": self._get_tts_sample_rate(),
+            **self._gemma4_audio_runtime_snapshot(),
         }
 
     def _update_voice_session_metadata(

--- a/venom_core/api/routes/system_llm.py
+++ b/venom_core/api/routes/system_llm.py
@@ -1151,7 +1151,12 @@ async def _local_models_by_runtime(
     *,
     local_models: list[dict[str, Any]] | None = None,
 ) -> tuple[dict[str, list[dict[str, Any]]], list[dict[str, Any]]]:
-    grouped: dict[str, list[dict[str, Any]]] = {"ollama": [], "vllm": [], "onnx": []}
+    grouped: dict[str, list[dict[str, Any]]] = {
+        "ollama": [],
+        "vllm": [],
+        "onnx": [],
+        "gemma4_audio": [],
+    }
     audit_issues: list[dict[str, Any]] = []
     if local_models is None:
         try:
@@ -1541,7 +1546,7 @@ def _local_runtime_targets(
     targets: list[dict[str, Any]] = []
     allowed = _allowed_local_servers()
     installed = _installed_local_servers()
-    for runtime_id in ("ollama", "vllm", "onnx"):
+    for runtime_id in ("ollama", "vllm", "gemma4_audio", "onnx"):
         info = server_status.get(runtime_id, {})
         status = str(info.get("status") or "unknown")
         reason = None

--- a/venom_core/config.py
+++ b/venom_core/config.py
@@ -186,6 +186,31 @@ class Settings(BaseSettings):
     OLLAMA_ENABLE_STRUCTURED_OUTPUTS: bool = True
     OLLAMA_ENABLE_TOOL_CALLING: bool = True
     OLLAMA_ENABLE_THINK: bool = False
+
+    # Konfiguracja Gemma 4 Audio Native Runtime Service
+    GEMMA4_AUDIO_ENABLED: bool = False  # Włącz runtime Gemma4 Audio
+    GEMMA4_AUDIO_MODEL_ID: str = "google/gemma-4-E2B-it"  # Model ID z Hugging Face
+    GEMMA4_AUDIO_ENDPOINT: str = _default_url(
+        "localhost", 8014, "/v1"
+    )  # Endpoint daemona
+    GEMMA4_AUDIO_HOST: str = "127.0.0.1"  # Host dla daemona
+    GEMMA4_AUDIO_PORT: int = 8014  # Port dla daemona
+    GEMMA4_AUDIO_CACHE_DIR: str = "models_cache/hf"  # Katalog cache HF
+    GEMMA4_AUDIO_DEVICE: str = "auto"  # Urządzenie (auto|cuda|cpu)
+    GEMMA4_AUDIO_MAX_NEW_TOKENS: int = 128  # Max nowych tokenów
+    GEMMA4_AUDIO_MAX_CONCURRENCY: int = 1  # Max równoczesnych requestów
+    GEMMA4_AUDIO_STARTUP_TIMEOUT_SECONDS: int = (
+        600  # Maksymalny czas oczekiwania na gotowość startu
+    )
+    GEMMA4_AUDIO_START_COMMAND: str = ""  # Komenda start (z env file)
+    GEMMA4_AUDIO_STOP_COMMAND: str = ""  # Komenda stop (z env file)
+    GEMMA4_AUDIO_RESTART_COMMAND: str = ""  # Komenda restart (z env file)
+    GEMMA4_AUDIO_SUPPORTS_AUDIO: bool = True  # Potrafi przetwarzać audio
+    GEMMA4_AUDIO_SUPPORTS_TEXT: bool = True  # Potrafi przetwarzać text
+    GEMMA4_AUDIO_LOG_PATH: str = "logs/gemma4_audio_service.log"  # Plik logu
+    GEMMA4_AUDIO_PID_PATH: str = ".venom_runtime/gemma4_audio.pid"  # Plik PID
+    LAST_MODEL_GEMMA4_AUDIO: str = ""  # Ostatnio wybrany model
+
     # Czy w trybach LOCAL/ECO zawsze wymuszać darmowe źródła (np. DuckDuckGo)
     LOW_COST_FORCE_DDG: bool = False
 

--- a/venom_core/core/llm_server_controller.py
+++ b/venom_core/core/llm_server_controller.py
@@ -117,6 +117,34 @@ class LlmServerController:
             },
         )
 
+        # Gemma 4 Audio Native Runtime Service
+        gemma4_audio_start_cmd = _normalize(
+            cfg.GEMMA4_AUDIO_START_COMMAND,
+            f"bash {repo_root / 'scripts/llm/gemma4_audio_service.sh'} start",
+        )
+        gemma4_audio_stop_cmd = _normalize(
+            cfg.GEMMA4_AUDIO_STOP_COMMAND,
+            f"bash {repo_root / 'scripts/llm/gemma4_audio_service.sh'} stop",
+        )
+        gemma4_audio_restart_cmd = _normalize(
+            cfg.GEMMA4_AUDIO_RESTART_COMMAND,
+            f"bash {repo_root / 'scripts/llm/gemma4_audio_service.sh'} restart",
+        )
+
+        servers["gemma4_audio"] = LlmServerConfig(
+            name="gemma4_audio",
+            display_name="Gemma 4 Audio",
+            provider="gemma4_audio",
+            description="Native audio inference daemon for Gemma 4 models (port 8014).",
+            endpoint=cfg.GEMMA4_AUDIO_ENDPOINT,
+            health_url=f"{cfg.GEMMA4_AUDIO_ENDPOINT.rstrip('/')}/health",
+            commands={
+                "start": gemma4_audio_start_cmd,
+                "stop": gemma4_audio_stop_cmd,
+                "restart": gemma4_audio_restart_cmd,
+            },
+        )
+
         # ONNX Runtime działa in-process, ale utrzymujemy spójny wpis serwera
         # żeby testy i UI mogły traktować ONNX jako trzeci lokalny stack.
         servers["onnx"] = LlmServerConfig(

--- a/venom_core/core/model_registry_runtime.py
+++ b/venom_core/core/model_registry_runtime.py
@@ -73,19 +73,32 @@ def apply_model_activation_config(model_name: str, runtime: str, meta: ModelMeta
     updates = {
         "LLM_MODEL_NAME": model_name,
         "ACTIVE_LLM_SERVER": runtime,
+        "LLM_SERVICE_TYPE": "local",
+        "LLM_LOCAL_ENDPOINT": SETTINGS.GEMMA4_AUDIO_ENDPOINT
+        if runtime == "gemma4_audio"
+        else SETTINGS.LLM_LOCAL_ENDPOINT,
     }
     if runtime == "vllm":
         apply_vllm_activation_updates(model_name, meta, updates, SETTINGS)
     if runtime == "ollama":
         updates["LAST_MODEL_OLLAMA"] = model_name
+    if runtime == "gemma4_audio":
+        updates["LAST_MODEL_GEMMA4_AUDIO"] = model_name
+        updates["LLM_LOCAL_ENDPOINT"] = SETTINGS.GEMMA4_AUDIO_ENDPOINT
 
     config_manager.update_config(updates)
     SETTINGS.LLM_MODEL_NAME = model_name
     SETTINGS.ACTIVE_LLM_SERVER = runtime
+    SETTINGS.LLM_SERVICE_TYPE = "local"
+    SETTINGS.LLM_LOCAL_ENDPOINT = updates.get(
+        "LLM_LOCAL_ENDPOINT", SETTINGS.LLM_LOCAL_ENDPOINT
+    )
     if runtime == "ollama":
         safe_setattr(SETTINGS, "LAST_MODEL_OLLAMA", model_name)
     if runtime == "vllm":
         safe_setattr(SETTINGS, "LAST_MODEL_VLLM", model_name)
+    if runtime == "gemma4_audio":
+        safe_setattr(SETTINGS, "LAST_MODEL_GEMMA4_AUDIO", model_name)
     return SETTINGS
 
 

--- a/venom_core/services/system_llm_service.py
+++ b/venom_core/services/system_llm_service.py
@@ -24,7 +24,7 @@ def allowed_local_servers(*, profile: str, onnx_enabled: bool) -> set[str]:
         return {"ollama"}
     if profile == "llm_off":
         return set()
-    allowed = {"ollama", "vllm"}
+    allowed = {"ollama", "vllm", "gemma4_audio"}
     if onnx_enabled:
         allowed.add("onnx")
     return allowed
@@ -54,6 +54,8 @@ def installed_local_servers(
         installed.add("vllm")
     if onnx_installed:
         installed.add("onnx")
+    # Gemma4 Audio is always available (pure Python daemon)
+    installed.add("gemma4_audio")
     return installed
 
 

--- a/venom_core/utils/llm_runtime.py
+++ b/venom_core/utils/llm_runtime.py
@@ -52,15 +52,14 @@ def infer_local_provider(endpoint: Optional[str]) -> str:
         return "local"
     if "ollama" in endpoint_lower or "11434" in endpoint_lower:
         return "ollama"
-    if "vllm" in endpoint_lower:
+    if "vllm" in endpoint_lower or ":8001" in endpoint_lower:
         return "vllm"
+    if "gemma4" in endpoint_lower or "8014" in endpoint_lower:
+        return "gemma4_audio"
     if "onnx" in endpoint_lower:
         return "onnx"
     if "lmstudio" in endpoint_lower:
         return "lmstudio"
-    if ":8000" in endpoint_lower or ":8001" in endpoint_lower:
-        # Najczęstsze porty nowych instancji vLLM w tym projekcie
-        return "vllm"
     return "local"
 
 
@@ -153,6 +152,12 @@ def _build_health_url(runtime: LLMRuntimeInfo) -> Optional[str]:
             f"{base}/api/tags"
             if base
             else build_http_url("localhost", 11434, "/api/tags")
+        )
+
+    if runtime.provider == "gemma4_audio":
+        base = urlunparse((parsed.scheme, parsed.netloc, "", "", "", ""))
+        return (
+            f"{base}/health" if base else build_http_url("localhost", 8014, "/health")
         )
 
     endpoint = runtime.endpoint.rstrip("/")


### PR DESCRIPTION
What changed:

- Added a production-oriented local `gemma4_audio` runtime service under `services/gemma4_audio_runtime/`.
- Added `scripts/llm/gemma4_audio_service.sh` with start/stop/restart/status/health, PID handling, and log-path reporting.
- Added a unified multimodal `POST /v1/respond` contract plus supporting runtime endpoints.
- Integrated the runtime into Venom backend runtime selection and server control:
  - `venom_core/core/llm_server_controller.py`
  - `venom_core/core/model_registry_runtime.py`
  - `venom_core/utils/llm_runtime.py`
  - `venom_core/api/routes/system_llm.py`
  - `venom_core/services/system_llm_service.py`
- Updated `venom_core/api/audio_stream.py` so `/voice` can branch to `gemma4_audio` and bypass `faster-whisper -> operator_agent.process(...)` when this runtime is active, while keeping Piper TTS as the final playback step.
- Added smoke/dev tooling:
  - `scripts/dev/gemma4_audio_direct_ingest_probe.py`
  - `scripts/dev/gemma4_audio_service_smoke.py`
  - `scripts/dev/gemma4_audio_voice_session_replay.py`
- Added env/config/runtime metadata support in `.env.dev.example` and `venom_core/config.py`.
- Updated requirements/profile declarations needed by the Gemma 4 runtime.

Why:

- PR 209 proved direct Gemma 4 audio ingest locally.
- This PR turns that experiment into a real local daemon + API for Venom backend integration.
- UI/runtime selection wiring is intentionally left for PR 211.

Validation:

- `./.venv/bin/python -m py_compile scripts/dev/gemma4_audio_direct_ingest_probe.py scripts/dev/gemma4_audio_service_smoke.py scripts/dev/gemma4_audio_voice_session_replay.py services/gemma4_audio_runtime/main.py services/gemma4_audio_runtime/engine.py services/gemma4_audio_runtime/audio.py services/gemma4_audio_runtime/schemas.py`
- `./.venv/bin/pytest -q tests/test_llm_server_controller.py tests/test_llm_runtime_options_api.py tests/test_system_llm_service.py tests/test_env_contracts.py`
  - result: `23 passed`

Scope notes:

- Backward compatibility is preserved: existing `ollama` flows, including `ollama + gemma`, stay on the current pipeline unless `gemma4_audio` is explicitly selected as the active runtime.
- This PR does not add the UI engine picker integration; that is covered by PR 211.
