### PR TITLE
feat(gemma4): steerable daemon with VRAM hygiene and control API (214A)

### DIFF
--- a/config/pytest-groups/fast.txt
+++ b/config/pytest-groups/fast.txt
@@ -12,6 +12,7 @@ tests/api/test_system_api.py
 tests/api/test_system_api_dynamic.py
 tests/security/test_autonomy_enforcement.py
 tests/test_204a_canonical_control_state.py
+tests/test_214a_gemma4_daemon.py
 tests/test_academy_202c_signing_coverage.py
 tests/test_academy_202d_lora_onnx_deploy.py
 tests/test_academy_adapter_runtime_service.py

--- a/config/pytest-groups/sonar-new-code.txt
+++ b/config/pytest-groups/sonar-new-code.txt
@@ -4,6 +4,7 @@
 tests/ollama_bench/test_common_and_scoreboard.py
 tests/ollama_bench/test_scheduler.py
 tests/test_204a_canonical_control_state.py
+tests/test_214a_gemma4_daemon.py
 tests/test_academy_202c_signing_coverage.py
 tests/test_academy_202d_lora_onnx_deploy.py
 tests/test_academy_adapter_runtime_service.py

--- a/config/testing/test_catalog.json
+++ b/config/testing/test_catalog.json
@@ -2282,6 +2282,20 @@
       "rationale": "Default release-lane regression coverage."
     },
     {
+      "path": "tests/test_214a_gemma4_daemon.py",
+      "domain": "runtime",
+      "test_type": "service_contract",
+      "intent": "contract",
+      "primary_lane": "new-code",
+      "allowed_lanes": [
+        "new-code",
+        "ci-lite",
+        "release"
+      ],
+      "legacy_targeted": false,
+      "rationale": "Daemon engine and control API tests for PR 214A (Gemma 4 Runtime Ops: daemon, VRAM hygiene, reload signals, assistant attach/detach, fallback)."
+    },
+    {
       "path": "tests/test_gemma4_audio_runtime_main.py",
       "domain": "runtime",
       "test_type": "service_contract",

--- a/docs/PL/VOICE_RUNTIME_CAPABILITIES.md
+++ b/docs/PL/VOICE_RUNTIME_CAPABILITIES.md
@@ -189,6 +189,36 @@ Kryteria akceptacji dla native audio:
 6. Traktować ONNX jako osobne badanie edge/ASR, nie jako pierwszy kierunek Gemma4 audio-native.
 7. Budować PR 206 voice orb dopiero na stabilnych stanach runtime emitowanych przez PR 207.
 
+## Operacyjna strategia Gemma 4
+
+Aktualny kierunek dla Gemma 4 to utrzymanie daemona opartego o Transformers i
+traktowanie oficjalnych checkpointów Google jako bazy runtime.
+
+Założenia robocze:
+
+1. model bazowy: `google/gemma-4-E2B-it`,
+2. opcjonalny drafter/asystent: `google/gemma-4-E2B-it-assistant`,
+3. główne kontrolki runtime:
+   - `enable_thinking` on/off,
+   - `max_new_tokens`,
+   - `cache_implementation="static"`,
+   - limity multimodalne,
+4. kierunki optymalizacji:
+   - speculative decoding przez MTP,
+   - kompresja KV cache, np. TurboQuant,
+5. wymaganie operacyjne:
+   - po reloadzie lub zmianie modelu VRAM ma być faktycznie zwalniany,
+   - drugi model nie może wisieć w pamięci po przełączeniu.
+
+Z tego wynika, że następny krok implementacyjny powinien dotyczyć:
+
+1. przełączania wariantów modelu z poziomu daemona / API / UX,
+2. wystawienia kontroli thinking i kontekstu,
+3. bezpiecznych reguł reloadu daemona,
+4. pokazania stanu VRAM i stanu reloadu w UI,
+5. utrzymania przyszłych wariantów kwantyzowanych jako zgodnych z tym samym
+   daemonem, a nie jako nowego osobnego stosu.
+
 ## Źródła
 
 1. Ollama show model details: https://docs.ollama.com/api-reference/show-model-details

--- a/docs/VOICE_RUNTIME_CAPABILITIES.md
+++ b/docs/VOICE_RUNTIME_CAPABILITIES.md
@@ -189,6 +189,36 @@ Acceptance criteria for native audio:
 6. Treat ONNX as a separate edge/ASR investigation, not as the first Gemma4 audio-native path.
 7. Build PR 206 voice orb only on the stable runtime states emitted by PR 207.
 
+## Gemma 4 Operational Runtime Strategy
+
+Current operational direction for Gemma 4 is to keep the Transformers-based
+daemon and treat the official Google checkpoints as the base runtime family.
+
+Working assumptions:
+
+1. base model: `google/gemma-4-E2B-it`,
+2. optional drafter/assistant: `google/gemma-4-E2B-it-assistant`,
+3. preferred runtime controls:
+   - `enable_thinking` on/off,
+   - `max_new_tokens`,
+   - `cache_implementation="static"`,
+   - multimodal context limits,
+4. long-term optimization candidates:
+   - speculative decoding via MTP assistant,
+   - KV-cache compression research such as TurboQuant,
+5. operational constraint:
+   - keep VRAM hygiene strict so a second model never lingers in memory
+     after reload or switch.
+
+This means the next implementation step should focus on:
+
+1. switching model variants from daemon/API/UX,
+2. exposing thinking/context controls,
+3. adding safe reload rules for the daemon,
+4. exposing VRAM status and reload state to the UI,
+5. keeping future quantized variants compatible with the same daemon rather
+   than creating a second runtime stack.
+
 ## References
 
 1. Ollama show model details: https://docs.ollama.com/api-reference/show-model-details

--- a/services/gemma4_audio_runtime/audio.py
+++ b/services/gemma4_audio_runtime/audio.py
@@ -10,8 +10,6 @@ from pathlib import Path
 from typing import Optional, Tuple
 
 import numpy as np
-import soundfile as sf
-from scipy.signal import resample_poly
 
 TARGET_SAMPLE_RATE = 16_000
 
@@ -24,6 +22,8 @@ class AudioNormalizationError(Exception):
 
 def read_audio_file(path: Path) -> Tuple[np.ndarray, int]:
     """Read audio file using soundfile with ffmpeg fallback."""
+    import soundfile as sf
+
     try:
         audio, sample_rate = sf.read(str(path), always_2d=True, dtype="float32")
         return audio, int(sample_rate)
@@ -64,6 +64,8 @@ def read_audio_bytes(
     file_bytes: bytes, sample_rate_hint: Optional[int] = None
 ) -> Tuple[np.ndarray, int]:
     """Read audio from bytes using soundfile with ffmpeg fallback."""
+    import soundfile as sf
+
     try:
         with io.BytesIO(file_bytes) as buf:
             audio, sample_rate = sf.read(buf, always_2d=True, dtype="float32")
@@ -133,6 +135,8 @@ def normalize_audio(
 
         # Resample if needed
         if sample_rate != target_sr:
+            from scipy.signal import resample_poly
+
             gcd = math.gcd(sample_rate, target_sr)
             up = target_sr // gcd
             down = sample_rate // gcd

--- a/services/gemma4_audio_runtime/engine.py
+++ b/services/gemma4_audio_runtime/engine.py
@@ -10,7 +10,6 @@ from enum import Enum
 from typing import Any, Optional
 
 import numpy as np
-import transformers
 
 from .audio import get_audio_duration, normalize_audio
 
@@ -114,6 +113,8 @@ class Gemma4AudioEngine:
 
     def load(self) -> None:
         """Load model and processor, trying multimodal then causal-LM classes."""
+        import transformers
+
         try:
             self.processor = transformers.AutoProcessor.from_pretrained(
                 self.model_id,

--- a/services/gemma4_audio_runtime/engine.py
+++ b/services/gemma4_audio_runtime/engine.py
@@ -80,7 +80,7 @@ def _get_vram_info() -> VRAMInfo:
                 total_mb=round(total / 1024**2, 1),
                 free_mb=round((total - allocated) / 1024**2, 1),
             )
-    except Exception:
+    except (ImportError, AttributeError, RuntimeError):
         pass
     return VRAMInfo()
 
@@ -238,10 +238,17 @@ class Gemma4AudioEngine:
             if enable_thinking:
                 apply_template_kwargs["enable_thinking"] = True
 
-            inputs = self.processor.apply_chat_template(
-                messages,
-                **apply_template_kwargs,
-            )
+            try:
+                inputs = self.processor.apply_chat_template(
+                    messages,
+                    **apply_template_kwargs,
+                )
+            except TypeError:
+                apply_template_kwargs.pop("enable_thinking", None)
+                inputs = self.processor.apply_chat_template(
+                    messages,
+                    **apply_template_kwargs,
+                )
 
             if hasattr(inputs, "to"):
                 inputs = inputs.to(self.model.device)
@@ -255,7 +262,11 @@ class Gemma4AudioEngine:
             if cache_implementation is not None:
                 generate_kwargs["cache_implementation"] = cache_implementation
 
-            outputs = self.model.generate(**inputs, **generate_kwargs)
+            try:
+                outputs = self.model.generate(**inputs, **generate_kwargs)
+            except TypeError:
+                generate_kwargs.pop("cache_implementation", None)
+                outputs = self.model.generate(**inputs, **generate_kwargs)
 
             input_len = 0
             if hasattr(inputs, "input_ids"):
@@ -324,12 +335,18 @@ class Gemma4Daemon:
 
     DEFAULT_TARGET = "google/gemma-4-E2B-it"
 
-    def __init__(self, cache_dir: str, device: str = "auto"):
-        self._target_id: str = self.DEFAULT_TARGET
+    def __init__(
+        self,
+        cache_dir: str,
+        device: str = "auto",
+        model_id: Optional[str] = None,
+        max_new_tokens: int = 128,
+    ):
+        self._target_id: str = model_id or self.DEFAULT_TARGET
         self._assistant_id: Optional[str] = None
         self._target_engine: Optional[Gemma4AudioEngine] = None
         self._assistant_engine: Optional[Gemma4AudioEngine] = None
-        self._params: DaemonParams = DaemonParams()
+        self._params: DaemonParams = DaemonParams(max_new_tokens=max_new_tokens)
         self._cache_dir = cache_dir
         self._device = device
         self._reload_reason: Optional[str] = None

--- a/services/gemma4_audio_runtime/engine.py
+++ b/services/gemma4_audio_runtime/engine.py
@@ -1,8 +1,12 @@
-"""Gemma 4 model engine and inference logic."""
+"""Gemma 4 model engine, inference logic, and daemon orchestration."""
 
 from __future__ import annotations
 
+import gc
+import logging
 import re
+from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Optional
 
 import numpy as np
@@ -10,17 +14,75 @@ import transformers
 
 from .audio import get_audio_duration, normalize_audio
 
+logger = logging.getLogger(__name__)
+
 
 class ModelLoadError(Exception):
     """Raised when model fails to load."""
-
-    pass
 
 
 class InferenceError(Exception):
     """Raised when inference fails."""
 
-    pass
+
+class RuntimeMode(str, Enum):
+    TARGET_ONLY = "target_only"
+    TARGET_WITH_ASSISTANT = "target_with_assistant"
+
+
+class ReloadSignal(str, Enum):
+    NONE = "none"
+    SOFT_RELOAD = "soft_reload"
+    HARD_RESTART = "hard_restart"
+
+
+@dataclass
+class DaemonParams:
+    max_new_tokens: int = 128
+    enable_thinking: bool = False
+    cache_implementation: Optional[str] = None
+
+
+@dataclass
+class VRAMInfo:
+    backend: str = "cpu"
+    allocated_mb: float = 0.0
+    reserved_mb: float = 0.0
+    total_mb: float = 0.0
+    free_mb: float = 0.0
+
+
+def _free_vram() -> None:
+    """Release Python references and flush CUDA cache."""
+    gc.collect()
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+    except ImportError:
+        pass
+
+
+def _get_vram_info() -> VRAMInfo:
+    """Return current VRAM usage snapshot."""
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            allocated = torch.cuda.memory_allocated(0)
+            reserved = torch.cuda.memory_reserved(0)
+            total = torch.cuda.get_device_properties(0).total_memory
+            return VRAMInfo(
+                backend="cuda",
+                allocated_mb=round(allocated / 1024**2, 1),
+                reserved_mb=round(reserved / 1024**2, 1),
+                total_mb=round(total / 1024**2, 1),
+                free_mb=round((total - allocated) / 1024**2, 1),
+            )
+    except Exception:
+        pass
+    return VRAMInfo()
 
 
 class Gemma4AudioEngine:
@@ -33,14 +95,6 @@ class Gemma4AudioEngine:
         device: str = "auto",
         max_new_tokens: int = 128,
     ):
-        """Initialize the engine.
-
-        Args:
-            model_id: Hugging Face model ID (e.g., 'google/gemma-4-E2B-it')
-            cache_dir: Cache directory for model download
-            device: Device to load model on ('auto', 'cuda', 'cpu')
-            max_new_tokens: Default max new tokens for generation
-        """
         self.model_id = model_id
         self.cache_dir = cache_dir
         self.device = device
@@ -50,57 +104,62 @@ class Gemma4AudioEngine:
         self.processor: Optional[Any] = None
         self.model_class_name: Optional[str] = None
 
+    # Model classes tried in order — multimodal first, causal-LM last (for
+    # assistant/drafter models like Gemma4AssistantConfig used in spec. decoding).
+    _MODEL_CLASS_CANDIDATES = (
+        "AutoModelForMultimodalLM",
+        "AutoModelForImageTextToText",
+        "AutoModelForCausalLM",
+    )
+
     def load(self) -> None:
-        """Load model and processor from Hugging Face."""
+        """Load model and processor, trying multimodal then causal-LM classes."""
         try:
             self.processor = transformers.AutoProcessor.from_pretrained(
                 self.model_id,
                 cache_dir=self.cache_dir,
                 local_files_only=True,
             )
-
-            model_class = self._resolve_model_class()
-            self.model = model_class.from_pretrained(
-                self.model_id,
-                dtype="auto",
-                device_map=self.device,
-                cache_dir=self.cache_dir,
-                local_files_only=True,
-            )
-            self.model_class_name = model_class.__name__
-
         except Exception as e:
-            raise ModelLoadError(f"Failed to load model {self.model_id}: {e}") from e
+            raise ModelLoadError(
+                f"Failed to load processor for {self.model_id}: {e}"
+            ) from e
+
+        last_error: Optional[Exception] = None
+        for cls_name in self._MODEL_CLASS_CANDIDATES:
+            model_cls = getattr(transformers, cls_name, None)
+            if model_cls is None:
+                continue
+            try:
+                self.model = model_cls.from_pretrained(
+                    self.model_id,
+                    dtype="auto",
+                    device_map=self.device,
+                    cache_dir=self.cache_dir,
+                    local_files_only=True,
+                )
+                self.model_class_name = cls_name
+                logger.debug("Loaded %s with %s", self.model_id, cls_name)
+                return
+            except Exception as e:
+                last_error = e
+                continue
+
+        raise ModelLoadError(
+            f"Failed to load model {self.model_id} with any candidate class: {last_error}"
+        ) from last_error
 
     def unload(self) -> None:
-        """Unload model and free resources."""
+        """Unload model and free references."""
         self.model = None
         self.processor = None
 
     def is_loaded(self) -> bool:
-        """Check if model is currently loaded."""
         return self.model is not None and self.processor is not None
-
-    @staticmethod
-    def _resolve_model_class() -> type[Any]:
-        """Resolve the correct multimodal model class from transformers."""
-        model_cls = getattr(transformers, "AutoModelForMultimodalLM", None)
-        if model_cls is not None:
-            return model_cls
-
-        model_cls = getattr(transformers, "AutoModelForImageTextToText", None)
-        if model_cls is not None:
-            return model_cls
-
-        raise ModelLoadError(
-            "No compatible multimodal model class found in installed transformers. "
-            "Ensure transformers >= 5.0 is installed."
-        )
 
     def _build_prompt_for_task(
         self, task: Optional[str], question: Optional[str], default_prompt: str
     ) -> str:
-        """Build the prompt instruction based on task or question."""
         if task == "math-5x5":
             return (
                 "Listen to the audio and answer the question using only the audio as evidence. "
@@ -132,40 +191,24 @@ class Gemma4AudioEngine:
         temperature: Optional[float] = None,
         top_p: Optional[float] = None,
         do_sample: Optional[bool] = None,
+        enable_thinking: bool = False,
+        cache_implementation: Optional[str] = None,
     ) -> tuple[str, float]:
         """Run inference on audio with optional text.
 
-        Args:
-            audio_array: Audio array (should be normalized to 16kHz mono float32)
-            sample_rate: Sample rate of audio
-            prompt: Default prompt if task/question not set
-            task: Preset task ('transcribe', 'question', 'math-5x5')
-            question: Question to answer about audio
-            system_prompt: System message override
-            max_new_tokens: Generation budget (uses default if None)
-            temperature: Sampling temperature
-            top_p: Top-p sampling parameter
-            do_sample: Whether to use sampling
-
         Returns:
             Tuple of (generated_text, duration_sec)
-
-        Raises:
-            InferenceError: If inference fails
         """
         if not self.is_loaded():
             raise InferenceError("Model is not loaded. Call load() first.")
 
-        # Normalize audio once more to ensure consistency
         try:
             audio_normalized, sr = normalize_audio(audio_array, sample_rate)
         except Exception as e:
             raise InferenceError(f"Failed to normalize audio: {e}") from e
 
-        # Build the effective prompt
         effective_prompt = self._build_prompt_for_task(task, question, prompt)
 
-        # Build messages in the format expected by Gemma processor
         messages = [
             {
                 "role": "user",
@@ -186,29 +229,34 @@ class Gemma4AudioEngine:
             )
 
         try:
-            # Apply chat template and tokenize
+            apply_template_kwargs: dict[str, Any] = {
+                "add_generation_prompt": True,
+                "tokenize": True,
+                "return_dict": True,
+                "return_tensors": "pt",
+            }
+            if enable_thinking:
+                apply_template_kwargs["enable_thinking"] = True
+
             inputs = self.processor.apply_chat_template(
                 messages,
-                add_generation_prompt=True,
-                tokenize=True,
-                return_dict=True,
-                return_tensors="pt",
+                **apply_template_kwargs,
             )
 
-            # Move inputs to model device if necessary
             if hasattr(inputs, "to"):
                 inputs = inputs.to(self.model.device)
 
-            # Generate
-            outputs = self.model.generate(
-                **inputs,
-                max_new_tokens=max_new_tokens or self.default_max_new_tokens,
-                temperature=temperature,
-                top_p=top_p,
-                do_sample=do_sample if do_sample is not None else False,
-            )
+            generate_kwargs: dict[str, Any] = {
+                "max_new_tokens": max_new_tokens or self.default_max_new_tokens,
+                "temperature": temperature,
+                "top_p": top_p,
+                "do_sample": do_sample if do_sample is not None else False,
+            }
+            if cache_implementation is not None:
+                generate_kwargs["cache_implementation"] = cache_implementation
 
-            # Decode output
+            outputs = self.model.generate(**inputs, **generate_kwargs)
+
             input_len = 0
             if hasattr(inputs, "input_ids"):
                 try:
@@ -231,9 +279,7 @@ class Gemma4AudioEngine:
                 clean_up_tokenization_spaces=False,
             )
 
-            # Clean up special tokens
             generated_text = self._clean_generated_text(generated_text)
-
             duration_sec = get_audio_duration(audio_normalized, sr)
 
             return generated_text, duration_sec
@@ -243,7 +289,6 @@ class Gemma4AudioEngine:
 
     @staticmethod
     def _clean_generated_text(text: str) -> str:
-        """Clean generated text by removing special tokens."""
         cleaned = (
             text.replace("<bos>", "").replace("<turn|>", "").replace("<|turn>", "")
         )
@@ -256,16 +301,6 @@ class Gemma4AudioEngine:
         sample_rate: int,
         max_new_tokens: int = 256,
     ) -> str:
-        """Transcribe audio to text.
-
-        Args:
-            audio_array: Audio array
-            sample_rate: Sample rate
-            max_new_tokens: Generation budget
-
-        Returns:
-            Transcribed text
-        """
         text, _ = self.respond(
             audio_array,
             sample_rate,
@@ -274,3 +309,216 @@ class Gemma4AudioEngine:
             max_new_tokens=max_new_tokens,
         )
         return text
+
+
+class Gemma4Daemon:
+    """Steerable daemon wrapping a target Gemma 4 model with optional assistant.
+
+    Responsibilities:
+    - Holds exactly one target model as the base.
+    - Optionally loads an assistant/drafter model.
+    - Provides live parameter updates when no reload is needed.
+    - Signals when soft reload or hard restart is required.
+    - Guarantees VRAM is clean after every switch or reload.
+    """
+
+    DEFAULT_TARGET = "google/gemma-4-E2B-it"
+
+    def __init__(self, cache_dir: str, device: str = "auto"):
+        self._target_id: str = self.DEFAULT_TARGET
+        self._assistant_id: Optional[str] = None
+        self._target_engine: Optional[Gemma4AudioEngine] = None
+        self._assistant_engine: Optional[Gemma4AudioEngine] = None
+        self._params: DaemonParams = DaemonParams()
+        self._cache_dir = cache_dir
+        self._device = device
+        self._reload_reason: Optional[str] = None
+        self._mode: RuntimeMode = RuntimeMode.TARGET_ONLY
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def load_target(self) -> None:
+        """Load target model. Cleans VRAM first to prevent orphaned models."""
+        self._ensure_vram_clean()
+        self._target_engine = Gemma4AudioEngine(
+            model_id=self._target_id,
+            cache_dir=self._cache_dir,
+            device=self._device,
+            max_new_tokens=self._params.max_new_tokens,
+        )
+        self._target_engine.load()
+        logger.info("Target model loaded: %s", self._target_id)
+
+    def soft_reload(self) -> str:
+        """Free VRAM and reload the target model. Returns the reload reason."""
+        reason = self._reload_reason or "manual_reload"
+        self._reload_reason = None
+        # Soft reload drops the assistant — caller must re-attach explicitly.
+        assistant_was = self._assistant_id
+        self._ensure_vram_clean()
+        self._assistant_id = None
+        self._mode = RuntimeMode.TARGET_ONLY
+        self.load_target()
+        if assistant_was:
+            logger.info(
+                "Soft reload completed; assistant '%s' was dropped. Re-attach manually.",
+                assistant_was,
+            )
+        logger.info("Soft reload done. Reason: %s", reason)
+        return reason
+
+    def unload_all(self) -> None:
+        """Unload every model and free VRAM. Used before hard restart."""
+        self._ensure_vram_clean()
+        self._assistant_id = None
+        self._mode = RuntimeMode.TARGET_ONLY
+        logger.info("All models unloaded (pre-restart)")
+
+    # ------------------------------------------------------------------
+    # Assistant management
+    # ------------------------------------------------------------------
+
+    def attach_assistant(self, model_id: str) -> None:
+        """Attach an assistant model. Replaces any existing assistant."""
+        if self._assistant_engine is not None:
+            self._drop_assistant()
+        self._assistant_id = model_id
+        try:
+            engine = Gemma4AudioEngine(
+                model_id=model_id,
+                cache_dir=self._cache_dir,
+                device=self._device,
+                max_new_tokens=self._params.max_new_tokens,
+            )
+            engine.load()
+            self._assistant_engine = engine
+            self._mode = RuntimeMode.TARGET_WITH_ASSISTANT
+            logger.info("Assistant model attached: %s", model_id)
+        except Exception as exc:
+            self._assistant_engine = None
+            self._assistant_id = None
+            _free_vram()
+            raise ModelLoadError(
+                f"Failed to attach assistant '{model_id}': {exc}"
+            ) from exc
+
+    def detach_assistant(self) -> None:
+        """Detach and unload the current assistant model."""
+        self._drop_assistant()
+
+    def _drop_assistant(self) -> None:
+        if self._assistant_engine is not None:
+            self._assistant_engine.unload()
+            self._assistant_engine = None
+            _free_vram()
+        self._assistant_id = None
+        self._mode = RuntimeMode.TARGET_ONLY
+        logger.info("Assistant model detached")
+
+    # ------------------------------------------------------------------
+    # Parameter control
+    # ------------------------------------------------------------------
+
+    def update_params(
+        self,
+        max_new_tokens: Optional[int] = None,
+        enable_thinking: Optional[bool] = None,
+        cache_implementation: Optional[str] = None,
+    ) -> ReloadSignal:
+        """Apply parameter changes. Returns the minimum reload action required."""
+        reload_signal = ReloadSignal.NONE
+
+        if max_new_tokens is not None:
+            self._params.max_new_tokens = max_new_tokens
+            if self._target_engine:
+                self._target_engine.default_max_new_tokens = max_new_tokens
+            if self._assistant_engine:
+                self._assistant_engine.default_max_new_tokens = max_new_tokens
+
+        if enable_thinking is not None:
+            self._params.enable_thinking = enable_thinking
+
+        if (
+            cache_implementation is not None
+            and cache_implementation != self._params.cache_implementation
+        ):
+            self._params.cache_implementation = cache_implementation
+            self._reload_reason = (
+                f"cache_implementation changed to '{cache_implementation}'"
+            )
+            reload_signal = ReloadSignal.SOFT_RELOAD
+
+        return reload_signal
+
+    def fallback(self) -> ReloadSignal:
+        """Reset to safe defaults (target only, default params).
+
+        Returns the reload signal needed to complete the fallback.
+        Caller should execute the reload after receiving the signal.
+        """
+        self._drop_assistant()
+        prev_target = self._target_id
+        prev_cache = self._params.cache_implementation
+        self._params = DaemonParams()
+
+        if prev_target != self.DEFAULT_TARGET:
+            self._target_id = self.DEFAULT_TARGET
+            self._reload_reason = f"fallback: target changed from '{prev_target}' to '{self.DEFAULT_TARGET}'"
+            return ReloadSignal.HARD_RESTART
+
+        if prev_cache is not None:
+            self._reload_reason = "fallback: cache_implementation reset to default"
+            return ReloadSignal.SOFT_RELOAD
+
+        self._reload_reason = "fallback: clean reload"
+        return ReloadSignal.SOFT_RELOAD
+
+    # ------------------------------------------------------------------
+    # Status and routing
+    # ------------------------------------------------------------------
+
+    def is_ready(self) -> bool:
+        return self._target_engine is not None and self._target_engine.is_loaded()
+
+    def active_engine(self) -> Gemma4AudioEngine:
+        """Return the engine to use for inference (always the target)."""
+        if not self.is_ready():
+            raise RuntimeError("Daemon target model is not loaded")
+        assert self._target_engine is not None
+        return self._target_engine
+
+    def status(self) -> dict[str, Any]:
+        return {
+            "target_model": self._target_id,
+            "assistant_model": self._assistant_id,
+            "mode": self._mode.value,
+            "target_loaded": self.is_ready(),
+            "assistant_loaded": (
+                self._assistant_engine is not None
+                and self._assistant_engine.is_loaded()
+            ),
+            "params": {
+                "max_new_tokens": self._params.max_new_tokens,
+                "enable_thinking": self._params.enable_thinking,
+                "cache_implementation": self._params.cache_implementation,
+            },
+            "vram": _get_vram_info().__dict__,
+            "pending_reload": self._reload_reason is not None,
+            "reload_reason": self._reload_reason,
+        }
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_vram_clean(self) -> None:
+        """Unload all models and flush VRAM. No orphaned tensors left behind."""
+        if self._target_engine is not None:
+            self._target_engine.unload()
+            self._target_engine = None
+        if self._assistant_engine is not None:
+            self._assistant_engine.unload()
+            self._assistant_engine = None
+        _free_vram()

--- a/services/gemma4_audio_runtime/main.py
+++ b/services/gemma4_audio_runtime/main.py
@@ -17,93 +17,99 @@ from fastapi import FastAPI, File, HTTPException, Request, UploadFile
 from pydantic import BaseModel, ConfigDict, Field
 
 from .audio import audio_from_bytes, audio_from_file, get_audio_duration
-from .engine import Gemma4AudioEngine, InferenceError
+from .engine import Gemma4Daemon, InferenceError, ModelLoadError, ReloadSignal
 from .schemas import (
+    AssistantAttachRequest,
+    AssistantAttachResponse,
     AudioMetadata,
     Capabilities,
+    DaemonConfigRequest,
+    DaemonConfigResponse,
+    DaemonParamsInfo,
+    DaemonStatusResponse,
+    FallbackResponse,
     GenerationConfig,
     HealthResponse,
     ModelInfo,
     RespondRequest,
     RespondResponse,
+    RestartResponse,
+    SoftReloadResponse,
     StatusResponse,
     TranscribeResponse,
+    VRAMStatus,
 )
 
 logger = logging.getLogger(__name__)
 
 
-# Global engine instance
-_engine: Optional[Gemma4AudioEngine] = None
+# Global daemon instance
+_daemon: Optional[Gemma4Daemon] = None
 _start_time: float = 0
 _warming: bool = False
 _startup_error: Optional[str] = None
 
 
-def get_engine() -> Gemma4AudioEngine:
-    """Get the global engine instance."""
-    global _engine
-    if _engine is None:
-        raise RuntimeError("Engine not initialized")
-    return _engine
+def get_daemon() -> Gemma4Daemon:
+    global _daemon
+    if _daemon is None:
+        raise RuntimeError("Daemon not initialized")
+    return _daemon
 
 
-async def initialize_engine(
+def get_engine():
+    """Return the active inference engine from the daemon (backward compat)."""
+    return get_daemon().active_engine()
+
+
+async def initialize_daemon(
     model_id: str, cache_dir: str, device: str = "auto", max_new_tokens: int = 128
 ) -> None:
-    """Initialize the engine with model loading."""
-    global _engine, _warming, _startup_error
+    global _daemon, _warming, _startup_error
 
     _warming = True
     _startup_error = None
     try:
-        logger.info(f"Initializing Gemma 4 Audio Engine with model {model_id}")
-        _engine = Gemma4AudioEngine(
-            model_id=model_id,
-            cache_dir=cache_dir,
-            device=device,
-            max_new_tokens=max_new_tokens,
-        )
-        logger.info("Loading model...")
-        await asyncio.to_thread(_engine.load)
-        logger.info(f"Model loaded successfully. Class: {_engine.model_class_name}")
+        logger.info("Initializing Gemma 4 Daemon with target model %s", model_id)
+        daemon = Gemma4Daemon(cache_dir=cache_dir, device=device)
+        # Override default target if explicitly specified
+        if model_id and model_id != Gemma4Daemon.DEFAULT_TARGET:
+            daemon._target_id = model_id  # noqa: SLF001
+        daemon._params.max_new_tokens = max_new_tokens  # noqa: SLF001
+        # Expose daemon immediately so control endpoints work during warmup.
+        _daemon = daemon
+        logger.info("Loading target model...")
+        await asyncio.to_thread(daemon.load_target)
+        logger.info("Daemon ready. Target: %s", daemon._target_id)  # noqa: SLF001
         _warming = False
     except Exception as e:
-        logger.error(f"Failed to initialize engine: {e}")
+        logger.error("Failed to initialize daemon: %s", e)
         _startup_error = str(e)
         _warming = False
 
 
 async def _startup_model_loader() -> None:
-    """Background model loader that keeps the API server available during warmup."""
     model_id = os.getenv("GEMMA4_AUDIO_MODEL_ID", "google/gemma-4-E2B-it")
     cache_dir = os.getenv("GEMMA4_AUDIO_CACHE_DIR", "models_cache/hf")
     device = os.getenv("GEMMA4_AUDIO_DEVICE", "auto")
     max_tokens = int(os.getenv("GEMMA4_AUDIO_MAX_NEW_TOKENS", "128"))
-    await initialize_engine(model_id, cache_dir, device, max_tokens)
+    await initialize_daemon(model_id, cache_dir, device, max_tokens)
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """FastAPI lifespan context manager."""
     global _start_time
     _start_time = time.time()
-
-    # Startup: keep API available while the model is loading in background.
     asyncio.create_task(_startup_model_loader())
-
     yield
-
-    # Shutdown
-    if _engine is not None:
-        _engine.unload()
-        logger.info("Engine unloaded")
+    if _daemon is not None:
+        _daemon.unload_all()
+        logger.info("Daemon unloaded")
 
 
 async def _parse_respond_request(
     request: Request,
 ) -> tuple[RespondRequest, bytes | None]:
-    """Parse /v1/respond input from JSON or multipart form."""
     content_type = request.headers.get("content-type", "").lower()
     if "multipart/form-data" in content_type:
         form = await request.form()
@@ -124,64 +130,54 @@ async def _parse_respond_request(
 app = FastAPI(
     title="Gemma 4 Audio Runtime Service",
     description="Local native audio inference daemon for Gemma 4 models",
-    version="0.1.0",
+    version="0.2.0",
     lifespan=lifespan,
 )
 
 
+# ---------------------------------------------------------------------------
+# Health / status
+# ---------------------------------------------------------------------------
+
+
 @app.get("/health", response_model=HealthResponse)
 async def health() -> HealthResponse:
-    """Health check endpoint."""
     try:
-        engine = get_engine()
+        daemon = get_daemon()
         if _warming:
             return HealthResponse(
-                status="warming",
-                message="Model is warming up, please wait...",
+                status="warming", message="Model is warming up, please wait..."
             )
-        if not engine.is_loaded():
-            return HealthResponse(
-                status="error",
-                message="Model is not loaded",
-            )
-        return HealthResponse(
-            status="ok",
-            message="Service is healthy and ready",
-        )
+        if not daemon.is_ready():
+            return HealthResponse(status="error", message="Model is not loaded")
+        return HealthResponse(status="ok", message="Service is healthy and ready")
     except RuntimeError:
         if _startup_error:
             return HealthResponse(
-                status="error",
-                message=f"Startup failed: {_startup_error}",
+                status="error", message=f"Startup failed: {_startup_error}"
             )
         if _warming:
             return HealthResponse(
-                status="warming",
-                message="Service is initializing...",
+                status="warming", message="Service is initializing..."
             )
-        return HealthResponse(
-            status="error",
-            message="Service not initialized",
-        )
+        return HealthResponse(status="error", message="Service not initialized")
 
 
 @app.get("/v1/health", response_model=HealthResponse)
 async def v1_health() -> HealthResponse:
-    """Compatibility health endpoint for clients probing /v1/health."""
     return await health()
 
 
 @app.get("/status", response_model=StatusResponse)
 async def status() -> StatusResponse:
-    """Get service status."""
     try:
-        engine = get_engine()
-        is_loaded = engine.is_loaded()
+        daemon = get_daemon()
+        is_loaded = daemon.is_ready()
 
         model_info = None
         if is_loaded:
             model_info = ModelInfo(
-                model_id=engine.model_id,
+                model_id=daemon._target_id,  # noqa: SLF001
                 instruction_tuned=True,
                 supports_text_input=True,
                 supports_audio_input=True,
@@ -192,7 +188,6 @@ async def status() -> StatusResponse:
             )
 
         status_val = "warming" if _warming else ("running" if is_loaded else "error")
-
         return StatusResponse(
             service="gemma4_audio",
             status=status_val,
@@ -211,138 +206,315 @@ async def status() -> StatusResponse:
 
 @app.get("/v1/models")
 async def list_models():
-    """List available models."""
     try:
-        engine = get_engine()
-        return {
-            "object": "list",
-            "data": [
+        daemon = get_daemon()
+        models = [
+            {
+                "id": daemon._target_id,  # noqa: SLF001
+                "object": "model",
+                "owned_by": "google",
+                "role": "target",
+                "instruction_tuned": True,
+                "supports_text_input": True,
+                "supports_audio_input": True,
+                "supports_image_input": False,
+                "supports_text_output": True,
+                "runtime_mode": "processor_model",
+                "status": "loaded" if daemon.is_ready() else "warming",
+            }
+        ]
+        if daemon._assistant_id:  # noqa: SLF001
+            models.append(
                 {
-                    "id": engine.model_id,
+                    "id": daemon._assistant_id,  # noqa: SLF001
                     "object": "model",
                     "owned_by": "google",
-                    "instruction_tuned": True,
-                    "supports_text_input": True,
-                    "supports_audio_input": True,
-                    "supports_image_input": False,
-                    "supports_text_output": True,
-                    "runtime_mode": "processor_model",
-                    "status": "loaded" if engine.is_loaded() else "warming",
+                    "role": "assistant",
+                    "status": "loaded"
+                    if daemon._assistant_engine and daemon._assistant_engine.is_loaded()
+                    else "error",  # noqa: SLF001
                 }
-            ],
-        }
+            )
+        return {"object": "list", "data": models}
     except RuntimeError:
         raise HTTPException(status_code=503, detail="Service not initialized")
 
 
-@app.post("/v1/respond", response_model=RespondResponse)
-async def respond(
-    request: Request,
-) -> RespondResponse:
-    """Generate response from multimodal input (audio and/or text)."""
+# ---------------------------------------------------------------------------
+# Daemon control API
+# ---------------------------------------------------------------------------
+
+
+@app.get("/v1/daemon/status", response_model=DaemonStatusResponse)
+async def daemon_status() -> DaemonStatusResponse:
+    """Full daemon state: active models, params, VRAM, reload requirements."""
     try:
-        engine = get_engine()
+        daemon = get_daemon()
+    except RuntimeError:
+        raise HTTPException(status_code=503, detail="Daemon not initialized")
 
-        if not engine.is_loaded():
-            raise HTTPException(status_code=503, detail="Model not loaded")
+    raw = daemon.status()
+    return DaemonStatusResponse(
+        target_model=raw["target_model"],
+        assistant_model=raw["assistant_model"],
+        mode=raw["mode"],
+        target_loaded=raw["target_loaded"],
+        assistant_loaded=raw["assistant_loaded"],
+        params=DaemonParamsInfo(**raw["params"]),
+        vram=VRAMStatus(**raw["vram"]),
+        pending_reload=raw["pending_reload"],
+        reload_reason=raw["reload_reason"],
+    )
 
-        request_payload, audio_bytes = await _parse_respond_request(request)
 
-        start_time = time.time()
+@app.post("/v1/daemon/config", response_model=DaemonConfigResponse)
+async def daemon_config(body: DaemonConfigRequest) -> DaemonConfigResponse:
+    """Update daemon parameters. Returns the minimum reload action required.
 
-        # Extract audio and text from messages
-        audio_array = None
-        sample_rate = 16000
-        text_content = None
+    - `none` — change applied live, no reload needed.
+    - `soft_reload` — call POST /v1/daemon/reload to apply.
+    - `hard_restart` — full process restart required.
+    """
+    try:
+        daemon = get_daemon()
+    except RuntimeError:
+        raise HTTPException(status_code=503, detail="Daemon not initialized")
 
-        if audio_bytes is not None:
-            try:
-                audio_array, sample_rate = audio_from_bytes(audio_bytes)
-            except Exception as e:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Failed to process uploaded audio: {e}",
-                )
-        else:
-            for message in request_payload.messages:
-                for content in message.content:
-                    if content.type == "audio" and content.path:
-                        # Audio referenced by path - load from file
-                        audio_path = Path(content.path)
-                        try:
-                            audio_array, sample_rate = audio_from_file(audio_path)
-                        except Exception as e:
-                            raise HTTPException(
-                                status_code=400,
-                                detail=f"Failed to load audio from {content.path}: {e}",
-                            )
-                    elif content.type == "text" and content.text:
-                        text_content = content.text
+    signal = daemon.update_params(
+        max_new_tokens=body.max_new_tokens,
+        enable_thinking=body.enable_thinking,
+        cache_implementation=body.cache_implementation,
+    )
 
-        if audio_array is None and not text_content:
-            raise HTTPException(
-                status_code=400, detail="No audio or text content provided"
-            )
+    raw = daemon.status()
+    msg_map = {
+        ReloadSignal.NONE: "Parameters applied live — no reload required.",
+        ReloadSignal.SOFT_RELOAD: "Parameters staged — run POST /v1/daemon/reload to apply.",
+        ReloadSignal.HARD_RESTART: "Parameters staged — hard restart required to apply.",
+    }
+    return DaemonConfigResponse(
+        reload_signal=signal.value,
+        applied=DaemonParamsInfo(**raw["params"]),
+        message=msg_map[signal],
+    )
 
-        # Use provided prompt or build from task
-        prompt = text_content or request_payload.system_prompt or "Respond to the audio"
 
-        # Run inference
-        try:
-            generated_text, duration = engine.respond(
-                audio_array
-                if audio_array is not None
-                else np.zeros(16000, dtype=np.float32),
-                sample_rate=sample_rate,
-                prompt=prompt,
-                task=request_payload.task,
-                question=request_payload.question,
-                system_prompt=request_payload.system_prompt,
-                max_new_tokens=request_payload.max_new_tokens,
-                temperature=request_payload.temperature,
-                top_p=request_payload.top_p,
-                do_sample=request_payload.do_sample,
-            )
-        except InferenceError as e:
-            raise HTTPException(status_code=500, detail=f"Inference failed: {e}")
+@app.post("/v1/daemon/reload", response_model=SoftReloadResponse)
+async def daemon_reload() -> SoftReloadResponse:
+    """Soft reload: free VRAM and reload the target model.
 
-        total_duration_ms = int((time.time() - start_time) * 1000)
+    The assistant model is dropped and must be re-attached explicitly.
+    """
+    try:
+        daemon = get_daemon()
+    except RuntimeError:
+        raise HTTPException(status_code=503, detail="Daemon not initialized")
 
-        return RespondResponse(
-            model=engine.model_id,
-            task=request_payload.task,
-            text=generated_text,
-            duration_ms=total_duration_ms,
-            audio=AudioMetadata(
-                sample_rate=sample_rate,
-                duration_sec=duration,
-            ),
-            input_modalities=["text", "audio"] if audio_array is not None else ["text"],
-            output_modalities=["text"],
-            runtime_mode="processor_model",
-            capabilities=Capabilities(
-                audio_input="verified" if audio_array is not None else "unknown",
-                audio_reasoning="verified" if audio_array is not None else "unknown",
-                audio_transcription="verified"
-                if audio_array is not None
-                else "unknown",
-            ),
-            generation_config=GenerationConfig(
-                max_new_tokens=request_payload.max_new_tokens,
-                temperature=request_payload.temperature,
-                top_p=request_payload.top_p,
-                do_sample=request_payload.do_sample,
-            ),
+    if not daemon.is_ready() and not _warming:
+        raise HTTPException(status_code=503, detail="Target model is not loaded")
+
+    try:
+        reason = await asyncio.to_thread(daemon.soft_reload)
+    except ModelLoadError as e:
+        raise HTTPException(status_code=500, detail=f"Soft reload failed: {e}")
+
+    return SoftReloadResponse(
+        reason=reason,
+        target_model=daemon._target_id,  # noqa: SLF001
+        message="Soft reload complete. VRAM freed and target model reloaded.",
+    )
+
+
+@app.post("/v1/daemon/restart", response_model=RestartResponse)
+async def daemon_restart() -> RestartResponse:
+    """Hard restart: unload everything and restart the process.
+
+    The OS process manager (Docker, systemd) is expected to restart the service.
+    """
+    try:
+        daemon = get_daemon()
+        daemon.unload_all()
+    except RuntimeError:
+        pass  # Not initialized — still proceed with restart
+
+    async def _do_restart():
+        await asyncio.sleep(0.2)
+        os.execv(sys.executable, [sys.executable] + sys.argv)
+
+    asyncio.create_task(_do_restart())
+    return RestartResponse(
+        status="restarting",
+        message="All models unloaded. Process will restart in ~200ms.",
+    )
+
+
+@app.post("/v1/daemon/assistant/attach", response_model=AssistantAttachResponse)
+async def daemon_assistant_attach(
+    body: AssistantAttachRequest,
+) -> AssistantAttachResponse:
+    """Attach an assistant/drafter model alongside the target.
+
+    The assistant is loaded into VRAM in addition to the target.
+    Only one assistant at a time — attaching a new one replaces the current.
+    """
+    try:
+        daemon = get_daemon()
+    except RuntimeError:
+        raise HTTPException(status_code=503, detail="Daemon not initialized")
+
+    if not daemon.is_ready():
+        raise HTTPException(status_code=503, detail="Target model must be loaded first")
+
+    try:
+        await asyncio.to_thread(daemon.attach_assistant, body.model_id)
+    except ModelLoadError as e:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Cannot attach assistant: {e}",
         )
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Respond endpoint error: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Internal error: {e}")
+
+    return AssistantAttachResponse(
+        assistant_model=body.model_id,
+        mode=daemon.status()["mode"],
+        message=f"Assistant '{body.model_id}' attached successfully.",
+    )
+
+
+@app.post("/v1/daemon/assistant/detach")
+async def daemon_assistant_detach() -> dict:
+    """Detach and unload the assistant model. VRAM freed immediately."""
+    try:
+        daemon = get_daemon()
+    except RuntimeError:
+        raise HTTPException(status_code=503, detail="Daemon not initialized")
+
+    daemon.detach_assistant()
+    return {"mode": "target_only", "message": "Assistant model detached. VRAM freed."}
+
+
+@app.post("/v1/daemon/fallback", response_model=FallbackResponse)
+async def daemon_fallback() -> FallbackResponse:
+    """Reset daemon to safe defaults (target-only, default params).
+
+    Returns a reload signal indicating what action is needed to complete the fallback.
+    If reload_signal is 'soft_reload', call POST /v1/daemon/reload.
+    If reload_signal is 'hard_restart', call POST /v1/daemon/restart.
+    """
+    try:
+        daemon = get_daemon()
+    except RuntimeError:
+        raise HTTPException(status_code=503, detail="Daemon not initialized")
+
+    signal = daemon.fallback()
+
+    msg_map = {
+        ReloadSignal.NONE: "Fallback complete — no reload needed.",
+        ReloadSignal.SOFT_RELOAD: "Fallback staged — run POST /v1/daemon/reload to complete.",
+        ReloadSignal.HARD_RESTART: "Target model changed — run POST /v1/daemon/restart to complete.",
+    }
+    return FallbackResponse(
+        reload_signal=signal.value,
+        target_model=daemon._target_id,  # noqa: SLF001
+        message=msg_map[signal],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Inference endpoints
+# ---------------------------------------------------------------------------
+
+
+@app.post("/v1/respond", response_model=RespondResponse)
+async def respond(request: Request) -> RespondResponse:
+    try:
+        daemon = get_daemon()
+        engine = daemon.active_engine()
+    except RuntimeError as e:
+        raise HTTPException(status_code=503, detail=str(e))
+
+    if not engine.is_loaded():
+        raise HTTPException(status_code=503, detail="Model not loaded")
+
+    request_payload, audio_bytes = await _parse_respond_request(request)
+
+    start_time = time.time()
+    audio_array = None
+    sample_rate = 16000
+    text_content = None
+
+    if audio_bytes is not None:
+        try:
+            audio_array, sample_rate = audio_from_bytes(audio_bytes)
+        except Exception as e:
+            raise HTTPException(
+                status_code=400, detail=f"Failed to process uploaded audio: {e}"
+            )
+    else:
+        for message in request_payload.messages:
+            for content in message.content:
+                if content.type == "audio" and content.path:
+                    audio_path = Path(content.path)
+                    try:
+                        audio_array, sample_rate = audio_from_file(audio_path)
+                    except Exception as e:
+                        raise HTTPException(
+                            status_code=400,
+                            detail=f"Failed to load audio from {content.path}: {e}",
+                        )
+                elif content.type == "text" and content.text:
+                    text_content = content.text
+
+    if audio_array is None and not text_content:
+        raise HTTPException(status_code=400, detail="No audio or text content provided")
+
+    prompt = text_content or request_payload.system_prompt or "Respond to the audio"
+
+    try:
+        generated_text, duration = engine.respond(
+            audio_array
+            if audio_array is not None
+            else np.zeros(16000, dtype=np.float32),
+            sample_rate=sample_rate,
+            prompt=prompt,
+            task=request_payload.task,
+            question=request_payload.question,
+            system_prompt=request_payload.system_prompt,
+            max_new_tokens=request_payload.max_new_tokens,
+            temperature=request_payload.temperature,
+            top_p=request_payload.top_p,
+            do_sample=request_payload.do_sample,
+            enable_thinking=daemon._params.enable_thinking,  # noqa: SLF001
+            cache_implementation=daemon._params.cache_implementation,  # noqa: SLF001
+        )
+    except InferenceError as e:
+        raise HTTPException(status_code=500, detail=f"Inference failed: {e}")
+
+    total_duration_ms = int((time.time() - start_time) * 1000)
+
+    return RespondResponse(
+        model=engine.model_id,
+        task=request_payload.task,
+        text=generated_text,
+        duration_ms=total_duration_ms,
+        audio=AudioMetadata(sample_rate=sample_rate, duration_sec=duration),
+        input_modalities=["text", "audio"] if audio_array is not None else ["text"],
+        output_modalities=["text"],
+        runtime_mode="processor_model",
+        capabilities=Capabilities(
+            audio_input="verified" if audio_array is not None else "unknown",
+            audio_reasoning="verified" if audio_array is not None else "unknown",
+            audio_transcription="verified" if audio_array is not None else "unknown",
+        ),
+        generation_config=GenerationConfig(
+            max_new_tokens=request_payload.max_new_tokens,
+            temperature=request_payload.temperature,
+            top_p=request_payload.top_p,
+            do_sample=request_payload.do_sample,
+        ),
+    )
 
 
 def _extract_text_prompt_from_openai_messages(messages: list[dict]) -> str:
-    """Extract a text prompt from OpenAI-style chat messages."""
     for message in reversed(messages):
         if str(message.get("role", "")).strip().lower() != "user":
             continue
@@ -386,153 +558,135 @@ class ChatCompletionRequest(BaseModel):
 async def chat_completions(payload: ChatCompletionRequest) -> dict:
     """OpenAI-compatible text chat endpoint for Semantic Kernel connectors."""
     try:
-        engine = get_engine()
-        if not engine.is_loaded():
-            raise HTTPException(status_code=503, detail="Model not loaded")
+        daemon = get_daemon()
+        engine = daemon.active_engine()
+    except RuntimeError as e:
+        raise HTTPException(status_code=503, detail=str(e))
 
-        model = str(payload.model or engine.model_id)
-        messages = [message.model_dump(mode="python") for message in payload.messages]
+    if not engine.is_loaded():
+        raise HTTPException(status_code=503, detail="Model not loaded")
 
-        prompt = _extract_text_prompt_from_openai_messages(messages)
-        max_tokens = int(payload.max_tokens or payload.max_completion_tokens or 128)
-        temperature_raw = payload.temperature
-        top_p_raw = payload.top_p
-        if payload.stream:
-            raise HTTPException(
-                status_code=400,
-                detail="Streaming is not supported by gemma4_audio runtime",
-            )
+    model = str(payload.model or engine.model_id)
+    messages = [message.model_dump(mode="python") for message in payload.messages]
 
-        # Text-only path: use 1s silence placeholder expected by the current engine API.
-        dummy_audio = np.zeros(16000, dtype=np.float32)
-        text, _ = engine.respond(
-            dummy_audio,
-            sample_rate=16000,
-            prompt=prompt,
-            max_new_tokens=max_tokens,
-            temperature=float(temperature_raw) if temperature_raw is not None else None,
-            top_p=float(top_p_raw) if top_p_raw is not None else None,
-            do_sample=bool(temperature_raw is not None or top_p_raw is not None),
+    prompt = _extract_text_prompt_from_openai_messages(messages)
+    max_tokens = int(payload.max_tokens or payload.max_completion_tokens or 128)
+    temperature_raw = payload.temperature
+    top_p_raw = payload.top_p
+
+    if payload.stream:
+        raise HTTPException(
+            status_code=400,
+            detail="Streaming is not supported by gemma4_audio runtime",
         )
 
-        now = int(time.time())
-        completion_tokens = max(1, len(text) // 4)
-        prompt_tokens = max(1, len(prompt) // 4)
-        return {
-            "id": f"chatcmpl-gemma4-{int(time.time() * 1000)}",
-            "object": "chat.completion",
-            "created": now,
-            "model": model,
-            "choices": [
-                {
-                    "index": 0,
-                    "message": {"role": "assistant", "content": text},
-                    "finish_reason": "stop",
-                }
-            ],
-            "usage": {
-                "prompt_tokens": prompt_tokens,
-                "completion_tokens": completion_tokens,
-                "total_tokens": prompt_tokens + completion_tokens,
-            },
-        }
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"chat/completions error: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Internal error: {e}")
+    dummy_audio = np.zeros(16000, dtype=np.float32)
+    text, _ = engine.respond(
+        dummy_audio,
+        sample_rate=16000,
+        prompt=prompt,
+        max_new_tokens=max_tokens,
+        temperature=float(temperature_raw) if temperature_raw is not None else None,
+        top_p=float(top_p_raw) if top_p_raw is not None else None,
+        do_sample=bool(temperature_raw is not None or top_p_raw is not None),
+        enable_thinking=daemon._params.enable_thinking,  # noqa: SLF001
+        cache_implementation=daemon._params.cache_implementation,  # noqa: SLF001
+    )
+
+    now = int(time.time())
+    completion_tokens = max(1, len(text) // 4)
+    prompt_tokens = max(1, len(prompt) // 4)
+    return {
+        "id": f"chatcmpl-gemma4-{int(time.time() * 1000)}",
+        "object": "chat.completion",
+        "created": now,
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": text},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        },
+    }
 
 
 @app.post("/audio/transcribe", response_model=TranscribeResponse)
-async def transcribe(
-    audio: UploadFile = File(...),
-) -> TranscribeResponse:
-    """Transcribe audio file."""
+async def transcribe(audio: UploadFile = File(...)) -> TranscribeResponse:
     try:
-        engine = get_engine()
+        daemon = get_daemon()
+        engine = daemon.active_engine()
+    except RuntimeError as e:
+        raise HTTPException(status_code=503, detail=str(e))
 
-        if not engine.is_loaded():
-            raise HTTPException(status_code=503, detail="Model not loaded")
+    if not engine.is_loaded():
+        raise HTTPException(status_code=503, detail="Model not loaded")
 
-        start_time = time.time()
+    start_time = time.time()
 
-        # Read uploaded file
-        try:
-            file_bytes = await audio.read()
-            audio_array, sample_rate = audio_from_bytes(file_bytes)
-        except Exception as e:
-            raise HTTPException(
-                status_code=400, detail=f"Failed to process audio file: {e}"
-            )
-
-        # Transcribe
-        try:
-            text = engine.transcribe(audio_array, sample_rate)
-        except InferenceError as e:
-            raise HTTPException(status_code=500, detail=f"Transcription failed: {e}")
-
-        duration_sec = get_audio_duration(audio_array, sample_rate)
-        duration_ms = int((time.time() - start_time) * 1000)
-
-        return TranscribeResponse(
-            text=text,
-            duration_ms=duration_ms,
-            audio=AudioMetadata(
-                sample_rate=sample_rate,
-                duration_sec=duration_sec,
-            ),
-        )
-    except HTTPException:
-        raise
+    try:
+        file_bytes = await audio.read()
+        audio_array, sample_rate = audio_from_bytes(file_bytes)
     except Exception as e:
-        logger.error(f"Transcribe endpoint error: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Internal error: {e}")
+        raise HTTPException(
+            status_code=400, detail=f"Failed to process audio file: {e}"
+        )
+
+    try:
+        text = engine.transcribe(audio_array, sample_rate)
+    except InferenceError as e:
+        raise HTTPException(status_code=500, detail=f"Transcription failed: {e}")
+
+    duration_sec = get_audio_duration(audio_array, sample_rate)
+    duration_ms = int((time.time() - start_time) * 1000)
+
+    return TranscribeResponse(
+        text=text,
+        duration_ms=duration_ms,
+        audio=AudioMetadata(sample_rate=sample_rate, duration_sec=duration_sec),
+    )
 
 
 @app.post("/warmup")
 async def warmup():
-    """Warmup the model by running a dummy inference."""
     try:
-        engine = get_engine()
+        daemon = get_daemon()
+        engine = daemon.active_engine()
+    except RuntimeError as e:
+        raise HTTPException(status_code=503, detail=str(e))
 
-        if not engine.is_loaded():
-            raise HTTPException(status_code=503, detail="Model not loaded")
+    if not engine.is_loaded():
+        raise HTTPException(status_code=503, detail="Model not loaded")
 
-        # Run a small dummy inference to warm up
-        dummy_audio = np.zeros(16000, dtype=np.float32)  # 1 second of silence
-        try:
-            text, _ = engine.respond(
-                dummy_audio,
-                sample_rate=16000,
-                prompt="Say hello",
-                max_new_tokens=10,
-            )
-            return {"status": "warmed", "sample_output": text}
-        except InferenceError as e:
-            raise HTTPException(status_code=500, detail=f"Warmup failed: {e}")
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Warmup error: {e}")
+    dummy_audio = np.zeros(16000, dtype=np.float32)
+    try:
+        text, _ = engine.respond(
+            dummy_audio, sample_rate=16000, prompt="Say hello", max_new_tokens=10
+        )
+        return {"status": "warmed", "sample_output": text}
+    except InferenceError as e:
         raise HTTPException(status_code=500, detail=f"Warmup failed: {e}")
 
 
 @app.get("/")
 async def root():
-    """Root endpoint."""
-    return {
-        "service": "Gemma 4 Audio Runtime",
-        "version": "0.1.0",
-        "status": "running",
-    }
+    return {"service": "Gemma 4 Audio Runtime", "version": "0.2.0", "status": "running"}
+
+
+# ---------------------------------------------------------------------------
+# Server helpers
+# ---------------------------------------------------------------------------
 
 
 def configure_logging(log_file: Optional[str] = None, level: int = logging.INFO):
-    """Configure logging for the service."""
     root_logger = logging.getLogger()
     root_logger.setLevel(level)
 
-    # Console handler
     console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setLevel(level)
     formatter = logging.Formatter(
@@ -541,26 +695,18 @@ def configure_logging(log_file: Optional[str] = None, level: int = logging.INFO)
     console_handler.setFormatter(formatter)
     root_logger.addHandler(console_handler)
 
-    # File handler if specified
     if log_file:
         file_handler = logging.FileHandler(log_file)
         file_handler.setLevel(level)
         file_handler.setFormatter(formatter)
         root_logger.addHandler(file_handler)
 
-    logger.info(f"Logging configured. Level: {logging.getLevelName(level)}")
-
 
 def run_server(
-    host: str = "127.0.0.1",
-    port: int = 8014,
-    log_file: Optional[str] = None,
+    host: str = "127.0.0.1", port: int = 8014, log_file: Optional[str] = None
 ):
-    """Run the FastAPI server."""
     configure_logging(log_file)
-
-    logger.info(f"Starting Gemma 4 Audio Runtime Service on {host}:{port}")
-
+    logger.info("Starting Gemma 4 Audio Runtime Service on %s:%d", host, port)
     uvicorn.run(
         "services.gemma4_audio_runtime.main:app",
         host=host,
@@ -571,9 +717,7 @@ def run_server(
 
 
 if __name__ == "__main__":
-    # Get configuration from environment
     host = os.getenv("GEMMA4_AUDIO_HOST", "127.0.0.1")
     port = int(os.getenv("GEMMA4_AUDIO_PORT", "8014"))
     log_file = os.getenv("GEMMA4_AUDIO_LOG_PATH", "logs/gemma4_audio_service.log")
-
     run_server(host, port, log_file)

--- a/services/gemma4_audio_runtime/main.py
+++ b/services/gemma4_audio_runtime/main.py
@@ -48,6 +48,7 @@ _daemon: Optional[Gemma4Daemon] = None
 _start_time: float = 0
 _warming: bool = False
 _startup_error: Optional[str] = None
+_lifecycle_lock: asyncio.Lock = asyncio.Lock()
 
 
 def get_daemon() -> Gemma4Daemon:
@@ -71,11 +72,12 @@ async def initialize_daemon(
     _startup_error = None
     try:
         logger.info("Initializing Gemma 4 Daemon with target model %s", model_id)
-        daemon = Gemma4Daemon(cache_dir=cache_dir, device=device)
-        # Override default target if explicitly specified
-        if model_id and model_id != Gemma4Daemon.DEFAULT_TARGET:
-            daemon._target_id = model_id  # noqa: SLF001
-        daemon._params.max_new_tokens = max_new_tokens  # noqa: SLF001
+        daemon = Gemma4Daemon(
+            cache_dir=cache_dir,
+            device=device,
+            model_id=model_id,
+            max_new_tokens=max_new_tokens,
+        )
         # Expose daemon immediately so control endpoints work during warmup.
         _daemon = daemon
         logger.info("Loading target model...")
@@ -310,13 +312,17 @@ async def daemon_reload() -> SoftReloadResponse:
     except RuntimeError:
         raise HTTPException(status_code=503, detail="Daemon not initialized")
 
-    if not daemon.is_ready() and not _warming:
+    if _warming:
+        raise HTTPException(status_code=409, detail="Cannot reload while warming up")
+
+    if not daemon.is_ready():
         raise HTTPException(status_code=503, detail="Target model is not loaded")
 
-    try:
-        reason = await asyncio.to_thread(daemon.soft_reload)
-    except ModelLoadError as e:
-        raise HTTPException(status_code=500, detail=f"Soft reload failed: {e}")
+    async with _lifecycle_lock:
+        try:
+            reason = await asyncio.to_thread(daemon.soft_reload)
+        except ModelLoadError as e:
+            raise HTTPException(status_code=500, detail=f"Soft reload failed: {e}")
 
     return SoftReloadResponse(
         reason=reason,
@@ -331,11 +337,12 @@ async def daemon_restart() -> RestartResponse:
 
     The OS process manager (Docker, systemd) is expected to restart the service.
     """
-    try:
-        daemon = get_daemon()
-        daemon.unload_all()
-    except RuntimeError:
-        pass  # Not initialized — still proceed with restart
+    async with _lifecycle_lock:
+        try:
+            daemon = get_daemon()
+            daemon.unload_all()
+        except RuntimeError:
+            pass  # Not initialized — still proceed with restart
 
     async def _do_restart():
         await asyncio.sleep(0.2)
@@ -365,13 +372,14 @@ async def daemon_assistant_attach(
     if not daemon.is_ready():
         raise HTTPException(status_code=503, detail="Target model must be loaded first")
 
-    try:
-        await asyncio.to_thread(daemon.attach_assistant, body.model_id)
-    except ModelLoadError as e:
-        raise HTTPException(
-            status_code=422,
-            detail=f"Cannot attach assistant: {e}",
-        )
+    async with _lifecycle_lock:
+        try:
+            await asyncio.to_thread(daemon.attach_assistant, body.model_id)
+        except ModelLoadError as e:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Cannot attach assistant: {e}",
+            )
 
     return AssistantAttachResponse(
         assistant_model=body.model_id,
@@ -388,7 +396,8 @@ async def daemon_assistant_detach() -> dict:
     except RuntimeError:
         raise HTTPException(status_code=503, detail="Daemon not initialized")
 
-    daemon.detach_assistant()
+    async with _lifecycle_lock:
+        daemon.detach_assistant()
     return {"mode": "target_only", "message": "Assistant model detached. VRAM freed."}
 
 

--- a/services/gemma4_audio_runtime/schemas.py
+++ b/services/gemma4_audio_runtime/schemas.py
@@ -146,3 +146,77 @@ class HealthResponse(BaseModel):
 
     status: Literal["ok", "warming", "error"] = Field("ok")
     message: str = Field(...)
+
+
+# ---------------------------------------------------------------------------
+# Daemon control schemas
+# ---------------------------------------------------------------------------
+
+
+class VRAMStatus(BaseModel):
+    backend: str = Field("cpu")
+    allocated_mb: float = Field(0.0)
+    reserved_mb: float = Field(0.0)
+    total_mb: float = Field(0.0)
+    free_mb: float = Field(0.0)
+
+
+class DaemonParamsInfo(BaseModel):
+    max_new_tokens: int
+    enable_thinking: bool
+    cache_implementation: Optional[str] = None
+
+
+class DaemonStatusResponse(BaseModel):
+    """Full daemon state: models, params, VRAM, reload signal."""
+
+    target_model: str
+    assistant_model: Optional[str] = None
+    mode: Literal["target_only", "target_with_assistant"]
+    target_loaded: bool
+    assistant_loaded: bool
+    params: DaemonParamsInfo
+    vram: VRAMStatus
+    pending_reload: bool
+    reload_reason: Optional[str] = None
+
+
+class DaemonConfigRequest(BaseModel):
+    """Live parameter update. Returns required reload signal."""
+
+    max_new_tokens: Optional[int] = Field(None, ge=1, le=32768)
+    enable_thinking: Optional[bool] = None
+    cache_implementation: Optional[str] = None
+
+
+class DaemonConfigResponse(BaseModel):
+    reload_signal: Literal["none", "soft_reload", "hard_restart"]
+    applied: DaemonParamsInfo
+    message: str
+
+
+class AssistantAttachRequest(BaseModel):
+    model_id: str = Field(..., description="HuggingFace model ID of the assistant")
+
+
+class AssistantAttachResponse(BaseModel):
+    assistant_model: str
+    mode: Literal["target_only", "target_with_assistant"]
+    message: str
+
+
+class SoftReloadResponse(BaseModel):
+    reason: str
+    target_model: str
+    message: str
+
+
+class FallbackResponse(BaseModel):
+    reload_signal: Literal["none", "soft_reload", "hard_restart"]
+    target_model: str
+    message: str
+
+
+class RestartResponse(BaseModel):
+    status: Literal["restarting"]
+    message: str

--- a/tests/test_214a_gemma4_daemon.py
+++ b/tests/test_214a_gemma4_daemon.py
@@ -12,8 +12,10 @@ Covers the 7 backend test cases from the spec (section 2.3):
 
 from __future__ import annotations
 
+import sys
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 from fastapi.testclient import TestClient
 
@@ -21,9 +23,12 @@ import services.gemma4_audio_runtime.main as runtime_main
 from services.gemma4_audio_runtime.engine import (
     Gemma4AudioEngine,
     Gemma4Daemon,
+    InferenceError,
     ModelLoadError,
     ReloadSignal,
     RuntimeMode,
+    _free_vram,
+    _get_vram_info,
 )
 
 # ---------------------------------------------------------------------------
@@ -601,3 +606,769 @@ def test_chat_completions_rejects_streaming(monkeypatch) -> None:
 
     assert response.status_code == 400
     assert "Streaming is not supported" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Gemma4AudioEngine — unit coverage
+# ---------------------------------------------------------------------------
+
+
+class TestAudioEngineUnit:
+    def test_clean_generated_text_removes_special_tokens(self):
+        result = Gemma4AudioEngine._clean_generated_text(
+            "<bos>hello<turn|> world<|turn>"
+        )
+        assert result == "hello world"
+
+    def test_clean_generated_text_collapses_whitespace(self):
+        result = Gemma4AudioEngine._clean_generated_text("  foo   bar  ")
+        assert result == "foo bar"
+
+    def test_build_prompt_math_task(self):
+        engine = Gemma4AudioEngine(model_id="m", cache_dir="/tmp")
+        prompt = engine._build_prompt_for_task("math-5x5", None, "default")
+        assert "5 razy 5" in prompt
+
+    def test_build_prompt_transcribe_task(self):
+        engine = Gemma4AudioEngine(model_id="m", cache_dir="/tmp")
+        prompt = engine._build_prompt_for_task("transcribe", None, "default")
+        assert "Transcribe" in prompt
+
+    def test_build_prompt_with_question(self):
+        engine = Gemma4AudioEngine(model_id="m", cache_dir="/tmp")
+        prompt = engine._build_prompt_for_task(None, "Jak masz na imię?", "default")
+        assert "Jak masz na imię?" in prompt
+
+    def test_build_prompt_default(self):
+        engine = Gemma4AudioEngine(model_id="m", cache_dir="/tmp")
+        assert engine._build_prompt_for_task(None, None, "fallback") == "fallback"
+
+    def test_build_prompt_blank_question_falls_through_to_default(self):
+        engine = Gemma4AudioEngine(model_id="m", cache_dir="/tmp")
+        assert engine._build_prompt_for_task(None, "   ", "default") == "default"
+
+    def test_unload_clears_model_and_processor(self):
+        engine = Gemma4AudioEngine(model_id="m", cache_dir="/tmp")
+        engine.model = MagicMock()
+        engine.processor = MagicMock()
+        engine.unload()
+        assert engine.model is None
+        assert engine.processor is None
+
+    def test_is_loaded_false_when_both_none(self):
+        engine = Gemma4AudioEngine(model_id="m", cache_dir="/tmp")
+        assert engine.is_loaded() is False
+
+    def test_is_loaded_false_when_model_only(self):
+        engine = Gemma4AudioEngine(model_id="m", cache_dir="/tmp")
+        engine.model = MagicMock()
+        assert engine.is_loaded() is False
+
+    def test_is_loaded_true_when_both_set(self):
+        engine = Gemma4AudioEngine(model_id="m", cache_dir="/tmp")
+        engine.model = MagicMock()
+        engine.processor = MagicMock()
+        assert engine.is_loaded() is True
+
+    def test_respond_raises_when_not_loaded(self):
+        engine = Gemma4AudioEngine(model_id="m", cache_dir="/tmp")
+        with pytest.raises(InferenceError, match="not loaded"):
+            engine.respond(np.zeros(16000, dtype=np.float32), 16000)
+
+    def test_respond_raises_on_normalize_failure(self, monkeypatch):
+        engine = Gemma4AudioEngine(model_id="m", cache_dir="/tmp")
+        engine.model = MagicMock()
+        engine.processor = MagicMock()
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine.normalize_audio",
+            lambda *a, **kw: (_ for _ in ()).throw(ValueError("bad audio")),
+        )
+        with pytest.raises(InferenceError, match="normalize"):
+            engine.respond(np.zeros(16000, dtype=np.float32), 16000)
+
+    def _setup_respond(self, monkeypatch):
+        """Shared setup: engine with mocked normalize_audio and get_audio_duration."""
+        engine = Gemma4AudioEngine(model_id="m", cache_dir="/tmp")
+        engine.model = MagicMock()
+        engine.processor = MagicMock()
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine.normalize_audio",
+            lambda arr, sr, **kw: (arr, sr),
+        )
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine.get_audio_duration",
+            lambda arr, sr: 1.0,
+        )
+        # apply_chat_template returns a dict so **inputs works in generate()
+        engine.processor.apply_chat_template.return_value = {}
+        engine.model.generate.return_value = [[1, 2, 3]]
+        engine.processor.decode.return_value = "<bos>hej<|turn>"
+        return engine
+
+    def test_respond_success_basic(self, monkeypatch):
+        engine = self._setup_respond(monkeypatch)
+        audio = np.zeros(16000, dtype=np.float32)
+        text, dur = engine.respond(audio, 16000)
+        assert text == "hej"
+        assert dur == 1.0
+
+    def test_respond_with_system_prompt(self, monkeypatch):
+        engine = self._setup_respond(monkeypatch)
+        audio = np.zeros(16000, dtype=np.float32)
+
+        captured_messages: list = []
+
+        def capture(msgs, **kw):
+            captured_messages.extend(msgs)
+            return {}
+
+        engine.processor.apply_chat_template.side_effect = capture
+        engine.processor.decode.return_value = "ok"
+
+        engine.respond(audio, 16000, system_prompt="Be concise.")
+        roles = [m["role"] for m in captured_messages]
+        assert "system" in roles
+
+    def test_respond_enable_thinking_typeerror_fallback(self, monkeypatch):
+        engine = self._setup_respond(monkeypatch)
+        audio = np.zeros(16000, dtype=np.float32)
+
+        call_count = [0]
+
+        def _apply_template(msgs, **kw):
+            call_count[0] += 1
+            if "enable_thinking" in kw:
+                raise TypeError("unexpected kwarg enable_thinking")
+            return {}
+
+        engine.processor.apply_chat_template.side_effect = _apply_template
+        engine.processor.decode.return_value = "result"
+
+        text, _ = engine.respond(audio, 16000, enable_thinking=True)
+        assert text == "result"
+        assert call_count[0] == 2
+
+    def test_respond_cache_implementation_typeerror_fallback(self, monkeypatch):
+        engine = self._setup_respond(monkeypatch)
+        audio = np.zeros(16000, dtype=np.float32)
+
+        generate_calls: list[dict] = []
+
+        def _generate(**kw):
+            generate_calls.append(dict(kw))
+            if "cache_implementation" in kw:
+                raise TypeError("unsupported cache_implementation")
+            return [[1]]
+
+        engine.model.generate.side_effect = _generate
+        engine.processor.decode.return_value = "ok"
+
+        text, _ = engine.respond(audio, 16000, cache_implementation="static")
+        assert text == "ok"
+        assert len(generate_calls) == 2
+        assert "cache_implementation" not in generate_calls[1]
+
+    def test_transcribe_delegates_to_respond(self, monkeypatch):
+        engine = self._setup_respond(monkeypatch)
+        engine.processor.decode.return_value = "hello"
+        audio = np.zeros(16000, dtype=np.float32)
+        result = engine.transcribe(audio, 16000)
+        assert result == "hello"
+
+    def test_load_success_mocked_transformers(self, monkeypatch):
+        fake_transformers = MagicMock()
+        fake_processor = MagicMock()
+        fake_model = MagicMock()
+
+        fake_transformers.AutoProcessor.from_pretrained.return_value = fake_processor
+
+        fake_cls = MagicMock()
+        fake_cls.from_pretrained.return_value = fake_model
+        fake_transformers.AutoModelForMultimodalLM = fake_cls
+
+        monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+
+        engine = Gemma4AudioEngine(model_id="model/x", cache_dir="/tmp")
+        engine.load()
+
+        assert engine.processor is fake_processor
+        assert engine.model is fake_model
+        assert engine.model_class_name == "AutoModelForMultimodalLM"
+
+    def test_load_falls_back_to_causallm(self, monkeypatch):
+        fake_transformers = MagicMock()
+        fake_processor = MagicMock()
+        fake_model = MagicMock()
+
+        fake_transformers.AutoProcessor.from_pretrained.return_value = fake_processor
+        fake_transformers.AutoModelForMultimodalLM = None
+        fake_transformers.AutoModelForImageTextToText = None
+
+        fake_causallm = MagicMock()
+        fake_causallm.from_pretrained.return_value = fake_model
+        fake_transformers.AutoModelForCausalLM = fake_causallm
+
+        monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+
+        engine = Gemma4AudioEngine(model_id="model/x", cache_dir="/tmp")
+        engine.load()
+
+        assert engine.model is fake_model
+        assert engine.model_class_name == "AutoModelForCausalLM"
+
+    def test_load_raises_model_load_error_when_processor_fails(self, monkeypatch):
+        fake_transformers = MagicMock()
+        fake_transformers.AutoProcessor.from_pretrained.side_effect = OSError("no file")
+        monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+
+        engine = Gemma4AudioEngine(model_id="model/x", cache_dir="/tmp")
+        with pytest.raises(ModelLoadError, match="processor"):
+            engine.load()
+
+    def test_load_raises_when_all_model_classes_fail(self, monkeypatch):
+        fake_transformers = MagicMock()
+        fake_processor = MagicMock()
+        fake_transformers.AutoProcessor.from_pretrained.return_value = fake_processor
+
+        failing_cls = MagicMock()
+        failing_cls.from_pretrained.side_effect = RuntimeError("nope")
+        fake_transformers.AutoModelForMultimodalLM = failing_cls
+        fake_transformers.AutoModelForImageTextToText = failing_cls
+        fake_transformers.AutoModelForCausalLM = failing_cls
+
+        monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+
+        engine = Gemma4AudioEngine(model_id="model/x", cache_dir="/tmp")
+        with pytest.raises(ModelLoadError, match="any candidate class"):
+            engine.load()
+
+
+class TestVRAMHelpers:
+    def test_free_vram_no_torch(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "torch", None)
+        _free_vram()  # must not raise
+
+    def test_get_vram_info_returns_cpu_when_no_torch(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "torch", None)
+        info = _get_vram_info()
+        assert info.backend == "cpu"
+
+    def test_get_vram_info_cuda_path(self, monkeypatch):
+        fake_torch = MagicMock()
+        fake_torch.cuda.is_available.return_value = True
+        fake_torch.cuda.memory_allocated.return_value = 512 * 1024**2
+        fake_torch.cuda.memory_reserved.return_value = 768 * 1024**2
+        props = MagicMock()
+        props.total_memory = 8192 * 1024**2
+        fake_torch.cuda.get_device_properties.return_value = props
+
+        monkeypatch.setitem(sys.modules, "torch", fake_torch)
+        info = _get_vram_info()
+
+        assert info.backend == "cuda"
+        assert info.allocated_mb == 512.0
+        assert info.total_mb == 8192.0
+
+    def test_get_vram_info_returns_cpu_when_cuda_not_available(self, monkeypatch):
+        fake_torch = MagicMock()
+        fake_torch.cuda.is_available.return_value = False
+        monkeypatch.setitem(sys.modules, "torch", fake_torch)
+        info = _get_vram_info()
+        assert info.backend == "cpu"
+
+
+class TestDaemonExtended:
+    def test_constructor_with_model_id(self):
+        daemon = Gemma4Daemon(cache_dir="/tmp", model_id="custom/model")
+        assert daemon._target_id == "custom/model"  # noqa: SLF001
+
+    def test_constructor_with_max_new_tokens(self):
+        daemon = Gemma4Daemon(cache_dir="/tmp", max_new_tokens=512)
+        assert daemon._params.max_new_tokens == 512  # noqa: SLF001
+
+    def test_constructor_defaults(self):
+        daemon = Gemma4Daemon(cache_dir="/tmp")
+        assert daemon._target_id == Gemma4Daemon.DEFAULT_TARGET  # noqa: SLF001
+        assert daemon._params.max_new_tokens == 128  # noqa: SLF001
+
+    def test_active_engine_raises_when_not_ready(self):
+        daemon = Gemma4Daemon(cache_dir="/tmp")
+        with pytest.raises(RuntimeError, match="not loaded"):
+            daemon.active_engine()
+
+    def test_fallback_hard_restart_on_non_default_target(self, monkeypatch):
+        daemon = _make_daemon()
+        daemon._target_id = "custom/model"  # noqa: SLF001
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine._free_vram", lambda: None
+        )
+        daemon._target_engine.unload = lambda: None  # noqa: SLF001
+
+        signal = daemon.fallback()
+
+        assert signal == ReloadSignal.HARD_RESTART
+        assert daemon._target_id == Gemma4Daemon.DEFAULT_TARGET  # noqa: SLF001
+        assert "fallback" in daemon._reload_reason  # noqa: SLF001
+
+    def test_fallback_soft_reload_when_cache_was_set(self, monkeypatch):
+        daemon = _make_daemon()
+        daemon._params.cache_implementation = "static"  # noqa: SLF001
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine._free_vram", lambda: None
+        )
+        daemon._target_engine.unload = lambda: None  # noqa: SLF001
+
+        signal = daemon.fallback()
+
+        assert signal == ReloadSignal.SOFT_RELOAD
+        assert daemon._params.cache_implementation is None  # noqa: SLF001
+
+    def test_update_params_propagates_to_assistant_engine(self):
+        daemon = _make_daemon(assistant_loaded=True, assistant_id="asst")
+        daemon.update_params(max_new_tokens=256)
+        assert daemon._assistant_engine.default_max_new_tokens == 256  # noqa: SLF001
+
+    def test_is_ready_false_when_no_target_engine(self):
+        daemon = Gemma4Daemon(cache_dir="/tmp")
+        assert daemon.is_ready() is False
+
+
+# ---------------------------------------------------------------------------
+# main.py — API endpoint coverage
+# ---------------------------------------------------------------------------
+
+
+def _ready_daemon() -> Gemma4Daemon:
+    """Return daemon with a loaded target engine stub."""
+
+    class _ReadyEngine:
+        model_id = "google/gemma-4-E2B-it"
+        default_max_new_tokens = 128
+
+        def is_loaded(self):
+            return True
+
+        def respond(self, audio, **kw):
+            return "ok", 1.0
+
+        def unload(self):
+            pass
+
+    daemon = Gemma4Daemon(cache_dir="/tmp")
+    daemon._target_engine = _ReadyEngine()  # noqa: SLF001
+    return daemon
+
+
+class TestMainHealthStatus:
+    def test_health_ok(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", _ready_daemon())
+        monkeypatch.setattr(runtime_main, "_warming", False)
+        client = TestClient(runtime_main.app)
+        r = client.get("/health")
+        assert r.status_code == 200
+        assert r.json()["status"] == "ok"
+
+    def test_health_warming(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", _ready_daemon())
+        monkeypatch.setattr(runtime_main, "_warming", True)
+        client = TestClient(runtime_main.app)
+        r = client.get("/health")
+        assert r.json()["status"] == "warming"
+
+    def test_health_model_not_loaded(self, monkeypatch):
+        daemon = Gemma4Daemon(cache_dir="/tmp")
+        monkeypatch.setattr(runtime_main, "_daemon", daemon)
+        monkeypatch.setattr(runtime_main, "_warming", False)
+        client = TestClient(runtime_main.app)
+        r = client.get("/health")
+        assert r.json()["status"] == "error"
+
+    def test_health_no_daemon_startup_error(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", None)
+        monkeypatch.setattr(runtime_main, "_warming", False)
+        monkeypatch.setattr(runtime_main, "_startup_error", "boom")
+        client = TestClient(runtime_main.app)
+        r = client.get("/health")
+        assert r.json()["status"] == "error"
+        assert "boom" in r.json()["message"]
+
+    def test_health_no_daemon_warming(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", None)
+        monkeypatch.setattr(runtime_main, "_warming", True)
+        monkeypatch.setattr(runtime_main, "_startup_error", None)
+        client = TestClient(runtime_main.app)
+        r = client.get("/health")
+        assert r.json()["status"] == "warming"
+
+    def test_v1_health_delegates(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", _ready_daemon())
+        monkeypatch.setattr(runtime_main, "_warming", False)
+        client = TestClient(runtime_main.app)
+        r = client.get("/v1/health")
+        assert r.status_code == 200
+        assert r.json()["status"] == "ok"
+
+    def test_status_running(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", _ready_daemon())
+        monkeypatch.setattr(runtime_main, "_warming", False)
+        client = TestClient(runtime_main.app)
+        r = client.get("/status")
+        body = r.json()
+        assert body["status"] == "running"
+        assert body["model_loaded"] is True
+
+    def test_status_warming(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", _ready_daemon())
+        monkeypatch.setattr(runtime_main, "_warming", True)
+        client = TestClient(runtime_main.app)
+        r = client.get("/status")
+        assert r.json()["status"] == "warming"
+
+    def test_status_no_daemon(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", None)
+        monkeypatch.setattr(runtime_main, "_warming", False)
+        client = TestClient(runtime_main.app)
+        r = client.get("/status")
+        assert r.json()["status"] == "error"
+        assert r.json()["model_loaded"] is False
+
+    def test_root_returns_service_name(self, monkeypatch):
+        client = TestClient(runtime_main.app)
+        r = client.get("/")
+        assert r.status_code == 200
+        assert "Gemma 4" in r.json()["service"]
+
+
+class TestMainListModels:
+    def test_list_models_target_only(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", _ready_daemon())
+        client = TestClient(runtime_main.app)
+        r = client.get("/v1/models")
+        assert r.status_code == 200
+        data = r.json()["data"]
+        assert len(data) == 1
+        assert data[0]["role"] == "target"
+
+    def test_list_models_with_assistant(self, monkeypatch):
+        daemon = _make_daemon(assistant_loaded=True, assistant_id="asst/model")
+        monkeypatch.setattr(runtime_main, "_daemon", daemon)
+        client = TestClient(runtime_main.app)
+        r = client.get("/v1/models")
+        data = r.json()["data"]
+        roles = [m["role"] for m in data]
+        assert "assistant" in roles
+
+    def test_list_models_no_daemon(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", None)
+        client = TestClient(runtime_main.app)
+        r = client.get("/v1/models")
+        assert r.status_code == 503
+
+
+class TestMainDaemonControlEndpoints:
+    def test_daemon_status_success(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", _ready_daemon())
+        client = TestClient(runtime_main.app)
+        r = client.get("/v1/daemon/status")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["target_loaded"] is True
+        assert "params" in body
+        assert "vram" in body
+
+    def test_daemon_status_no_daemon(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", None)
+        client = TestClient(runtime_main.app)
+        r = client.get("/v1/daemon/status")
+        assert r.status_code == 503
+
+    def test_daemon_config_none_signal(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", _ready_daemon())
+        client = TestClient(runtime_main.app)
+        r = client.post("/v1/daemon/config", json={"max_new_tokens": 64})
+        assert r.status_code == 200
+        assert r.json()["reload_signal"] == "none"
+
+    def test_daemon_config_soft_reload_signal(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", _ready_daemon())
+        client = TestClient(runtime_main.app)
+        r = client.post("/v1/daemon/config", json={"cache_implementation": "static"})
+        assert r.status_code == 200
+        assert r.json()["reload_signal"] == "soft_reload"
+
+    def test_daemon_config_no_daemon(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", None)
+        client = TestClient(runtime_main.app)
+        r = client.post("/v1/daemon/config", json={"max_new_tokens": 64})
+        assert r.status_code == 503
+
+    def test_daemon_reload_409_during_warmup(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", _ready_daemon())
+        monkeypatch.setattr(runtime_main, "_warming", True)
+        client = TestClient(runtime_main.app)
+        r = client.post("/v1/daemon/reload")
+        assert r.status_code == 409
+        assert "warm" in r.json()["detail"].lower()
+
+    def test_daemon_reload_503_not_ready(self, monkeypatch):
+        daemon = Gemma4Daemon(cache_dir="/tmp")
+        monkeypatch.setattr(runtime_main, "_daemon", daemon)
+        monkeypatch.setattr(runtime_main, "_warming", False)
+        client = TestClient(runtime_main.app)
+        r = client.post("/v1/daemon/reload")
+        assert r.status_code == 503
+
+    def test_daemon_reload_success(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_warming", False)
+
+        reload_called = []
+
+        daemon = _ready_daemon()
+        daemon.soft_reload = lambda: reload_called.append(True) or "test_reason"  # type: ignore[method-assign]
+        monkeypatch.setattr(runtime_main, "_daemon", daemon)
+
+        client = TestClient(runtime_main.app)
+        r = client.post("/v1/daemon/reload")
+        assert r.status_code == 200
+        assert reload_called
+
+    def test_daemon_restart_success(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", _ready_daemon())
+        monkeypatch.setattr("asyncio.sleep", lambda _: None)
+        monkeypatch.setattr("os.execv", lambda *a: None)
+
+        client = TestClient(runtime_main.app, raise_server_exceptions=False)
+        r = client.post("/v1/daemon/restart")
+        assert r.status_code == 200
+        assert r.json()["status"] == "restarting"
+
+    def test_daemon_assistant_attach_success(self, monkeypatch):
+        daemon = _ready_daemon()
+        attach_calls: list[str] = []
+        daemon.attach_assistant = lambda model_id: attach_calls.append(model_id)  # type: ignore[method-assign]
+        monkeypatch.setattr(runtime_main, "_daemon", daemon)
+
+        client = TestClient(runtime_main.app)
+        r = client.post("/v1/daemon/assistant/attach", json={"model_id": "asst/model"})
+        assert r.status_code == 200
+        assert attach_calls == ["asst/model"]
+
+    def test_daemon_assistant_attach_target_not_ready(self, monkeypatch):
+        daemon = Gemma4Daemon(cache_dir="/tmp")
+        monkeypatch.setattr(runtime_main, "_daemon", daemon)
+        client = TestClient(runtime_main.app)
+        r = client.post("/v1/daemon/assistant/attach", json={"model_id": "asst/model"})
+        assert r.status_code == 503
+
+    def test_daemon_assistant_detach_success(self, monkeypatch):
+        detach_calls: list = []
+        daemon = _ready_daemon()
+        daemon.detach_assistant = lambda: detach_calls.append(True)  # type: ignore[method-assign]
+        monkeypatch.setattr(runtime_main, "_daemon", daemon)
+
+        client = TestClient(runtime_main.app)
+        r = client.post("/v1/daemon/assistant/detach")
+        assert r.status_code == 200
+        assert detach_calls
+
+    def test_daemon_fallback_soft_reload(self, monkeypatch):
+        daemon = _ready_daemon()
+        daemon.fallback = lambda: ReloadSignal.SOFT_RELOAD  # type: ignore[method-assign]
+        monkeypatch.setattr(runtime_main, "_daemon", daemon)
+
+        client = TestClient(runtime_main.app)
+        r = client.post("/v1/daemon/fallback")
+        assert r.status_code == 200
+        assert r.json()["reload_signal"] == "soft_reload"
+
+    def test_daemon_fallback_no_daemon(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", None)
+        client = TestClient(runtime_main.app)
+        r = client.post("/v1/daemon/fallback")
+        assert r.status_code == 503
+
+    def test_warmup_no_daemon(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", None)
+        client = TestClient(runtime_main.app)
+        r = client.post("/warmup")
+        assert r.status_code == 503
+
+    def test_warmup_success(self, monkeypatch):
+        daemon = _ready_daemon()
+        daemon._target_engine.respond = lambda *a, **kw: ("hello", 0.5)  # type: ignore[union-attr]
+        monkeypatch.setattr(runtime_main, "_daemon", daemon)
+        client = TestClient(runtime_main.app)
+        r = client.post("/warmup")
+        assert r.status_code == 200
+        assert r.json()["status"] == "warmed"
+
+    def test_get_engine_returns_active_engine(self, monkeypatch):
+        daemon = _ready_daemon()
+        monkeypatch.setattr(runtime_main, "_daemon", daemon)
+        engine = runtime_main.get_engine()
+        assert engine is daemon._target_engine  # noqa: SLF001
+
+    def test_status_includes_model_info_when_loaded(self, monkeypatch):
+        daemon = _ready_daemon()
+        monkeypatch.setattr(runtime_main, "_daemon", daemon)
+        monkeypatch.setattr(runtime_main, "_warming", False)
+        client = TestClient(runtime_main.app)
+        r = client.get("/status")
+        body = r.json()
+        assert body["model_info"] is not None
+        assert "model_id" in body["model_info"]
+
+    def test_daemon_reload_returns_target_model(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_warming", False)
+        daemon = _ready_daemon()
+        daemon.soft_reload = lambda: "test_reason"  # type: ignore[method-assign]
+        monkeypatch.setattr(runtime_main, "_daemon", daemon)
+        client = TestClient(runtime_main.app)
+        r = client.post("/v1/daemon/reload")
+        assert r.status_code == 200
+        assert "target_model" in r.json()
+
+    def test_daemon_fallback_hard_restart_signal(self, monkeypatch):
+        daemon = _ready_daemon()
+        daemon.fallback = lambda: ReloadSignal.HARD_RESTART  # type: ignore[method-assign]
+        monkeypatch.setattr(runtime_main, "_daemon", daemon)
+        client = TestClient(runtime_main.app)
+        r = client.post("/v1/daemon/fallback")
+        assert r.status_code == 200
+        assert r.json()["reload_signal"] == "hard_restart"
+
+
+class TestMainRespondEndpoint:
+    def _make_respond_daemon(self, respond_fn=None):
+        class _Engine:
+            model_id = "google/gemma-4-E2B-it"
+            default_max_new_tokens = 128
+
+            def is_loaded(self):
+                return True
+
+            def respond(self, audio, **kw):
+                if respond_fn:
+                    return respond_fn(audio, **kw)
+                return "generated text", 1.0
+
+            def unload(self):
+                pass
+
+        daemon = Gemma4Daemon(cache_dir="/tmp")
+        daemon._target_engine = _Engine()  # noqa: SLF001
+        return daemon
+
+    def test_respond_text_only_no_audio(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", self._make_respond_daemon())
+        client = TestClient(runtime_main.app)
+        r = client.post(
+            "/v1/respond",
+            json={
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "What do you hear?"}],
+                    }
+                ]
+            },
+        )
+        assert r.status_code == 200
+        body = r.json()
+        assert body["text"] == "generated text"
+
+    def test_respond_returns_400_when_no_content(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", self._make_respond_daemon())
+        client = TestClient(runtime_main.app)
+        r = client.post(
+            "/v1/respond",
+            json={"messages": [{"role": "user", "content": []}]},
+        )
+        assert r.status_code == 400
+
+    def test_respond_503_when_no_daemon(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", None)
+        client = TestClient(runtime_main.app)
+        r = client.post(
+            "/v1/respond",
+            json={
+                "messages": [
+                    {"role": "user", "content": [{"type": "text", "text": "hello"}]}
+                ]
+            },
+        )
+        assert r.status_code == 503
+
+    def test_respond_inference_error_returns_500(self, monkeypatch):
+        def _failing_respond(audio, **kw):
+            raise InferenceError("GPU exploded")
+
+        daemon = self._make_respond_daemon(respond_fn=_failing_respond)
+        monkeypatch.setattr(runtime_main, "_daemon", daemon)
+        client = TestClient(runtime_main.app)
+        r = client.post(
+            "/v1/respond",
+            json={
+                "messages": [
+                    {"role": "user", "content": [{"type": "text", "text": "boom"}]}
+                ]
+            },
+        )
+        assert r.status_code == 500
+
+    def test_transcribe_endpoint_no_daemon(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", None)
+        client = TestClient(runtime_main.app)
+        r = client.post(
+            "/audio/transcribe",
+            files={"audio": ("test.wav", b"fake", "audio/wav")},
+        )
+        assert r.status_code == 503
+
+    def test_transcribe_endpoint_bad_audio(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", self._make_respond_daemon())
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.main.audio_from_bytes",
+            lambda b: (_ for _ in ()).throw(ValueError("bad")),
+        )
+        client = TestClient(runtime_main.app)
+        r = client.post(
+            "/audio/transcribe",
+            files={"audio": ("test.wav", b"fake", "audio/wav")},
+        )
+        assert r.status_code == 400
+
+    def test_transcribe_endpoint_success(self, monkeypatch):
+        monkeypatch.setattr(runtime_main, "_daemon", self._make_respond_daemon())
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.main.audio_from_bytes",
+            lambda b: (np.zeros(16000, dtype=np.float32), 16000),
+        )
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.main.get_audio_duration",
+            lambda arr, sr: 1.0,
+        )
+
+        class _EngineWithTranscribe:
+            model_id = "google/gemma-4-E2B-it"
+
+            def is_loaded(self):
+                return True
+
+            def transcribe(self, audio, sr, **kw):
+                return "hello world"
+
+            def unload(self):
+                pass
+
+        daemon = Gemma4Daemon(cache_dir="/tmp")
+        daemon._target_engine = _EngineWithTranscribe()  # noqa: SLF001
+        monkeypatch.setattr(runtime_main, "_daemon", daemon)
+
+        client = TestClient(runtime_main.app)
+        r = client.post(
+            "/audio/transcribe",
+            files={"audio": ("test.wav", b"fake", "audio/wav")},
+        )
+        assert r.status_code == 200
+        assert r.json()["text"] == "hello world"

--- a/tests/test_214a_gemma4_daemon.py
+++ b/tests/test_214a_gemma4_daemon.py
@@ -1,0 +1,603 @@
+"""Tests for Gemma 4 Daemon engine and control API — PR 214A.
+
+Covers the 7 backend test cases from the spec (section 2.3):
+  1. wybór target model
+  2. dodanie assistant model
+  3. zmiana parametrów bez restartu
+  4. soft reload
+  5. twardy restart
+  6. czyszczenie stanu / brak śmieci w VRAM
+  7. fallback gdy assistant model nie może się załadować
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+import services.gemma4_audio_runtime.main as runtime_main
+from services.gemma4_audio_runtime.engine import (
+    Gemma4AudioEngine,
+    Gemma4Daemon,
+    ModelLoadError,
+    ReloadSignal,
+    RuntimeMode,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_engine_stub(
+    loaded: bool = True, model_id: str = "google/gemma-4-E2B-it"
+) -> MagicMock:
+    stub = MagicMock(spec=Gemma4AudioEngine)
+    stub.is_loaded.return_value = loaded
+    stub.model_id = model_id
+    stub.default_max_new_tokens = 128
+    return stub
+
+
+def _make_daemon(
+    target_loaded: bool = True,
+    assistant_loaded: bool = False,
+    assistant_id: str | None = None,
+) -> Gemma4Daemon:
+    """Return a Gemma4Daemon with stubbed engines (no real model loading)."""
+    daemon = Gemma4Daemon(cache_dir="models_cache/hf")
+    target_stub = _make_engine_stub(loaded=target_loaded)
+    daemon._target_engine = target_stub  # noqa: SLF001
+    if assistant_id:
+        assistant_stub = _make_engine_stub(
+            loaded=assistant_loaded, model_id=assistant_id
+        )
+        daemon._assistant_engine = assistant_stub  # noqa: SLF001
+        daemon._assistant_id = assistant_id  # noqa: SLF001
+        daemon._mode = RuntimeMode.TARGET_WITH_ASSISTANT  # noqa: SLF001
+    return daemon
+
+
+# ---------------------------------------------------------------------------
+# 1. wybór target model
+# ---------------------------------------------------------------------------
+
+
+class TestTargetModelSelection:
+    def test_default_target_is_gemma4_e2b(self):
+        daemon = Gemma4Daemon(cache_dir="models_cache/hf")
+        assert daemon._target_id == "google/gemma-4-E2B-it"  # noqa: SLF001
+
+    def test_load_target_calls_engine_load(self, monkeypatch):
+        daemon = Gemma4Daemon(cache_dir="models_cache/hf")
+        load_calls = []
+
+        class FakeEngine:
+            model_id = "google/gemma-4-E2B-it"
+            model_class_name = None
+            default_max_new_tokens = 128
+
+            def load(self):
+                load_calls.append(self.model_id)
+
+            def is_loaded(self):
+                return True
+
+            def unload(self):
+                pass
+
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine.Gemma4AudioEngine",
+            lambda **_: FakeEngine(),
+        )
+        daemon.load_target()
+
+        assert load_calls == ["google/gemma-4-E2B-it"]
+        assert daemon.is_ready()
+
+    def test_status_reports_target_model(self):
+        daemon = _make_daemon()
+        st = daemon.status()
+        assert st["target_model"] == "google/gemma-4-E2B-it"
+        assert st["target_loaded"] is True
+        assert st["mode"] == "target_only"
+
+
+# ---------------------------------------------------------------------------
+# 2. dodanie assistant model
+# ---------------------------------------------------------------------------
+
+
+class TestAssistantAttach:
+    def test_attach_loads_assistant_engine(self, monkeypatch):
+        daemon = _make_daemon()
+        attached = []
+
+        class FakeAssistantEngine:
+            model_id = "google/gemma-4-E2B-it-assistant"
+            default_max_new_tokens = 128
+
+            def load(self):
+                attached.append(self.model_id)
+
+            def is_loaded(self):
+                return True
+
+            def unload(self):
+                pass
+
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine.Gemma4AudioEngine",
+            lambda **kw: FakeAssistantEngine(),
+        )
+
+        daemon.attach_assistant("google/gemma-4-E2B-it-assistant")
+
+        assert attached == ["google/gemma-4-E2B-it-assistant"]
+        assert daemon._assistant_id == "google/gemma-4-E2B-it-assistant"  # noqa: SLF001
+        assert daemon._mode == RuntimeMode.TARGET_WITH_ASSISTANT  # noqa: SLF001
+
+    def test_status_reports_assistant_when_attached(self):
+        daemon = _make_daemon(
+            assistant_loaded=True, assistant_id="google/gemma-4-E2B-it-assistant"
+        )
+        st = daemon.status()
+        assert st["assistant_model"] == "google/gemma-4-E2B-it-assistant"
+        assert st["assistant_loaded"] is True
+        assert st["mode"] == "target_with_assistant"
+
+    def test_only_one_assistant_at_a_time(self, monkeypatch):
+        daemon = _make_daemon(assistant_loaded=True, assistant_id="model-A")
+        unloaded = []
+
+        class FakeNewEngine:
+            model_id = "model-B"
+            default_max_new_tokens = 128
+
+            def load(self):
+                pass
+
+            def is_loaded(self):
+                return True
+
+            def unload(self):
+                unloaded.append("model-B")
+
+        # The existing assistant stub's unload should be tracked
+        old_stub = daemon._assistant_engine  # noqa: SLF001
+        old_stub.unload = lambda: unloaded.append("model-A")
+
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine.Gemma4AudioEngine",
+            lambda **kw: FakeNewEngine(),
+        )
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine._free_vram", lambda: None
+        )
+
+        daemon.attach_assistant("model-B")
+
+        assert "model-A" in unloaded
+        assert daemon._assistant_id == "model-B"  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# 3. zmiana parametrów bez restartu
+# ---------------------------------------------------------------------------
+
+
+class TestLiveParamUpdate:
+    def test_max_new_tokens_applied_live(self):
+        daemon = _make_daemon()
+        signal = daemon.update_params(max_new_tokens=512)
+        assert signal == ReloadSignal.NONE
+        assert daemon._params.max_new_tokens == 512  # noqa: SLF001
+        assert daemon._target_engine.default_max_new_tokens == 512  # noqa: SLF001
+
+    def test_enable_thinking_applied_live(self):
+        daemon = _make_daemon()
+        signal = daemon.update_params(enable_thinking=True)
+        assert signal == ReloadSignal.NONE
+        assert daemon._params.enable_thinking is True  # noqa: SLF001
+
+    def test_cache_implementation_signals_soft_reload(self):
+        daemon = _make_daemon()
+        signal = daemon.update_params(cache_implementation="static")
+        assert signal == ReloadSignal.SOFT_RELOAD
+        assert daemon._params.cache_implementation == "static"  # noqa: SLF001
+        assert daemon._reload_reason is not None  # noqa: SLF001
+
+    def test_same_cache_implementation_no_reload(self):
+        daemon = _make_daemon()
+        daemon._params.cache_implementation = "static"  # noqa: SLF001
+        signal = daemon.update_params(cache_implementation="static")
+        assert signal == ReloadSignal.NONE
+
+    def test_status_pending_reload_after_cache_change(self):
+        daemon = _make_daemon()
+        daemon.update_params(cache_implementation="quantized")
+        st = daemon.status()
+        assert st["pending_reload"] is True
+        assert "cache_implementation" in st["reload_reason"]
+
+
+# ---------------------------------------------------------------------------
+# 4. soft reload
+# ---------------------------------------------------------------------------
+
+
+class TestSoftReload:
+    def test_soft_reload_frees_vram_then_reloads(self, monkeypatch):
+        daemon = _make_daemon()
+        freed = []
+        loaded = []
+
+        original_target = daemon._target_engine  # noqa: SLF001
+        original_target.unload = lambda: freed.append("target_unloaded")
+
+        class FreshEngine:
+            model_id = "google/gemma-4-E2B-it"
+            model_class_name = None
+            default_max_new_tokens = 128
+
+            def load(self):
+                loaded.append("target_loaded")
+
+            def is_loaded(self):
+                return True
+
+            def unload(self):
+                pass
+
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine.Gemma4AudioEngine",
+            lambda **_: FreshEngine(),
+        )
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine._free_vram",
+            lambda: freed.append("vram_freed"),
+        )
+
+        reason = daemon.soft_reload()
+
+        assert "target_unloaded" in freed
+        assert "vram_freed" in freed
+        assert "target_loaded" in loaded
+        assert reason == "manual_reload"
+
+    def test_soft_reload_clears_reload_reason(self, monkeypatch):
+        daemon = _make_daemon()
+        daemon._reload_reason = "cache_implementation changed to 'static'"  # noqa: SLF001
+
+        class FreshEngine:
+            model_id = "google/gemma-4-E2B-it"
+            model_class_name = None
+            default_max_new_tokens = 128
+
+            def load(self):
+                pass
+
+            def is_loaded(self):
+                return True
+
+            def unload(self):
+                pass
+
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine.Gemma4AudioEngine",
+            lambda **_: FreshEngine(),
+        )
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine._free_vram", lambda: None
+        )
+
+        reason = daemon.soft_reload()
+
+        assert reason == "cache_implementation changed to 'static'"
+        assert daemon._reload_reason is None  # noqa: SLF001
+        st = daemon.status()
+        assert st["pending_reload"] is False
+
+    def test_soft_reload_drops_assistant(self, monkeypatch):
+        daemon = _make_daemon(
+            assistant_loaded=True, assistant_id="google/gemma-4-E2B-it-assistant"
+        )
+        unloaded_assistant = []
+        daemon._assistant_engine.unload = lambda: unloaded_assistant.append(True)  # noqa: SLF001
+
+        class FreshEngine:
+            model_id = "google/gemma-4-E2B-it"
+            model_class_name = None
+            default_max_new_tokens = 128
+
+            def load(self):
+                pass
+
+            def is_loaded(self):
+                return True
+
+            def unload(self):
+                pass
+
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine.Gemma4AudioEngine",
+            lambda **_: FreshEngine(),
+        )
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine._free_vram", lambda: None
+        )
+
+        daemon.soft_reload()
+
+        assert unloaded_assistant, "assistant.unload() must be called"
+        assert daemon._assistant_id is None  # noqa: SLF001
+        assert daemon._mode == RuntimeMode.TARGET_ONLY  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# 5. twardy restart
+# ---------------------------------------------------------------------------
+
+
+class TestHardRestart:
+    def test_restart_endpoint_unloads_and_schedules_execv(self, monkeypatch):
+        daemon = _make_daemon()
+        unloaded = []
+        daemon.unload_all = lambda: unloaded.append(True)
+
+        monkeypatch.setattr(runtime_main, "_daemon", daemon)
+
+        execv_calls = []
+
+        async def fake_sleep(_):
+            pass
+
+        monkeypatch.setattr("asyncio.sleep", fake_sleep)
+        monkeypatch.setattr("os.execv", lambda *a: execv_calls.append(a))
+
+        client = TestClient(runtime_main.app, raise_server_exceptions=False)
+        response = client.post("/v1/daemon/restart")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "restarting"
+        assert unloaded == [True]
+
+    def test_unload_all_cleans_all_models(self, monkeypatch):
+        daemon = _make_daemon(assistant_loaded=True, assistant_id="asst-model")
+        freed = []
+        daemon._target_engine.unload = lambda: freed.append("target")  # noqa: SLF001
+        daemon._assistant_engine.unload = lambda: freed.append("asst")  # noqa: SLF001
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine._free_vram",
+            lambda: freed.append("vram"),
+        )
+
+        daemon.unload_all()
+
+        assert "target" in freed
+        assert "asst" in freed
+        assert "vram" in freed
+        assert daemon._target_engine is None  # noqa: SLF001
+        assert daemon._assistant_engine is None  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# 6. czyszczenie stanu / brak śmieci w VRAM
+# ---------------------------------------------------------------------------
+
+
+class TestVRAMHygiene:
+    def test_detach_assistant_frees_vram(self, monkeypatch):
+        daemon = _make_daemon(assistant_loaded=True, assistant_id="asst")
+        freed = []
+        daemon._assistant_engine.unload = lambda: freed.append("unloaded")  # noqa: SLF001
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine._free_vram",
+            lambda: freed.append("cache_cleared"),
+        )
+
+        daemon.detach_assistant()
+
+        assert "unloaded" in freed
+        assert "cache_cleared" in freed
+        assert daemon._assistant_engine is None  # noqa: SLF001
+        assert daemon._assistant_id is None  # noqa: SLF001
+
+    def test_attach_failure_leaves_no_orphan(self, monkeypatch):
+        daemon = _make_daemon()
+        freed = []
+
+        class BrokenEngine:
+            model_id = "bad-model"
+            default_max_new_tokens = 128
+
+            def load(self):
+                raise Exception("OOM")
+
+            def is_loaded(self):
+                return False
+
+            def unload(self):
+                pass
+
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine.Gemma4AudioEngine",
+            lambda **_: BrokenEngine(),
+        )
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine._free_vram",
+            lambda: freed.append("cleared"),
+        )
+
+        with pytest.raises(ModelLoadError):
+            daemon.attach_assistant("bad-model")
+
+        assert freed, "_free_vram must be called on attach failure"
+        assert daemon._assistant_engine is None  # noqa: SLF001
+        assert daemon._assistant_id is None  # noqa: SLF001
+        assert daemon._mode == RuntimeMode.TARGET_ONLY  # noqa: SLF001
+
+    def test_ensure_vram_clean_removes_all_references(self, monkeypatch):
+        daemon = _make_daemon(assistant_loaded=True, assistant_id="asst")
+        unloaded = []
+        daemon._target_engine.unload = lambda: unloaded.append("target")  # noqa: SLF001
+        daemon._assistant_engine.unload = lambda: unloaded.append("asst")  # noqa: SLF001
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine._free_vram", lambda: None
+        )
+
+        daemon._ensure_vram_clean()  # noqa: SLF001
+
+        assert "target" in unloaded
+        assert "asst" in unloaded
+        assert daemon._target_engine is None  # noqa: SLF001
+        assert daemon._assistant_engine is None  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# 7. fallback gdy assistant model nie może się załadować
+# ---------------------------------------------------------------------------
+
+
+class TestAssistantFallback:
+    def test_failed_assistant_load_keeps_target_running(self, monkeypatch):
+        daemon = _make_daemon()
+
+        class FailingEngine:
+            model_id = "bad-assistant"
+            default_max_new_tokens = 128
+
+            def load(self):
+                raise Exception("GPU OOM")
+
+            def is_loaded(self):
+                return False
+
+            def unload(self):
+                pass
+
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine.Gemma4AudioEngine",
+            lambda **_: FailingEngine(),
+        )
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine._free_vram", lambda: None
+        )
+
+        with pytest.raises(ModelLoadError):
+            daemon.attach_assistant("bad-assistant")
+
+        # Target must still be operational
+        assert daemon.is_ready(), "Target must remain loaded after assistant failure"
+        assert daemon._assistant_id is None  # noqa: SLF001
+        assert daemon._mode == RuntimeMode.TARGET_ONLY  # noqa: SLF001
+
+    def test_api_returns_422_on_assistant_failure(self, monkeypatch):
+        daemon = _make_daemon()
+
+        def raise_load_error(model_id: str):
+            raise ModelLoadError(f"Cannot load {model_id}")
+
+        daemon.attach_assistant = raise_load_error  # type: ignore[method-assign]
+        monkeypatch.setattr(runtime_main, "_daemon", daemon)
+
+        client = TestClient(runtime_main.app)
+        response = client.post(
+            "/v1/daemon/assistant/attach",
+            json={"model_id": "bad-model"},
+        )
+
+        assert response.status_code == 422
+        assert "Cannot attach assistant" in response.json()["detail"]
+
+    def test_daemon_fallback_resets_to_safe_defaults(self, monkeypatch):
+        daemon = _make_daemon(assistant_loaded=True, assistant_id="asst")
+        daemon._params.max_new_tokens = 1024  # noqa: SLF001
+        daemon._params.enable_thinking = True  # noqa: SLF001
+        daemon._assistant_engine.unload = lambda: None  # noqa: SLF001
+        monkeypatch.setattr(
+            "services.gemma4_audio_runtime.engine._free_vram", lambda: None
+        )
+
+        signal = daemon.fallback()
+
+        # Default target was already set — cache was None — so soft reload (clean state)
+        assert signal in (ReloadSignal.SOFT_RELOAD, ReloadSignal.NONE)
+        assert daemon._assistant_id is None  # noqa: SLF001
+        assert daemon._params.max_new_tokens == 128  # noqa: SLF001
+        assert daemon._params.enable_thinking is False  # noqa: SLF001
+        assert daemon._mode == RuntimeMode.TARGET_ONLY  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat: existing chat completions tests still work
+# ---------------------------------------------------------------------------
+
+
+def test_extract_text_prompt_from_openai_messages_prefers_latest_user_text() -> None:
+    messages = [
+        {"role": "system", "content": "rules"},
+        {"role": "user", "content": [{"type": "text", "text": "pierwszy"}]},
+        {"role": "user", "content": "drugi"},
+    ]
+    assert runtime_main._extract_text_prompt_from_openai_messages(messages) == "drugi"  # noqa: SLF001
+
+
+def test_chat_completions_uses_pydantic_payload_and_sampling(monkeypatch) -> None:
+    captured: dict = {}
+
+    daemon = _make_daemon()
+
+    class EngineStub:
+        model_id = "google/gemma-4-E2B-it"
+
+        def is_loaded(self) -> bool:
+            return True
+
+        def respond(self, _audio, **kwargs):
+            captured.update(kwargs)
+            return "to jest odpowiedz", 0.25
+
+    daemon._target_engine = EngineStub()  # noqa: SLF001
+    monkeypatch.setattr(runtime_main, "_daemon", daemon)
+
+    client = TestClient(runtime_main.app)
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "google/gemma-4-E2B-it",
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "Ile to 5*5?"}]}
+            ],
+            "max_tokens": 77,
+            "temperature": 0.2,
+            "top_p": 0.9,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["choices"][0]["message"]["content"] == "to jest odpowiedz"
+    assert captured["max_new_tokens"] == 77
+    assert captured["do_sample"] is True
+    assert captured["temperature"] == 0.2
+    assert captured["top_p"] == 0.9
+    assert body["usage"]["prompt_tokens"] >= 1
+    assert body["usage"]["completion_tokens"] == max(1, len("to jest odpowiedz") // 4)
+
+
+def test_chat_completions_rejects_streaming(monkeypatch) -> None:
+    daemon = _make_daemon()
+    monkeypatch.setattr(runtime_main, "_daemon", daemon)
+
+    client = TestClient(runtime_main.app)
+    response = client.post(
+        "/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": "hej"}], "stream": True},
+    )
+
+    assert response.status_code == 400
+    assert "Streaming is not supported" in response.json()["detail"]

--- a/tests/test_gemma4_audio_runtime_main.py
+++ b/tests/test_gemma4_audio_runtime_main.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
-
 from fastapi.testclient import TestClient
 
 import services.gemma4_audio_runtime.main as runtime_main
+from services.gemma4_audio_runtime.engine import Gemma4Daemon
+
+
+def _make_test_daemon(engine_stub) -> Gemma4Daemon:
+    """Construct a daemon wired to a pre-built engine stub."""
+    daemon = Gemma4Daemon(cache_dir="models_cache/hf")
+    daemon._target_engine = engine_stub  # noqa: SLF001
+    return daemon
 
 
 def test_extract_text_prompt_from_openai_messages_prefers_latest_user_text() -> None:
@@ -30,7 +36,8 @@ def test_chat_completions_uses_pydantic_payload_and_sampling(monkeypatch) -> Non
             captured.update(kwargs)
             return "to jest odpowiedz", 0.25
 
-    monkeypatch.setattr(runtime_main, "get_engine", lambda: EngineStub())
+    daemon = _make_test_daemon(EngineStub())
+    monkeypatch.setattr(runtime_main, "_daemon", daemon)
 
     client = TestClient(runtime_main.app)
     response = client.post(
@@ -58,11 +65,15 @@ def test_chat_completions_uses_pydantic_payload_and_sampling(monkeypatch) -> Non
 
 
 def test_chat_completions_rejects_streaming(monkeypatch) -> None:
-    monkeypatch.setattr(
-        runtime_main,
-        "get_engine",
-        lambda: SimpleNamespace(is_loaded=lambda: True, model_id="m"),
-    )
+    class EngineStub:
+        model_id = "m"
+
+        def is_loaded(self) -> bool:
+            return True
+
+    daemon = _make_test_daemon(EngineStub())
+    monkeypatch.setattr(runtime_main, "_daemon", daemon)
+
     client = TestClient(runtime_main.app)
 
     response = client.post(


### PR DESCRIPTION
## Summary

- **Gemma4Daemon** replaces the static `Gemma4AudioEngine` global with a controllable daemon that holds exactly one target model (`google/gemma-4-E2B-it`) and an optional assistant/drafter, guaranteeing clean VRAM on every transition
- **ReloadSignal** enum (`none` / `soft_reload` / `hard_restart`) lets the caller know the minimum action needed after a parameter change — no guessing required
- **New daemon control API** under `/v1/daemon/`: `GET status`, `POST config`, `POST reload`, `POST restart`, `POST assistant/attach`, `POST assistant/detach`, `POST fallback`
- **load() class cascade**: tries `AutoModelForMultimodalLM` → `AutoModelForImageTextToText` → `AutoModelForCausalLM` — allows attaching `gemma-4-E2B-it-assistant` (Gemma4AssistantConfig, speculative decoding) alongside the multimodal target
- **Warmup access fix**: `_daemon` is now exposed before `load_target()` so all control endpoints respond during model warmup (previously 503)
- **25 new unit tests** covering all 7 backend cases from spec §2.3; `test_gemma4_audio_runtime_main.py` updated to patch `_daemon` instead of removed `get_engine`
- All existing inference endpoints (`/v1/respond`, `/v1/chat/completions`, `/audio/transcribe`, `/warmup`) unchanged — `enable_thinking` and `cache_implementation` now forwarded from daemon params to engine

## Files changed

| File | Change |
|------|--------|
| `services/gemma4_audio_runtime/engine.py` | `Gemma4Daemon`, `ReloadSignal`, `DaemonParams`, `VRAMInfo`, VRAM helpers, load() cascade |
| `services/gemma4_audio_runtime/main.py` | Daemon wiring, 7 new `/v1/daemon/*` endpoints |
| `services/gemma4_audio_runtime/schemas.py` | `DaemonStatusResponse`, `DaemonConfigRequest/Response`, `AssistantAttach*`, `SoftReloadResponse`, `FallbackResponse`, `RestartResponse` |
| `tests/test_214a_gemma4_daemon.py` | 25 new tests (7 spec cases) |
| `tests/test_gemma4_audio_runtime_main.py` | Patch target: `get_engine` → `_daemon` |
| `config/testing/test_catalog.json` | New entry for `test_214a_gemma4_daemon.py` |
| `config/pytest-groups/{fast,sonar-new-code}.txt` | Auto-synced from catalog |

## What is NOT in this PR (per spec §3)

- No frontend selectors or UI changes
- No new TTS runtime
- No changes to `/voice` UI architecture
- No stack other than Transformers

## Manual test results (live daemon on `google/gemma-4-E2B-it`)

| Scenario | Result |
|----------|--------|
| Daemon start, model load (~32s from cache) | ✅ |
| `GET /v1/daemon/status` with VRAM metrics (9736 MB allocated) | ✅ |
| `POST /v1/daemon/config` `max_new_tokens=256, enable_thinking=true` → `reload_signal: none` | ✅ |
| `POST /v1/daemon/config` `cache_implementation=static` → `reload_signal: soft_reload` + `pending_reload: true` | ✅ |
| `POST /v1/daemon/reload` — VRAM freed, model reloaded, `pending_reload` cleared (9.3s) | ✅ |
| `POST /v1/daemon/assistant/attach` `gemma-4-E2B-it-assistant` — loaded via CausalLM fallback, VRAM +150 MB | ✅ |
| `POST /v1/daemon/assistant/detach` — VRAM back to baseline, mode `target_only` | ✅ |
| `POST /v1/daemon/fallback` — params reset, `reload_signal: soft_reload` returned | ✅ |
| SIGTERM → graceful lifespan shutdown, `unload_all()` logged | ✅ |

## Test plan

- [x] `make test-catalog-check` — 446/446
- [x] `make test-groups-check` — in sync
- [x] `compileall venom_core scripts tests` — clean
- [x] `pytest tests/test_214a_gemma4_daemon.py tests/test_gemma4_audio_runtime_main.py` — 28/28

🤖 Generated with [Claude Code](https://claude.com/claude-code)