### PR TITLE
feat(voice): integrate gemma4_audio runtime in voice UI with runtime diagnostics

### DIFF
--- a/config/pytest-groups/fast.txt
+++ b/config/pytest-groups/fast.txt
@@ -143,6 +143,7 @@ tests/test_flow_mermaid_generation.py
 tests/test_flow_router.py
 tests/test_foreman_agent.py
 tests/test_forge_flow.py
+tests/test_gemma4_audio_runtime_main.py
 tests/test_generation_params_adapter.py
 tests/test_generation_schema.py
 tests/test_ghost_agent.py

--- a/config/pytest-groups/sonar-new-code.txt
+++ b/config/pytest-groups/sonar-new-code.txt
@@ -89,6 +89,7 @@ tests/test_feedback_loop_policy.py
 tests/test_file_skill.py
 tests/test_flow_coordinator.py
 tests/test_forge_flow.py
+tests/test_gemma4_audio_runtime_main.py
 tests/test_generation_params_adapter.py
 tests/test_ghost_agent.py
 tests/test_git_skill_roi.py

--- a/config/testing/test_catalog.json
+++ b/config/testing/test_catalog.json
@@ -893,7 +893,7 @@
         "release"
       ],
       "legacy_targeted": true,
-      "rationale": "Audio runtime validation for Gemma 4 service; legacy targeted for expanded coverage."
+      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
     },
     {
       "path": "tests/test_audio_stream_handler_roi.py",
@@ -4349,7 +4349,7 @@
     },
     {
       "path": "tests/test_port_pids_script.py",
-      "domain": "system",
+      "domain": "environment",
       "test_type": "unit",
       "intent": "legacy_coverage",
       "primary_lane": "new-code",
@@ -4359,7 +4359,7 @@
         "release"
       ],
       "legacy_targeted": true,
-      "rationale": "System-level port and process validation; legacy targeted for infrastructure coverage."
+      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
     },
     {
       "path": "tests/test_preprod_mutation_guards.py",
@@ -4882,8 +4882,8 @@
     {
       "path": "tests/test_runtime_registry_contracts.py",
       "domain": "runtime",
-      "test_type": "unit",
-      "intent": "regression",
+      "test_type": "service_contract",
+      "intent": "contract",
       "primary_lane": "new-code",
       "allowed_lanes": [
         "new-code",

--- a/config/testing/test_catalog.json
+++ b/config/testing/test_catalog.json
@@ -2282,6 +2282,20 @@
       "rationale": "Default release-lane regression coverage."
     },
     {
+      "path": "tests/test_gemma4_audio_runtime_main.py",
+      "domain": "runtime",
+      "test_type": "service_contract",
+      "intent": "contract",
+      "primary_lane": "new-code",
+      "allowed_lanes": [
+        "new-code",
+        "ci-lite",
+        "release"
+      ],
+      "legacy_targeted": false,
+      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
+    },
+    {
       "path": "tests/test_git_routes_logic.py",
       "domain": "api",
       "test_type": "route_contract",

--- a/scripts/dev/start_stack.sh
+++ b/scripts/dev/start_stack.sh
@@ -308,6 +308,33 @@ start_vllm() {
   return 1
 }
 
+start_gemma4_audio() {
+  echo "▶️  Uruchamiam Gemma4 Audio..."
+  mk vllm-stop >/dev/null || true
+  mk ollama-stop >/dev/null || true
+  if ! bash scripts/llm/gemma4_audio_service.sh start; then
+    echo "❌ Nie udało się uruchomić Gemma4 Audio (sprawdź logi wyżej)."
+    return 1
+  fi
+
+  echo "⏳ Czekam na Gemma4 Audio (/health)..."
+  for _ in {1..90}; do
+    if curl -fsS "http://127.0.0.1:8014/health" >/dev/null 2>&1; then
+      echo "✅ Gemma4 Audio gotowy"
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "❌ Gemma4 Audio nie wystartował w czasie (brak odpowiedzi z /health)"
+  if [[ -f logs/gemma4_audio_service.log ]]; then
+    echo "ℹ️  Ostatnie logi Gemma4 Audio:"
+    tail -n 40 logs/gemma4_audio_service.log || true
+  fi
+  bash scripts/llm/gemma4_audio_service.sh stop >/dev/null 2>&1 || true
+  return 1
+}
+
 llm_ready=""
 case "$active_server" in
   onnx)
@@ -324,14 +351,18 @@ case "$active_server" in
     mk ollama-stop >/dev/null || true
     if start_vllm; then llm_ready="vllm"; fi
     ;;
+  gemma4_audio)
+    if start_gemma4_audio; then llm_ready="gemma4_audio"; fi
+    ;;
   none)
     echo "▶️  ACTIVE_LLM_SERVER=none (start bez lokalnego serwera LLM)"
     mk vllm-stop >/dev/null || true
     mk ollama-stop >/dev/null || true
+    bash scripts/llm/gemma4_audio_service.sh stop >/dev/null 2>&1 || true
     llm_ready="none"
     ;;
   *)
-    echo "❌ Nieznany ACTIVE_LLM_SERVER='$active_server' (dozwolone: ollama|vllm|onnx|none)"
+    echo "❌ Nieznany ACTIVE_LLM_SERVER='$active_server' (dozwolone: ollama|vllm|gemma4_audio|onnx|none)"
     exit 1
     ;;
 esac

--- a/scripts/dev/start_stack.sh
+++ b/scripts/dev/start_stack.sh
@@ -309,6 +309,8 @@ start_vllm() {
 }
 
 start_gemma4_audio() {
+  local gemma4_audio_port
+  gemma4_audio_port="$(env_contract_get GEMMA4_AUDIO_PORT "8014" "$ENV_FILE")"
   echo "▶️  Uruchamiam Gemma4 Audio..."
   mk vllm-stop >/dev/null || true
   mk ollama-stop >/dev/null || true
@@ -319,7 +321,7 @@ start_gemma4_audio() {
 
   echo "⏳ Czekam na Gemma4 Audio (/health)..."
   for _ in {1..90}; do
-    if curl -fsS "http://127.0.0.1:8014/health" >/dev/null 2>&1; then
+    if curl -fsS "http://127.0.0.1:${gemma4_audio_port}/health" >/dev/null 2>&1; then
       echo "✅ Gemma4 Audio gotowy"
       return 0
     fi

--- a/scripts/stop_venom.sh
+++ b/scripts/stop_venom.sh
@@ -79,6 +79,7 @@ pkill -f "uvicorn.*venom_core.main:app" 2>/dev/null || true
 echo "🧠 Zwalniam zasoby LLM..."
 bash scripts/llm/vllm_service.sh stop >/dev/null 2>&1 || true
 bash scripts/llm/ollama_service.sh stop >/dev/null 2>&1 || true
+bash scripts/llm/gemma4_audio_service.sh stop >/dev/null 2>&1 || true
 
 # 4. Academy training jobs (local runtime)
 echo "🧪 Zatrzymuję lokalne joby treningowe Academy..."
@@ -98,7 +99,7 @@ echo "🐳 Zatrzymuję kontenery Venom..."
 stop_venom_containers
 
 # 7. Czyszczenie portów (API/Web/LLM + data services)
-PORTS_TO_CLEAN="8000 3000 11434 8001"
+PORTS_TO_CLEAN="8000 3000 11434 8001 8014"
 if [[ "$STOP_DATA_PORTS" == "1" ]]; then
     PORTS_TO_CLEAN="$PORTS_TO_CLEAN 6379 5432 3306 27017 5672 15672 6333 6334 9200"
 fi

--- a/services/gemma4_audio_runtime/main.py
+++ b/services/gemma4_audio_runtime/main.py
@@ -14,6 +14,7 @@ from typing import Optional
 import numpy as np
 import uvicorn
 from fastapi import FastAPI, File, HTTPException, Request, UploadFile
+from pydantic import BaseModel, ConfigDict, Field
 
 from .audio import audio_from_bytes, audio_from_file, get_audio_duration
 from .engine import Gemma4AudioEngine, InferenceError
@@ -359,28 +360,44 @@ def _extract_text_prompt_from_openai_messages(messages: list[dict]) -> str:
     return "Hello"
 
 
+class ChatCompletionContentPart(BaseModel):
+    type: str
+    text: str | None = None
+
+
+class ChatCompletionMessage(BaseModel):
+    role: str
+    content: str | list[ChatCompletionContentPart]
+
+
+class ChatCompletionRequest(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    model: str | None = None
+    messages: list[ChatCompletionMessage] = Field(default_factory=list)
+    max_tokens: int | None = None
+    max_completion_tokens: int | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    stream: bool = False
+
+
 @app.post("/v1/chat/completions")
-async def chat_completions(request: Request) -> dict:
+async def chat_completions(payload: ChatCompletionRequest) -> dict:
     """OpenAI-compatible text chat endpoint for Semantic Kernel connectors."""
     try:
         engine = get_engine()
         if not engine.is_loaded():
             raise HTTPException(status_code=503, detail="Model not loaded")
 
-        payload = await request.json()
-        model = str(payload.get("model") or engine.model_id)
-        messages = payload.get("messages") or []
-        if not isinstance(messages, list):
-            raise HTTPException(status_code=400, detail="Invalid messages payload")
+        model = str(payload.model or engine.model_id)
+        messages = [message.model_dump(mode="python") for message in payload.messages]
 
         prompt = _extract_text_prompt_from_openai_messages(messages)
-        max_tokens = int(
-            payload.get("max_tokens") or payload.get("max_completion_tokens") or 128
-        )
-        temperature_raw = payload.get("temperature")
-        top_p_raw = payload.get("top_p")
-        stream = bool(payload.get("stream", False))
-        if stream:
+        max_tokens = int(payload.max_tokens or payload.max_completion_tokens or 128)
+        temperature_raw = payload.temperature
+        top_p_raw = payload.top_p
+        if payload.stream:
             raise HTTPException(
                 status_code=400,
                 detail="Streaming is not supported by gemma4_audio runtime",
@@ -395,12 +412,12 @@ async def chat_completions(request: Request) -> dict:
             max_new_tokens=max_tokens,
             temperature=float(temperature_raw) if temperature_raw is not None else None,
             top_p=float(top_p_raw) if top_p_raw is not None else None,
-            do_sample=None,
+            do_sample=bool(temperature_raw is not None or top_p_raw is not None),
         )
 
         now = int(time.time())
-        completion_tokens = max(1, len(text.split()))
-        prompt_tokens = max(1, len(prompt.split()))
+        completion_tokens = max(1, len(text) // 4)
+        prompt_tokens = max(1, len(prompt) // 4)
         return {
             "id": f"chatcmpl-gemma4-{int(time.time() * 1000)}",
             "object": "chat.completion",

--- a/services/gemma4_audio_runtime/main.py
+++ b/services/gemma4_audio_runtime/main.py
@@ -164,6 +164,12 @@ async def health() -> HealthResponse:
         )
 
 
+@app.get("/v1/health", response_model=HealthResponse)
+async def v1_health() -> HealthResponse:
+    """Compatibility health endpoint for clients probing /v1/health."""
+    return await health()
+
+
 @app.get("/status", response_model=StatusResponse)
 async def status() -> StatusResponse:
     """Get service status."""
@@ -331,6 +337,92 @@ async def respond(
         raise
     except Exception as e:
         logger.error(f"Respond endpoint error: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Internal error: {e}")
+
+
+def _extract_text_prompt_from_openai_messages(messages: list[dict]) -> str:
+    """Extract a text prompt from OpenAI-style chat messages."""
+    for message in reversed(messages):
+        if str(message.get("role", "")).strip().lower() != "user":
+            continue
+        content = message.get("content")
+        if isinstance(content, str) and content.strip():
+            return content.strip()
+        if isinstance(content, list):
+            for item in content:
+                if not isinstance(item, dict):
+                    continue
+                if item.get("type") == "text":
+                    text = str(item.get("text", "")).strip()
+                    if text:
+                        return text
+    return "Hello"
+
+
+@app.post("/v1/chat/completions")
+async def chat_completions(request: Request) -> dict:
+    """OpenAI-compatible text chat endpoint for Semantic Kernel connectors."""
+    try:
+        engine = get_engine()
+        if not engine.is_loaded():
+            raise HTTPException(status_code=503, detail="Model not loaded")
+
+        payload = await request.json()
+        model = str(payload.get("model") or engine.model_id)
+        messages = payload.get("messages") or []
+        if not isinstance(messages, list):
+            raise HTTPException(status_code=400, detail="Invalid messages payload")
+
+        prompt = _extract_text_prompt_from_openai_messages(messages)
+        max_tokens = int(
+            payload.get("max_tokens") or payload.get("max_completion_tokens") or 128
+        )
+        temperature_raw = payload.get("temperature")
+        top_p_raw = payload.get("top_p")
+        stream = bool(payload.get("stream", False))
+        if stream:
+            raise HTTPException(
+                status_code=400,
+                detail="Streaming is not supported by gemma4_audio runtime",
+            )
+
+        # Text-only path: use 1s silence placeholder expected by the current engine API.
+        dummy_audio = np.zeros(16000, dtype=np.float32)
+        text, _ = engine.respond(
+            dummy_audio,
+            sample_rate=16000,
+            prompt=prompt,
+            max_new_tokens=max_tokens,
+            temperature=float(temperature_raw) if temperature_raw is not None else None,
+            top_p=float(top_p_raw) if top_p_raw is not None else None,
+            do_sample=None,
+        )
+
+        now = int(time.time())
+        completion_tokens = max(1, len(text.split()))
+        prompt_tokens = max(1, len(prompt.split()))
+        return {
+            "id": f"chatcmpl-gemma4-{int(time.time() * 1000)}",
+            "object": "chat.completion",
+            "created": now,
+            "model": model,
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": text},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": prompt_tokens + completion_tokens,
+            },
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"chat/completions error: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Internal error: {e}")
 
 

--- a/tests/test_gemma4_audio_runtime_main.py
+++ b/tests/test_gemma4_audio_runtime_main.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+import services.gemma4_audio_runtime.main as runtime_main
+
+
+def test_extract_text_prompt_from_openai_messages_prefers_latest_user_text() -> None:
+    messages = [
+        {"role": "system", "content": "rules"},
+        {"role": "user", "content": [{"type": "text", "text": "pierwszy"}]},
+        {"role": "user", "content": "drugi"},
+    ]
+
+    assert runtime_main._extract_text_prompt_from_openai_messages(messages) == "drugi"  # noqa: SLF001
+
+
+def test_chat_completions_uses_pydantic_payload_and_sampling(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class EngineStub:
+        model_id = "google/gemma-4-E2B-it"
+
+        def is_loaded(self) -> bool:
+            return True
+
+        def respond(self, _audio, **kwargs):
+            captured.update(kwargs)
+            return "to jest odpowiedz", 0.25
+
+    monkeypatch.setattr(runtime_main, "get_engine", lambda: EngineStub())
+
+    client = TestClient(runtime_main.app)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "google/gemma-4-E2B-it",
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "Ile to 5*5?"}]}
+            ],
+            "max_tokens": 77,
+            "temperature": 0.2,
+            "top_p": 0.9,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["choices"][0]["message"]["content"] == "to jest odpowiedz"
+    assert captured["max_new_tokens"] == 77
+    assert captured["do_sample"] is True
+    assert captured["temperature"] == 0.2
+    assert captured["top_p"] == 0.9
+    assert body["usage"]["prompt_tokens"] >= 1
+    assert body["usage"]["completion_tokens"] == max(1, len("to jest odpowiedz") // 4)
+
+
+def test_chat_completions_rejects_streaming(monkeypatch) -> None:
+    monkeypatch.setattr(
+        runtime_main,
+        "get_engine",
+        lambda: SimpleNamespace(is_loaded=lambda: True, model_id="m"),
+    )
+    client = TestClient(runtime_main.app)
+
+    response = client.post(
+        "/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": "hej"}], "stream": True},
+    )
+
+    assert response.status_code == 400
+    assert "Streaming is not supported" in response.json()["detail"]

--- a/tests/test_llm_runtime_options_api.py
+++ b/tests/test_llm_runtime_options_api.py
@@ -621,3 +621,26 @@ def test_runtime_target_payload_no_gemma4_fields_for_other_runtimes() -> None:
     assert "supports_text_input" not in payload
     assert "supports_audio_input" not in payload
     assert "supported_models" not in payload
+
+
+def test_resolve_selected_model_for_switch_gemma4_audio_prefers_request() -> None:
+    request = SimpleNamespace(model="google/gemma-4-E4B-it", model_alias="")
+    selected, key = system_llm._resolve_selected_model_for_switch(  # noqa: SLF001
+        request=request,
+        server_name="gemma4_audio",
+        config={"LAST_MODEL_GEMMA4_AUDIO": "google/gemma-4-E2B-it"},
+        models=[],
+    )
+    assert selected == "google/gemma-4-E4B-it"
+    assert key == "LAST_MODEL_GEMMA4_AUDIO"
+
+
+def test_resolve_selected_model_for_switch_gemma4_audio_invalid_request() -> None:
+    request = SimpleNamespace(model="google/gemma-4-unknown", model_alias="")
+    with pytest.raises(system_llm.HTTPException):  # noqa: PT011
+        system_llm._resolve_selected_model_for_switch(  # noqa: SLF001
+            request=request,
+            server_name="gemma4_audio",
+            config={},
+            models=[],
+        )

--- a/tests/test_llm_runtime_options_api.py
+++ b/tests/test_llm_runtime_options_api.py
@@ -473,7 +473,12 @@ async def test_local_models_by_runtime_reports_unknown_provider_issue(
             local_models=local_models,
         )
 
-    assert grouped == {"ollama": [], "vllm": [], "onnx": [], "gemma4_audio": []}
+    assert grouped["ollama"] == []
+    assert grouped["vllm"] == []
+    assert grouped["onnx"] == []
+    gemma_ids = [m["id"] for m in grouped["gemma4_audio"]]
+    assert "google/gemma-4-E2B-it" in gemma_ids
+    assert "google/gemma-4-E4B-it" in gemma_ids
     assert audit == [
         {
             "name": "mystery-model",
@@ -482,3 +487,137 @@ async def test_local_models_by_runtime_reports_unknown_provider_issue(
             "reason": "provider_unknown",
         }
     ]
+
+
+def test_gemma4_audio_static_models_returns_two_models() -> None:
+    models = system_llm._gemma4_audio_static_models(  # noqa: SLF001
+        active_provider="gemma4_audio",
+        active_model="google/gemma-4-E2B-it",
+    )
+    ids = [m["id"] for m in models]
+    assert "google/gemma-4-E2B-it" in ids
+    assert "google/gemma-4-E4B-it" in ids
+    assert len(models) == 2
+
+
+def test_gemma4_audio_static_models_active_flag() -> None:
+    models = system_llm._gemma4_audio_static_models(  # noqa: SLF001
+        active_provider="gemma4_audio",
+        active_model="google/gemma-4-E4B-it",
+    )
+    by_id = {m["id"]: m for m in models}
+    assert by_id["google/gemma-4-E4B-it"]["active"] is True
+    assert by_id["google/gemma-4-E2B-it"]["active"] is False
+
+
+def test_gemma4_audio_static_models_inactive_when_different_provider() -> None:
+    models = system_llm._gemma4_audio_static_models(  # noqa: SLF001
+        active_provider="ollama",
+        active_model="google/gemma-4-E2B-it",
+    )
+    assert all(not m["active"] for m in models)
+
+
+def test_gemma4_audio_static_models_capabilities() -> None:
+    models = system_llm._gemma4_audio_static_models(  # noqa: SLF001
+        active_provider="gemma4_audio",
+        active_model="",
+    )
+    for model in models:
+        caps = model.get("capabilities") or []
+        assert "text" in caps
+        assert "audio" in caps
+        assert "voice" in caps
+        assert model["chat_compatible"] is True
+        assert model["runtime_id"] == "gemma4_audio"
+
+
+@pytest.mark.asyncio
+async def test_local_models_by_runtime_injects_gemma4_audio_static_models() -> None:
+    from unittest.mock import patch
+
+    active_runtime = SimpleNamespace(
+        provider="gemma4_audio", model_name="google/gemma-4-E2B-it"
+    )
+    with patch.object(
+        system_llm, "get_active_llm_runtime", return_value=active_runtime
+    ):
+        grouped, audit = await system_llm._local_models_by_runtime(  # noqa: SLF001
+            model_manager=object(),
+            local_models=[],
+        )
+
+    gemma_models = grouped["gemma4_audio"]
+    ids = [m["id"] for m in gemma_models]
+    assert "google/gemma-4-E2B-it" in ids
+    assert "google/gemma-4-E4B-it" in ids
+    assert audit == []
+
+
+def test_gemma4_audio_runtime_input_capabilities_present() -> None:
+    info = system_llm._gemma4_audio_runtime_input_capabilities("gemma4_audio")  # noqa: SLF001
+    assert info["supports_text_input"] is True
+    assert info["supports_audio_input"] is True
+    assert info["supports_text_output"] is True
+    assert info["supports_image_input"] is False
+    assert "google/gemma-4-E2B-it" in info["supported_models"]
+    assert "google/gemma-4-E4B-it" in info["supported_models"]
+    assert "log_path" in info
+    assert "pid_path" in info
+
+
+def test_gemma4_audio_runtime_input_capabilities_empty_for_other_runtimes() -> None:
+    for runtime in ("ollama", "vllm", "onnx", "openai"):
+        result = system_llm._gemma4_audio_runtime_input_capabilities(runtime)  # noqa: SLF001
+        assert result == {}, f"Expected empty dict for runtime={runtime}"
+
+
+def test_runtime_target_payload_includes_gemma4_audio_capabilities() -> None:
+    from unittest.mock import patch
+
+    active_runtime = SimpleNamespace(
+        provider="gemma4_audio", model_name="google/gemma-4-E2B-it"
+    )
+    with patch.object(
+        system_llm,
+        "SETTINGS",
+        SimpleNamespace(
+            GEMMA4_AUDIO_LOG_PATH="logs/gemma4_audio.log",
+            GEMMA4_AUDIO_PID_PATH=".venom_runtime/gemma4_audio.pid",
+        ),
+    ):
+        payload = system_llm._runtime_target_payload(  # noqa: SLF001
+            runtime_id="gemma4_audio",
+            source_type="local-runtime",
+            configured=True,
+            available=True,
+            status="online",
+            reason=None,
+            models=[],
+            active_runtime=active_runtime,
+        )
+
+    assert payload["supports_text_input"] is True
+    assert payload["supports_audio_input"] is True
+    assert payload["supports_text_output"] is True
+    assert payload["supports_image_input"] is False
+    assert "google/gemma-4-E2B-it" in payload["supported_models"]
+    assert payload["log_path"] == "logs/gemma4_audio.log"
+    assert payload["pid_path"] == ".venom_runtime/gemma4_audio.pid"
+
+
+def test_runtime_target_payload_no_gemma4_fields_for_other_runtimes() -> None:
+    active_runtime = SimpleNamespace(provider="ollama", model_name="phi3:latest")
+    payload = system_llm._runtime_target_payload(  # noqa: SLF001
+        runtime_id="ollama",
+        source_type="local-runtime",
+        configured=True,
+        available=True,
+        status="online",
+        reason=None,
+        models=[],
+        active_runtime=active_runtime,
+    )
+    assert "supports_text_input" not in payload
+    assert "supports_audio_input" not in payload
+    assert "supported_models" not in payload

--- a/tests/test_llm_server_controller.py
+++ b/tests/test_llm_server_controller.py
@@ -19,6 +19,8 @@ def _dummy_settings(**kwargs):
         "OLLAMA_STOP_COMMAND": "",
         "OLLAMA_RESTART_COMMAND": "",
         "GEMMA4_AUDIO_ENDPOINT": "http://localhost:8014/v1",
+        "GEMMA4_AUDIO_HOST": "127.0.0.1",
+        "GEMMA4_AUDIO_PORT": 8014,
         "GEMMA4_AUDIO_START_COMMAND": "",
         "GEMMA4_AUDIO_STOP_COMMAND": "",
         "GEMMA4_AUDIO_RESTART_COMMAND": "",
@@ -38,6 +40,15 @@ def test_list_servers_contains_known_entries():
     assert "ollama" in names
     assert "onnx" in names
     assert "gemma4_audio" in names
+
+
+def test_gemma4_audio_health_url_is_derived_from_stack_config():
+    controller = LlmServerController(
+        _dummy_settings(GEMMA4_AUDIO_HOST="gemma-host", GEMMA4_AUDIO_PORT=8123)
+    )
+    servers = {srv["name"]: srv for srv in controller.list_servers()}
+    assert servers["gemma4_audio"]["health_url"].endswith("/health")
+    assert "gemma-host:8123" in servers["gemma4_audio"]["health_url"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_main_internal_helpers.py
+++ b/tests/test_main_internal_helpers.py
@@ -127,6 +127,82 @@ async def test_build_voice_runtime_snapshot_returns_pipeline_snapshot(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_build_voice_runtime_snapshot_returns_gemma4_audio_snapshot_enabled(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        main_module,
+        "get_active_llm_runtime",
+        lambda: SimpleNamespace(
+            runtime_id="gemma4_audio@localhost",
+            provider="gemma4_audio",
+            model_name="google/gemma-4-E2B-it",
+            endpoint="http://127.0.0.1:8014",
+            config_hash="cfg123",
+        ),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "SETTINGS",
+        SimpleNamespace(
+            GEMMA4_AUDIO_ENABLED=True,
+            GEMMA4_AUDIO_SUPPORTS_AUDIO=True,
+            GEMMA4_AUDIO_SUPPORTS_TEXT=True,
+            GEMMA4_AUDIO_MODEL_ID="google/gemma-4-E2B-it",
+            GEMMA4_AUDIO_ENDPOINT="http://127.0.0.1:8014",
+        ),
+    )
+
+    snapshot = await main_module._build_voice_runtime_snapshot()
+
+    assert snapshot["runtime_id"] == "gemma4_audio@localhost"
+    assert snapshot["provider"] == "gemma4_audio"
+    assert snapshot["runtime_capabilities"]["compatibility_profile"] == (
+        "gemma4_audio_native"
+    )
+    assert snapshot["runtime_capabilities"]["probe_status"] == "verified"
+    assert snapshot["voice_pipeline"]["stt"] == "native_audio"
+
+
+@pytest.mark.asyncio
+async def test_build_voice_runtime_snapshot_returns_gemma4_audio_snapshot_metadata_only(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        main_module,
+        "get_active_llm_runtime",
+        lambda: SimpleNamespace(
+            runtime_id="gemma4_audio@localhost",
+            provider="gemma4_audio",
+            model_name="",
+            endpoint="",
+            config_hash="cfg999",
+        ),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "SETTINGS",
+        SimpleNamespace(
+            GEMMA4_AUDIO_ENABLED=False,
+            GEMMA4_AUDIO_SUPPORTS_AUDIO=True,
+            GEMMA4_AUDIO_SUPPORTS_TEXT=True,
+            GEMMA4_AUDIO_MODEL_ID="google/gemma-4-E4B-it",
+            GEMMA4_AUDIO_ENDPOINT="http://127.0.0.1:8014",
+        ),
+    )
+
+    snapshot = await main_module._build_voice_runtime_snapshot()
+
+    assert snapshot["model_name"] == "google/gemma-4-E4B-it"
+    assert snapshot["endpoint"] == "http://127.0.0.1:8014"
+    assert snapshot["runtime_capabilities"]["probe_status"] == "metadata_only"
+    assert snapshot["runtime_capabilities"]["probes"]["health"]["reason"] == (
+        "runtime_not_enabled"
+    )
+    assert snapshot["voice_pipeline"]["stt"] == "faster_whisper"
+
+
+@pytest.mark.asyncio
 async def test_audio_status_endpoint_includes_latest_session_download_url(monkeypatch):
     class DummyHandler:
         def get_status(self, operator_agent=None):

--- a/tests/test_main_setup_router_dependencies.py
+++ b/tests/test_main_setup_router_dependencies.py
@@ -198,6 +198,74 @@ def test_select_startup_model_prefers_first_available_when_no_match():
     assert selected in {"model-a", "model-b"}
 
 
+@pytest.mark.asyncio
+async def test_build_voice_runtime_snapshot_gemma4_audio_enabled(monkeypatch):
+    monkeypatch.setattr(
+        main_module,
+        "get_active_llm_runtime",
+        lambda: SimpleNamespace(
+            runtime_id="gemma4_audio@localhost",
+            provider="gemma4_audio",
+            model_name="google/gemma-4-E2B-it",
+            endpoint="http://127.0.0.1:8014",
+            config_hash="cfg-a",
+        ),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "SETTINGS",
+        SimpleNamespace(
+            GEMMA4_AUDIO_ENABLED=True,
+            GEMMA4_AUDIO_SUPPORTS_AUDIO=True,
+            GEMMA4_AUDIO_SUPPORTS_TEXT=True,
+            GEMMA4_AUDIO_MODEL_ID="google/gemma-4-E2B-it",
+            GEMMA4_AUDIO_ENDPOINT="http://127.0.0.1:8014",
+        ),
+    )
+
+    snapshot = await main_module._build_voice_runtime_snapshot()
+
+    assert snapshot["runtime_capabilities"]["compatibility_profile"] == (
+        "gemma4_audio_native"
+    )
+    assert snapshot["voice_pipeline"]["stt"] == "native_audio"
+
+
+@pytest.mark.asyncio
+async def test_build_voice_runtime_snapshot_gemma4_audio_metadata_only(monkeypatch):
+    monkeypatch.setattr(
+        main_module,
+        "get_active_llm_runtime",
+        lambda: SimpleNamespace(
+            runtime_id="gemma4_audio@localhost",
+            provider="gemma4_audio",
+            model_name="",
+            endpoint="",
+            config_hash="cfg-b",
+        ),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "SETTINGS",
+        SimpleNamespace(
+            GEMMA4_AUDIO_ENABLED=False,
+            GEMMA4_AUDIO_SUPPORTS_AUDIO=True,
+            GEMMA4_AUDIO_SUPPORTS_TEXT=True,
+            GEMMA4_AUDIO_MODEL_ID="google/gemma-4-E4B-it",
+            GEMMA4_AUDIO_ENDPOINT="http://127.0.0.1:8014",
+        ),
+    )
+
+    snapshot = await main_module._build_voice_runtime_snapshot()
+
+    assert snapshot["model_name"] == "google/gemma-4-E4B-it"
+    assert snapshot["endpoint"] == "http://127.0.0.1:8014"
+    assert snapshot["runtime_capabilities"]["probes"]["health"]["reason"] == (
+        "runtime_not_enabled"
+    )
+    assert snapshot["voice_pipeline"]["stt"] == "faster_whisper"
+
+
 def _patch_setup_routes(monkeypatch):
     def make_dummy():
         return SimpleNamespace(

--- a/tests/test_model_registry_split_modules.py
+++ b/tests/test_model_registry_split_modules.py
@@ -656,3 +656,12 @@ async def test_runtime_ensure_model_metadata_activation_branches():
         await runtime.ensure_model_metadata_for_activation(registry, "m2", "ollama")
         is False
     )
+
+    # gemma4_audio known models should pass without manifest/provider
+    registry = SimpleNamespace(manifest={}, providers={})
+    assert (
+        await runtime.ensure_model_metadata_for_activation(
+            registry, "google/gemma-4-E2B-it", "gemma4_audio"
+        )
+        is True
+    )

--- a/tests/test_runtime_registry_contracts.py
+++ b/tests/test_runtime_registry_contracts.py
@@ -631,3 +631,37 @@ async def test_runtime_stack_scheduler_documenter_and_shadow_disabled():
     assert shadow is None
     assert desktop_sensor is None
     assert notifier is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_model_metadata_for_gemma4_audio_known_models():
+    """Znane modele gemma4_audio mogą być aktywowane bez wpisu w manifeście."""
+    registry = SimpleNamespace(manifest={}, providers={})
+    assert await model_registry_runtime.ensure_model_metadata_for_activation(
+        registry, "google/gemma-4-E2B-it", "gemma4_audio"
+    )
+    assert await model_registry_runtime.ensure_model_metadata_for_activation(
+        registry, "google/gemma-4-E4B-it", "gemma4_audio"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ensure_model_metadata_for_gemma4_audio_unknown_model_fails():
+    """Nieznany model dla gemma4_audio (brak w manifeście) zwraca False."""
+    registry = SimpleNamespace(manifest={}, providers={})
+    result = await model_registry_runtime.ensure_model_metadata_for_activation(
+        registry, "google/gemma-4-unknown", "gemma4_audio"
+    )
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_ensure_model_metadata_for_gemma4_audio_manifest_entry_wins():
+    """Model w manifeście zawsze zwraca True niezależnie od runtime."""
+    registry = SimpleNamespace(
+        manifest={"google/gemma-4-unknown": SimpleNamespace()},
+        providers={},
+    )
+    assert await model_registry_runtime.ensure_model_metadata_for_activation(
+        registry, "google/gemma-4-unknown", "gemma4_audio"
+    )

--- a/venom_core/api/audio_stream.py
+++ b/venom_core/api/audio_stream.py
@@ -93,6 +93,7 @@ def _build_voice_session_record(
         "audio_runtime_provider": metadata.get("audio_runtime_provider"),
         "audio_runtime_model": metadata.get("audio_runtime_model"),
         "audio_input_status": metadata.get("audio_input_status"),
+        "decoder_source": metadata.get("decoder_source"),
         "fallback_reason": metadata.get("fallback_reason"),
         "native_audio_ms": metadata.get("native_audio_ms"),
         "runtime_log_path": metadata.get("runtime_log_path"),
@@ -721,6 +722,7 @@ class AudioStreamHandler:
                     **snapshot,
                     "pipeline_id": "whisper_llm_piper",
                     "audio_input_status": "fallback",
+                    "decoder_source": "faster_whisper",
                     "fallback_reason": "gemma4_audio health check failed",
                     "timings_ms": timings_ms,
                     "runtime": self._build_runtime_metadata(operator_agent),
@@ -746,6 +748,7 @@ class AudioStreamHandler:
                     **snapshot,
                     "pipeline_id": "whisper_llm_piper",
                     "audio_input_status": "fallback",
+                    "decoder_source": "faster_whisper",
                     "fallback_reason": str(exc),
                     "native_audio_ms": timings_ms["native_audio_ms"],
                     "timings_ms": timings_ms,
@@ -770,6 +773,7 @@ class AudioStreamHandler:
                 **snapshot,
                 "pipeline_id": "gemma4_audio_piper",
                 "audio_input_status": "verified",
+                "decoder_source": "gemma4_audio",
                 "fallback_reason": "",
                 "native_audio_ms": timings_ms["native_audio_ms"],
                 "transcription": transcription,
@@ -886,6 +890,7 @@ class AudioStreamHandler:
                     "timings_ms": timings_ms,
                     "voice_mode": self._connection_voice_mode(connection_id),
                     "audio_input_status": "verified",
+                    "decoder_source": "faster_whisper",
                     "fallback_reason": "",
                     "runtime_log_path": _coerce_str(
                         getattr(SETTINGS, "GEMMA4_AUDIO_LOG_PATH", ""), ""
@@ -1055,6 +1060,7 @@ class AudioStreamHandler:
                     "transcription_length": len(transcription or ""),
                     "timings_ms": timings_ms,
                     "audio_input_status": "verified",
+                    "decoder_source": "faster_whisper",
                     "fallback_reason": "",
                     "runtime_log_path": _coerce_str(
                         getattr(SETTINGS, "GEMMA4_AUDIO_LOG_PATH", ""), ""

--- a/venom_core/api/routes/system_llm.py
+++ b/venom_core/api/routes/system_llm.py
@@ -80,6 +80,11 @@ _runtime_options_catalog_cache_lock = remote_models_service.Lock()
 _runtime_options_catalog_cache: dict[str, dict[str, Any]] = {}
 _runtime_options_probe_cache_lock = remote_models_service.Lock()
 _runtime_options_probe_cache: dict[str, dict[str, Any]] = {}
+
+_GEMMA4_AUDIO_COMPATIBLE_MODELS: list[str] = [
+    "google/gemma-4-E2B-it",
+    "google/gemma-4-E4B-it",
+]
 _MODEL_ALIAS_TO_CANONICAL: dict[str, str] = {
     "gemma3:latest": "gemma-3-4b-it",
     "gemma3:4b": "gemma-3-4b-it",
@@ -292,6 +297,8 @@ def _resolve_local_endpoint(server_name: str, target: dict) -> str | None:
         return build_http_url("localhost", 11434, "/v1")
     if server_name == "vllm":
         return SETTINGS.VLLM_ENDPOINT
+    if server_name == "gemma4_audio":
+        return SETTINGS.GEMMA4_AUDIO_ENDPOINT
     if server_name == "onnx":
         return None
     return endpoint
@@ -539,6 +546,10 @@ def _build_model_updates(
         "HYBRID_LOCAL_MODEL": selected_model,
         last_model_key: selected_model,
     }
+    if server_name == "gemma4_audio":
+        updates["LAST_MODEL_GEMMA4_AUDIO"] = selected_model
+        updates["GEMMA4_AUDIO_MODEL_ID"] = selected_model
+        updates["GEMMA4_AUDIO_ENABLED"] = "true"
     if server_name == "vllm":
         model_info = next((m for m in models if m["name"] == selected_model), None)
         if model_info and model_info.get("path"):
@@ -567,11 +578,32 @@ def _persist_selected_model_settings(
     try:
         SETTINGS.LLM_MODEL_NAME = selected_model
         SETTINGS.HYBRID_LOCAL_MODEL = selected_model
+        if server_name in {"ollama", "vllm", "gemma4_audio"}:
+            SETTINGS.LLM_SERVICE_TYPE = "local"
+        if server_name == "gemma4_audio":
+            SETTINGS.GEMMA4_AUDIO_ENABLED = True
+            SETTINGS.GEMMA4_AUDIO_MODEL_ID = selected_model
+            SETTINGS.LLM_LOCAL_ENDPOINT = endpoint or SETTINGS.GEMMA4_AUDIO_ENDPOINT
+        else:
+            SETTINGS.GEMMA4_AUDIO_ENABLED = False
     except Exception:
         logger.warning("Nie udało się zaktualizować SETTINGS dla modelu LLM.")
 
     config_hash = compute_llm_config_hash(server_name, endpoint, selected_model)
-    config_manager.update_config({"LLM_CONFIG_HASH": config_hash})
+    config_updates: dict[str, Any] = {
+        "LLM_CONFIG_HASH": config_hash,
+        "ACTIVE_LLM_SERVER": server_name,
+    }
+    if server_name in {"ollama", "vllm", "gemma4_audio"}:
+        config_updates["LLM_SERVICE_TYPE"] = "local"
+    if endpoint:
+        config_updates["LLM_LOCAL_ENDPOINT"] = endpoint
+    if server_name == "gemma4_audio":
+        config_updates["GEMMA4_AUDIO_ENABLED"] = "true"
+        config_updates["GEMMA4_AUDIO_MODEL_ID"] = selected_model
+    else:
+        config_updates["GEMMA4_AUDIO_ENABLED"] = "false"
+    config_manager.update_config(config_updates)
     try:
         SETTINGS.LLM_CONFIG_HASH = config_hash
         SETTINGS.ACTIVE_LLM_SERVER = server_name
@@ -1181,7 +1213,31 @@ async def _local_models_by_runtime(
             runtime_id = str(payload.get("runtime_id") or "").strip().lower()
             if runtime_id in grouped:
                 grouped[runtime_id].append(payload)
+    grouped["gemma4_audio"] = _gemma4_audio_static_models(
+        active_provider=active_provider,
+        active_model=active_model,
+    )
     return grouped, audit_issues
+
+
+def _gemma4_audio_static_models(
+    *,
+    active_provider: str,
+    active_model: str,
+) -> list[dict[str, Any]]:
+    return [
+        _runtime_model_payload(
+            runtime_id="gemma4_audio",
+            model_id=model_id,
+            name=model_id,
+            provider="gemma4_audio",
+            source_type="local-runtime",
+            active=(active_provider == "gemma4_audio" and active_model == model_id),
+            capabilities=["text", "audio", "voice"],
+            chat_compatible=True,
+        )
+        for model_id in _GEMMA4_AUDIO_COMPATIBLE_MODELS
+    ]
 
 
 def _runtime_payload_or_audit_issue(
@@ -1319,6 +1375,21 @@ def _runtime_target_payload(
         "supports_adapter_runtime_apply": runtime_capabilities[
             "supports_adapter_runtime_apply"
         ],
+        **_gemma4_audio_runtime_input_capabilities(runtime_id),
+    }
+
+
+def _gemma4_audio_runtime_input_capabilities(runtime_id: str) -> dict[str, Any]:
+    if runtime_id.strip().lower() != "gemma4_audio":
+        return {}
+    return {
+        "supports_text_input": True,
+        "supports_audio_input": True,
+        "supports_text_output": True,
+        "supports_image_input": False,
+        "supported_models": _GEMMA4_AUDIO_COMPATIBLE_MODELS,
+        "log_path": str(getattr(SETTINGS, "GEMMA4_AUDIO_LOG_PATH", "")),
+        "pid_path": str(getattr(SETTINGS, "GEMMA4_AUDIO_PID_PATH", "")),
     }
 
 
@@ -1345,6 +1416,13 @@ def _runtime_capabilities(*, runtime_id: str, source_type: str) -> dict[str, boo
             "supports_adapter_import_safetensors": False,
             "supports_adapter_import_gguf": False,
             "supports_adapter_runtime_apply": True,
+        }
+    if runtime == "gemma4_audio":
+        return {
+            "supports_native_training": False,
+            "supports_adapter_import_safetensors": False,
+            "supports_adapter_import_gguf": False,
+            "supports_adapter_runtime_apply": False,
         }
     return {
         "supports_native_training": False,
@@ -2014,6 +2092,30 @@ def _resolve_selected_model_for_switch(
     config: dict[str, Any],
     models: list[dict[str, Any]],
 ) -> tuple[str, str]:
+    if server_name == "gemma4_audio":
+        requested_last_model_key = _last_model_key_for_server(server_name)
+        requested_model = str(request.model or "").strip()
+        if requested_model:
+            if requested_model not in _GEMMA4_AUDIO_COMPATIBLE_MODELS:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Model '{requested_model}' nie jest dostępny na serwerze "
+                        f"'{server_name}'. Dozwolone: {', '.join(_GEMMA4_AUDIO_COMPATIBLE_MODELS)}."
+                    ),
+                )
+            return requested_model, requested_last_model_key
+
+        previous_choice = str(config.get("LAST_MODEL_GEMMA4_AUDIO") or "").strip()
+        if previous_choice in _GEMMA4_AUDIO_COMPATIBLE_MODELS:
+            return previous_choice, requested_last_model_key
+
+        default_choice = str(getattr(SETTINGS, "GEMMA4_AUDIO_MODEL_ID", "")).strip()
+        if default_choice in _GEMMA4_AUDIO_COMPATIBLE_MODELS:
+            return default_choice, requested_last_model_key
+
+        return _GEMMA4_AUDIO_COMPATIBLE_MODELS[0], requested_last_model_key
+
     available_models = set(
         _available_models_for_server(models=models, server_name=server_name)
     )
@@ -2051,6 +2153,8 @@ def _last_model_key_for_server(server_name: str) -> str:
         return "LAST_MODEL_OLLAMA"
     if server_name == "onnx":
         return "LAST_MODEL_ONNX"
+    if server_name == "gemma4_audio":
+        return "LAST_MODEL_GEMMA4_AUDIO"
     return "LAST_MODEL_VLLM"
 
 

--- a/venom_core/api/routes/system_llm.py
+++ b/venom_core/api/routes/system_llm.py
@@ -2093,28 +2093,11 @@ def _resolve_selected_model_for_switch(
     models: list[dict[str, Any]],
 ) -> tuple[str, str]:
     if server_name == "gemma4_audio":
-        requested_last_model_key = _last_model_key_for_server(server_name)
-        requested_model = str(request.model or "").strip()
-        if requested_model:
-            if requested_model not in _GEMMA4_AUDIO_COMPATIBLE_MODELS:
-                raise HTTPException(
-                    status_code=400,
-                    detail=(
-                        f"Model '{requested_model}' nie jest dostępny na serwerze "
-                        f"'{server_name}'. Dozwolone: {', '.join(_GEMMA4_AUDIO_COMPATIBLE_MODELS)}."
-                    ),
-                )
-            return requested_model, requested_last_model_key
-
-        previous_choice = str(config.get("LAST_MODEL_GEMMA4_AUDIO") or "").strip()
-        if previous_choice in _GEMMA4_AUDIO_COMPATIBLE_MODELS:
-            return previous_choice, requested_last_model_key
-
-        default_choice = str(getattr(SETTINGS, "GEMMA4_AUDIO_MODEL_ID", "")).strip()
-        if default_choice in _GEMMA4_AUDIO_COMPATIBLE_MODELS:
-            return default_choice, requested_last_model_key
-
-        return _GEMMA4_AUDIO_COMPATIBLE_MODELS[0], requested_last_model_key
+        return _resolve_gemma4_audio_selected_model_for_switch(
+            request=request,
+            server_name=server_name,
+            config=config,
+        )
 
     available_models = set(
         _available_models_for_server(models=models, server_name=server_name)
@@ -2146,6 +2129,51 @@ def _resolve_selected_model_for_switch(
         if fallback is None:
             raise
         return fallback
+
+
+def _resolve_gemma4_audio_selected_model_for_switch(
+    *,
+    request: ActiveLlmServerRequest,
+    server_name: str,
+    config: dict[str, Any],
+) -> tuple[str, str]:
+    requested_last_model_key = _last_model_key_for_server(server_name)
+    requested_model = str(request.model or "").strip()
+
+    if requested_model:
+        _validate_gemma4_audio_requested_model(
+            requested_model=requested_model, server_name=server_name
+        )
+        return requested_model, requested_last_model_key
+
+    selected = _resolve_gemma4_audio_fallback_model(config=config)
+    return selected, requested_last_model_key
+
+
+def _validate_gemma4_audio_requested_model(
+    *, requested_model: str, server_name: str
+) -> None:
+    if requested_model in _GEMMA4_AUDIO_COMPATIBLE_MODELS:
+        return
+    raise HTTPException(
+        status_code=400,
+        detail=(
+            f"Model '{requested_model}' nie jest dostępny na serwerze "
+            f"'{server_name}'. Dozwolone: {', '.join(_GEMMA4_AUDIO_COMPATIBLE_MODELS)}."
+        ),
+    )
+
+
+def _resolve_gemma4_audio_fallback_model(*, config: dict[str, Any]) -> str:
+    previous_choice = str(config.get("LAST_MODEL_GEMMA4_AUDIO") or "").strip()
+    if previous_choice in _GEMMA4_AUDIO_COMPATIBLE_MODELS:
+        return previous_choice
+
+    default_choice = str(getattr(SETTINGS, "GEMMA4_AUDIO_MODEL_ID", "")).strip()
+    if default_choice in _GEMMA4_AUDIO_COMPATIBLE_MODELS:
+        return default_choice
+
+    return _GEMMA4_AUDIO_COMPATIBLE_MODELS[0]
 
 
 def _last_model_key_for_server(server_name: str) -> str:

--- a/venom_core/core/llm_server_controller.py
+++ b/venom_core/core/llm_server_controller.py
@@ -137,7 +137,7 @@ class LlmServerController:
             provider="gemma4_audio",
             description="Native audio inference daemon for Gemma 4 models (port 8014).",
             endpoint=cfg.GEMMA4_AUDIO_ENDPOINT,
-            health_url=f"{cfg.GEMMA4_AUDIO_ENDPOINT.rstrip('/')}/health",
+            health_url=f"http://{cfg.GEMMA4_AUDIO_HOST}:{cfg.GEMMA4_AUDIO_PORT}/health",
             commands={
                 "start": gemma4_audio_start_cmd,
                 "stop": gemma4_audio_stop_cmd,

--- a/venom_core/core/llm_server_controller.py
+++ b/venom_core/core/llm_server_controller.py
@@ -137,7 +137,9 @@ class LlmServerController:
             provider="gemma4_audio",
             description="Native audio inference daemon for Gemma 4 models (port 8014).",
             endpoint=cfg.GEMMA4_AUDIO_ENDPOINT,
-            health_url=f"http://{cfg.GEMMA4_AUDIO_HOST}:{cfg.GEMMA4_AUDIO_PORT}/health",
+            health_url=build_http_url(
+                cfg.GEMMA4_AUDIO_HOST, cfg.GEMMA4_AUDIO_PORT, "/health"
+            ),
             commands={
                 "start": gemma4_audio_start_cmd,
                 "stop": gemma4_audio_stop_cmd,

--- a/venom_core/core/model_registry_runtime.py
+++ b/venom_core/core/model_registry_runtime.py
@@ -39,10 +39,17 @@ async def activate_model(registry: Any, model_name: str, runtime: str) -> bool:
     return True
 
 
+_GEMMA4_AUDIO_KNOWN_MODELS: frozenset[str] = frozenset(
+    ["google/gemma-4-E2B-it", "google/gemma-4-E4B-it"]
+)
+
+
 async def ensure_model_metadata_for_activation(
     registry: Any, model_name: str, runtime: str
 ) -> bool:
     if model_name in registry.manifest:
+        return True
+    if runtime == "gemma4_audio" and model_name in _GEMMA4_AUDIO_KNOWN_MODELS:
         return True
     if runtime != "ollama":
         logger.error(f"Model {model_name} nie znaleziony w manifeście")

--- a/venom_core/main.py
+++ b/venom_core/main.py
@@ -277,6 +277,62 @@ class AudioTtsModelUpdateRequest(BaseModel):
 
 async def _build_voice_runtime_snapshot() -> dict[str, object] | None:
     runtime = get_active_llm_runtime()
+    if runtime.provider == "gemma4_audio":
+        runtime_capabilities = {
+            "compatibility_profile": "gemma4_audio_native",
+            "probe_status": "verified"
+            if bool(getattr(SETTINGS, "GEMMA4_AUDIO_ENABLED", False))
+            else "metadata_only",
+            "capabilities": {
+                "audio_input": bool(
+                    getattr(SETTINGS, "GEMMA4_AUDIO_SUPPORTS_AUDIO", True)
+                ),
+                "text_input": bool(
+                    getattr(SETTINGS, "GEMMA4_AUDIO_SUPPORTS_TEXT", True)
+                ),
+                "text_output": True,
+                "vision_input": False,
+                "tool_calling": False,
+                "thinking": False,
+            },
+            "probes": {
+                "health": {
+                    "status": "verified"
+                    if bool(getattr(SETTINGS, "GEMMA4_AUDIO_ENABLED", False))
+                    else "metadata_only",
+                    "reason": None
+                    if bool(getattr(SETTINGS, "GEMMA4_AUDIO_ENABLED", False))
+                    else "runtime_not_enabled",
+                }
+            },
+            "fallbacks": {
+                "voice_fallback_pipeline": "whisper_llm_piper",
+                "tts": "piper",
+            },
+        }
+        voice_pipeline = {
+            "profile": "gemma4_audio_native",
+            "stt": "native_audio"
+            if bool(getattr(SETTINGS, "GEMMA4_AUDIO_ENABLED", False))
+            else "faster_whisper",
+            "reasoning": "native_audio_model",
+            "tools": "disabled",
+            "vision": "disabled",
+            "tts": "piper",
+            "notes": [],
+        }
+        return {
+            "runtime_id": runtime.runtime_id,
+            "provider": runtime.provider,
+            "model_name": runtime.model_name
+            or str(getattr(SETTINGS, "GEMMA4_AUDIO_MODEL_ID", "") or "").strip(),
+            "endpoint": runtime.endpoint
+            or str(getattr(SETTINGS, "GEMMA4_AUDIO_ENDPOINT", "") or "").strip(),
+            "config_hash": runtime.config_hash,
+            "runtime_capabilities": runtime_capabilities,
+            "voice_pipeline": voice_pipeline,
+        }
+
     if runtime.provider != "ollama" or not runtime.model_name or not runtime.endpoint:
         return None
 

--- a/web-next/components/cockpit/cockpit-llm-ops-panel.tsx
+++ b/web-next/components/cockpit/cockpit-llm-ops-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { LogEntryType } from "@/lib/logs";
-import type { LlmServerInfo, Task } from "@/lib/types";
+import type { LlmRuntimeTargetOption, LlmServerInfo, Task } from "@/lib/types";
 import type { SelectMenuOption } from "@/components/ui/select-menu";
 import { CockpitLogs } from "@/components/cockpit/cockpit-logs";
 import { CockpitModels } from "@/components/cockpit/cockpit-models";
@@ -38,6 +38,15 @@ type CockpitLlmOpsPanelProps = Readonly<{
   onExportPinnedLogs: () => void;
   onClearPinnedLogs: () => void;
   tasksPreview: Task[];
+  gemma4AudioRuntimeInfo?: Pick<
+    LlmRuntimeTargetOption,
+    | "supports_text_input"
+    | "supports_audio_input"
+    | "supports_text_output"
+    | "supports_image_input"
+    | "log_path"
+    | "pid_path"
+  > | null;
 }>;
 
 export function CockpitLlmOpsPanel({
@@ -62,6 +71,7 @@ export function CockpitLlmOpsPanel({
   activeServerName,
   llmActionPending,
   onActivateServer,
+  gemma4AudioRuntimeInfo,
   connected,
   logFilter,
   onLogFilterChange,
@@ -97,6 +107,7 @@ export function CockpitLlmOpsPanel({
         activeServerName={activeServerName}
         llmActionPending={llmActionPending}
         onActivateServer={onActivateServer}
+        gemma4AudioRuntimeInfo={gemma4AudioRuntimeInfo}
       />
       <CockpitLogs
         connected={connected}

--- a/web-next/components/cockpit/cockpit-models.tsx
+++ b/web-next/components/cockpit/cockpit-models.tsx
@@ -8,7 +8,17 @@ import Link from "next/link";
 import type { SelectMenuOption } from "@/components/ui/select-menu";
 import { SelectMenu } from "@/components/ui/select-menu";
 import { useTranslation } from "@/lib/i18n";
-import type { LlmServerInfo } from "@/lib/types";
+import type { LlmRuntimeTargetOption, LlmServerInfo } from "@/lib/types";
+
+type Gemma4AudioRuntimeInfo = Pick<
+  LlmRuntimeTargetOption,
+  | "supports_text_input"
+  | "supports_audio_input"
+  | "supports_text_output"
+  | "supports_image_input"
+  | "log_path"
+  | "pid_path"
+>;
 
 type CockpitModelsProps = Readonly<{
   llmServersLoading: boolean;
@@ -32,6 +42,7 @@ type CockpitModelsProps = Readonly<{
   activeServerName?: string | null;
   llmActionPending: string | null;
   onActivateServer: () => void;
+  gemma4AudioRuntimeInfo?: Gemma4AudioRuntimeInfo | null;
 }>;
 
 export function CockpitModels({
@@ -56,6 +67,7 @@ export function CockpitModels({
   activeServerName,
   llmActionPending,
   onActivateServer,
+  gemma4AudioRuntimeInfo,
 }: CockpitModelsProps) {
   const t = useTranslation();
   let activateServerLabel = "Aktywuj serwer";
@@ -211,8 +223,46 @@ export function CockpitModels({
           >
             {activateServerLabel}
           </Button>
+          {selectedLlmServer === "gemma4_audio" && gemma4AudioRuntimeInfo && (
+            <Gemma4AudioCapabilityInfo info={gemma4AudioRuntimeInfo} />
+          )}
         </div>
       </div>
     </Panel>
+  );
+}
+
+const GEMMA4_AUDIO_CAPABILITY_BADGES = [
+  { key: "text", label: "text" },
+  { key: "audio", label: "audio" },
+  { key: "voice", label: "voice" },
+  { key: "tts", label: "Piper TTS" },
+] as const;
+
+function Gemma4AudioCapabilityInfo({
+  info,
+}: Readonly<{ info: Gemma4AudioRuntimeInfo }>) {
+  return (
+    <div className="mt-3 rounded-xl border border-white/10 bg-white/[0.03] p-3 text-xs text-zinc-400">
+      <p className="mb-2 text-[10px] uppercase tracking-widest text-zinc-500">
+        Gemma 4 Audio — capability
+      </p>
+      <div className="mb-2 flex flex-wrap gap-1">
+        {GEMMA4_AUDIO_CAPABILITY_BADGES.map(({ key, label }) => (
+          <span
+            key={key}
+            className="rounded bg-zinc-800 px-2 py-0.5 text-[10px] font-medium text-zinc-300"
+          >
+            {label}
+          </span>
+        ))}
+      </div>
+      {info.log_path && (
+        <p className="truncate text-zinc-500">log: {info.log_path}</p>
+      )}
+      {info.pid_path && (
+        <p className="truncate text-zinc-500">pid: {info.pid_path}</p>
+      )}
+    </div>
   );
 }

--- a/web-next/components/cockpit/cockpit-section-props.ts
+++ b/web-next/components/cockpit/cockpit-section-props.ts
@@ -573,6 +573,19 @@ export function useCockpitSectionProps() {
     tuningLabel,
   ]);
 
+  const gemma4AudioRuntimeInfo = useMemo(() => {
+    const target = runtimeTargets.find((rt) => rt.runtime_id === "gemma4_audio");
+    if (!target) return null;
+    return {
+      supports_text_input: target.supports_text_input,
+      supports_audio_input: target.supports_audio_input,
+      supports_text_output: target.supports_text_output,
+      supports_image_input: target.supports_image_input,
+      log_path: target.log_path,
+      pid_path: target.pid_path,
+    };
+  }, [runtimeTargets]);
+
   const llmOpsPanelProps = useMemo(() => ({
     llmServersLoading,
     llmServers,
@@ -595,6 +608,7 @@ export function useCockpitSectionProps() {
     activeServerName,
     llmActionPending,
     onActivateServer,
+    gemma4AudioRuntimeInfo,
     connected,
     logFilter,
     onLogFilterChange,
@@ -611,6 +625,7 @@ export function useCockpitSectionProps() {
     availableModelsForServer,
     connected,
     exportingPinned,
+    gemma4AudioRuntimeInfo,
     llmActionPending,
     llmModelOptionsPanel,
     llmServerOptionsPanel,

--- a/web-next/components/voice/dev-diagnostics-drawer.tsx
+++ b/web-next/components/voice/dev-diagnostics-drawer.tsx
@@ -34,6 +34,14 @@ type AudioStatus = {
       llm_model?: string | null;
       tts_sample_rate?: number | null;
     };
+    pipeline_id?: string | null;
+    audio_runtime_provider?: string | null;
+    audio_runtime_model?: string | null;
+    audio_input_status?: string | null;
+    decoder_source?: string | null;
+    fallback_reason?: string | null;
+    native_audio_ms?: number | null;
+    runtime_log_path?: string | null;
   } | null;
   runtime_snapshot?: {
     runtime_id?: string | null;
@@ -254,6 +262,35 @@ function LatestRecordingSection({
           </p>
         )}
         {latestVoiceSession.transcription && <p>STT: {latestVoiceSession.transcription}</p>}
+        {latestVoiceSession.pipeline_id && (
+          <p>Pipeline: {latestVoiceSession.pipeline_id}</p>
+        )}
+        {latestVoiceSession.audio_runtime_provider && (
+          <p>
+            STT backend:{" "}
+            {latestVoiceSession.audio_runtime_provider === "gemma4_audio"
+              ? "gemma4_audio"
+              : "faster-whisper"}
+            {latestVoiceSession.audio_runtime_model
+              ? ` (${latestVoiceSession.audio_runtime_model})`
+              : ""}
+          </p>
+        )}
+        {latestVoiceSession.decoder_source && (
+          <p>Decoder source: {latestVoiceSession.decoder_source}</p>
+        )}
+        {latestVoiceSession.audio_input_status && (
+          <p>Audio input: {latestVoiceSession.audio_input_status}</p>
+        )}
+        {latestVoiceSession.fallback_reason && (
+          <p className="text-amber-400">Fallback: {latestVoiceSession.fallback_reason}</p>
+        )}
+        {latestVoiceSession.native_audio_ms != null && (
+          <p>Native audio: {formatSeconds(latestVoiceSession.native_audio_ms)}</p>
+        )}
+        {latestVoiceSession.runtime_log_path && (
+          <p className="truncate text-zinc-500">Log: {latestVoiceSession.runtime_log_path}</p>
+        )}
       </div>
     </div>
   );

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -63,6 +63,14 @@ export type AudioStatus = {
     transcription?: string;
     response_text?: string;
     download_url?: string | null;
+    pipeline_id?: string | null;
+    audio_runtime_provider?: string | null;
+    audio_runtime_model?: string | null;
+    audio_input_status?: string | null;
+    decoder_source?: string | null;
+    fallback_reason?: string | null;
+    native_audio_ms?: number | null;
+    runtime_log_path?: string | null;
   } | null;
   message?: string;
   runtime_snapshot?: {

--- a/web-next/lib/i18n/index.tsx
+++ b/web-next/lib/i18n/index.tsx
@@ -7,6 +7,7 @@ import {
   useEffect,
   useMemo,
   useState,
+  useSyncExternalStore,
   type ReactNode,
 } from "react";
 import { pl } from "./locales/pl";
@@ -63,7 +64,7 @@ function applyReplacements(value: string, replacements?: Record<string, string |
   }, value);
 }
 
-function resolveInitialLanguage(): LanguageCode {
+function resolvePreferredLanguage(): LanguageCode {
   if (globalThis.window === undefined) return "pl";
   const stored = globalThis.window.localStorage.getItem(STORAGE_KEY) as LanguageCode | null;
   if (stored && stored in translations) {
@@ -76,8 +77,25 @@ function resolveInitialLanguage(): LanguageCode {
   return "pl";
 }
 
+function subscribeToLanguagePreference(onStoreChange: () => void): () => void {
+  if (globalThis.window === undefined) return () => undefined;
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === STORAGE_KEY) {
+      onStoreChange();
+    }
+  };
+  globalThis.window.addEventListener("storage", handleStorage);
+  return () => globalThis.window.removeEventListener("storage", handleStorage);
+}
+
 export function LanguageProvider({ children }: Readonly<{ children: ReactNode }>) {
-  const [language, setLanguage] = useState<LanguageCode>(() => resolveInitialLanguage());
+  const preferredLanguage = useSyncExternalStore(
+    subscribeToLanguagePreference,
+    resolvePreferredLanguage,
+    () => "pl",
+  );
+  const [userSelectedLanguage, setUserSelectedLanguage] = useState<LanguageCode | null>(null);
+  const language = userSelectedLanguage ?? preferredLanguage;
 
   useEffect(() => {
     if (globalThis.window === undefined) return;
@@ -88,6 +106,7 @@ export function LanguageProvider({ children }: Readonly<{ children: ReactNode }>
     if (globalThis.window === undefined) return;
     globalThis.window.localStorage.setItem(STORAGE_KEY, language);
     dayjs.locale(language);
+    document.documentElement.lang = language;
   }, [language]);
 
   const translate = useCallback(
@@ -104,10 +123,10 @@ export function LanguageProvider({ children }: Readonly<{ children: ReactNode }>
   const value = useMemo(
     () => ({
       language,
-      setLanguage,
+      setLanguage: setUserSelectedLanguage,
       t: translate,
     }),
-    [language, translate],
+    [language, translate, setUserSelectedLanguage],
   );
 
   return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;

--- a/web-next/lib/types.ts
+++ b/web-next/lib/types.ts
@@ -153,6 +153,13 @@ export interface LlmRuntimeTargetOption {
   supports_adapter_import_safetensors?: boolean;
   supports_adapter_import_gguf?: boolean;
   supports_adapter_runtime_apply?: boolean;
+  supports_text_input?: boolean;
+  supports_audio_input?: boolean;
+  supports_text_output?: boolean;
+  supports_image_input?: boolean;
+  supported_models?: string[];
+  log_path?: string;
+  pid_path?: string;
 }
 
 export interface LlmRuntimeOptionsResponse {

--- a/web-next/tests/gemma4-audio-runtime.test.ts
+++ b/web-next/tests/gemma4-audio-runtime.test.ts
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { LlmRuntimeTargetOption } from "../lib/types";
+
+const GEMMA4_AUDIO_MODELS = ["google/gemma-4-E2B-it", "google/gemma-4-E4B-it"];
+
+function makeGemma4AudioRuntime(
+  overrides: Partial<LlmRuntimeTargetOption> = {},
+): LlmRuntimeTargetOption {
+  return {
+    runtime_id: "gemma4_audio",
+    source_type: "local-runtime",
+    configured: true,
+    available: true,
+    status: "online",
+    active: false,
+    models: GEMMA4_AUDIO_MODELS.map((id) => ({
+      id,
+      name: id,
+      provider: "gemma4_audio",
+      runtime_id: "gemma4_audio",
+      source_type: "local-runtime",
+      active: false,
+      capabilities: ["text", "audio", "voice"],
+      chat_compatible: true,
+    })),
+    supports_text_input: true,
+    supports_audio_input: true,
+    supports_text_output: true,
+    supports_image_input: false,
+    supported_models: GEMMA4_AUDIO_MODELS,
+    log_path: "logs/gemma4_audio_service.log",
+    pid_path: ".venom_runtime/gemma4_audio.pid",
+    ...overrides,
+  };
+}
+
+describe("gemma4_audio runtime type contract", () => {
+  it("runtime appears as local-runtime with correct runtime_id", () => {
+    const rt = makeGemma4AudioRuntime();
+    assert.equal(rt.runtime_id, "gemma4_audio");
+    assert.equal(rt.source_type, "local-runtime");
+  });
+
+  it("exposes exactly two compatible models", () => {
+    const rt = makeGemma4AudioRuntime();
+    assert.equal(rt.models.length, 2);
+    const ids = rt.models.map((m) => m.id);
+    assert.ok(ids.includes("google/gemma-4-E2B-it"));
+    assert.ok(ids.includes("google/gemma-4-E4B-it"));
+  });
+
+  it("model list filters to chat_compatible models only", () => {
+    const rt = makeGemma4AudioRuntime();
+    const chatModels = rt.models.filter((m) => m.chat_compatible !== false);
+    assert.equal(chatModels.length, 2);
+  });
+
+  it("each model carries text+audio+voice capability badges", () => {
+    const rt = makeGemma4AudioRuntime();
+    for (const model of rt.models) {
+      const caps = model.capabilities ?? [];
+      assert.ok(caps.includes("text"), `text missing for ${model.id}`);
+      assert.ok(caps.includes("audio"), `audio missing for ${model.id}`);
+      assert.ok(caps.includes("voice"), `voice missing for ${model.id}`);
+    }
+  });
+
+  it("supports_text_input and supports_audio_input are true", () => {
+    const rt = makeGemma4AudioRuntime();
+    assert.equal(rt.supports_text_input, true);
+    assert.equal(rt.supports_audio_input, true);
+    assert.equal(rt.supports_text_output, true);
+  });
+
+  it("supports_image_input is false", () => {
+    const rt = makeGemma4AudioRuntime();
+    assert.equal(rt.supports_image_input, false);
+  });
+
+  it("log_path and pid_path are present", () => {
+    const rt = makeGemma4AudioRuntime();
+    assert.ok(rt.log_path);
+    assert.ok(rt.pid_path);
+  });
+
+  it("active model flag is correct when E2B-it is active", () => {
+    const rt = makeGemma4AudioRuntime({
+      active: true,
+      models: GEMMA4_AUDIO_MODELS.map((id) => ({
+        id,
+        name: id,
+        provider: "gemma4_audio",
+        runtime_id: "gemma4_audio",
+        source_type: "local-runtime" as const,
+        active: id === "google/gemma-4-E2B-it",
+        capabilities: ["text", "audio", "voice"],
+        chat_compatible: true,
+      })),
+    });
+    const activeModels = rt.models.filter((m) => m.active);
+    assert.equal(activeModels.length, 1);
+    assert.equal(activeModels[0].id, "google/gemma-4-E2B-it");
+  });
+
+  it("runtime status maps to expected states", () => {
+    for (const status of ["disabled", "offline", "starting", "ready", "error"]) {
+      const rt = makeGemma4AudioRuntime({ status });
+      assert.equal(rt.status, status);
+    }
+  });
+
+  it("supported_models list contains both compatible models", () => {
+    const rt = makeGemma4AudioRuntime();
+    assert.ok(rt.supported_models?.includes("google/gemma-4-E2B-it"));
+    assert.ok(rt.supported_models?.includes("google/gemma-4-E4B-it"));
+  });
+});
+
+describe("gemma4_audio voice diagnostics fields", () => {
+  type LatestVoiceSession = {
+    session_id: string;
+    pipeline_id?: string | null;
+    audio_runtime_provider?: string | null;
+    audio_runtime_model?: string | null;
+    audio_input_status?: string | null;
+    decoder_source?: string | null;
+    fallback_reason?: string | null;
+    native_audio_ms?: number | null;
+    runtime_log_path?: string | null;
+  };
+
+  it("native pipeline session has gemma4_audio_piper pipeline_id", () => {
+    const session: LatestVoiceSession = {
+      session_id: "sess-1",
+      pipeline_id: "gemma4_audio_piper",
+      audio_runtime_provider: "gemma4_audio",
+      audio_runtime_model: "google/gemma-4-E2B-it",
+      audio_input_status: "verified",
+      decoder_source: "gemma4_audio",
+      fallback_reason: "",
+      native_audio_ms: 1200,
+    };
+    assert.equal(session.pipeline_id, "gemma4_audio_piper");
+    assert.equal(session.audio_runtime_provider, "gemma4_audio");
+    assert.equal(session.audio_input_status, "verified");
+    assert.equal(session.decoder_source, "gemma4_audio");
+  });
+
+  it("fallback session has whisper_llm_piper pipeline_id and fallback_reason", () => {
+    const session: LatestVoiceSession = {
+      session_id: "sess-2",
+      pipeline_id: "whisper_llm_piper",
+      audio_runtime_provider: "gemma4_audio",
+      audio_input_status: "fallback",
+      decoder_source: "faster_whisper",
+      fallback_reason: "gemma4_audio health check failed",
+    };
+    assert.equal(session.pipeline_id, "whisper_llm_piper");
+    assert.ok(session.fallback_reason);
+    assert.equal(session.audio_input_status, "fallback");
+    assert.equal(session.decoder_source, "faster_whisper");
+  });
+
+  it("older whisper session has no audio_runtime_provider", () => {
+    const session: LatestVoiceSession = {
+      session_id: "sess-3",
+      pipeline_id: "whisper_llm_piper",
+    };
+    assert.equal(session.audio_runtime_provider, undefined);
+  });
+});

--- a/web-next/tests/streaming.spec.ts
+++ b/web-next/tests/streaming.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { ensureChatRuntimeReadyOrSkip } from "./utils/chat-runtime-readiness";
 
 const emptyJson = JSON.stringify([]);
@@ -317,5 +317,10 @@ test.describe("Cockpit streaming SSE", () => {
       undefined,
       { timeout: 10000 },
     );
+    const streamEventsCount = await page.evaluate(() => {
+      const win = window as typeof window & { __taskStreamEvents?: Record<string, unknown>[] };
+      return Array.isArray(win.__taskStreamEvents) ? win.__taskStreamEvents.length : 0;
+    });
+    expect(streamEventsCount).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Cel
Integracja nowego toru `gemma4_audio` na ekranie `/voice` jako alternatywnego silnika LLM (bez łamania kompatybilności wstecznej dla Ollama/VLLM), z czytelną diagnostyką w UI i poprawnym workflow start/stop stosu.

## Co zostało zrobione
- Dodano obsługę przełączania runtime na `gemma4_audio` w kontrolkach i API runtime.
- Uzupełniono flow start/stop:
  - przy starcie `gemma4_audio` zatrzymywane są konflikty VRAM (`ollama`, `vllm`),
  - przy stopie zatrzymywany jest daemon gemma4 i czyszczony port runtime.
- Naprawiono endpointy health/chat dla natywnego runtime gemma:
  - `GET /health`,
  - `GET /v1/health` (alias),
  - `POST /v1/chat/completions` (OpenAI-compatible dla toru tekstowego).
- Ujednolicono wybór modelu i utrwalanie configu runtime (`GEMMA4_AUDIO_*`) w backendzie.
- Dodano telemetry/diagnostics źródła dekodera STT (`decoder_source`), aby w UI było wprost widoczne czy dekodowanie robi `gemma4_audio` czy fallback.
- Uzupełniono `runtime_snapshot` dla nowego runtime, aby `/voice` pokazywał aktywny stos/model po odświeżeniu statusu.
- Rozszerzono i doprecyzowano dokumentację zakresu PR 211.

## Testy
- Backend:
  - rozszerzone testy runtime/options + kontrakty registry,
  - testy ścieżek `gemma4_audio` i fallback.
- Frontend:
  - nowe testy jednostkowe dla diagnostyki runtime/decoder source (`web-next/tests/gemma4-audio-runtime.test.ts`).
- Lokalnie testy przechodziły w trakcie implementacji (backend + web unit).

## Ryzyko / kompatybilność
- Zachowana kompatybilność wsteczna: wybór `ollama` działa po staremu.
- Nowy runtime jest opcjonalny i aktywowany wyłącznie przez wybór stacku/modelu.

## Zakres poza PR
- Dalsze usprawnienia UX/sterowania pod pełny przepływ multimodalny będą domykane w kolejnych PR (w tym rozszerzenia TTS toru alternatywnego).
