### PR TITLE
214C: Gemma4 runtime params UI + voice runtime stability

### DIFF
--- a/tests/test_env_contracts.py
+++ b/tests/test_env_contracts.py
@@ -26,3 +26,14 @@ def test_gemma4_keys_present_in_env_dev():
 
     missing = [k for k in gemma_keys if k not in dev]
     assert not missing, f"Missing GEMMA4_AUDIO keys in .env.dev: {missing}"
+
+
+def test_active_local_runtime_matches_endpoint_contract():
+    dev = _read_env_keys(".env.dev")
+    active = dev.get("ACTIVE_LLM_SERVER", "").strip().lower()
+    endpoint = dev.get("LLM_LOCAL_ENDPOINT", "").strip()
+
+    if active == "ollama":
+        assert endpoint.startswith("http://localhost:11434"), endpoint
+    elif active == "gemma4_audio":
+        assert endpoint.startswith("http://localhost:8014"), endpoint

--- a/tests/test_llm_runtime_utils.py
+++ b/tests/test_llm_runtime_utils.py
@@ -20,12 +20,18 @@ class DummySettings:
         model_name="model-x",
         endpoint=LOCALHOST_8000,
         azure_endpoint=None,
+        active_server="",
+        gemma4_endpoint="http://localhost:8014/v1",
+        vllm_endpoint=LOCALHOST_8001_V1,
     ):
         self.LLM_SERVICE_TYPE = service_type
         self.AI_MODE = mode
         self.LLM_MODEL_NAME = model_name
         self.LLM_LOCAL_ENDPOINT = endpoint
         self.AZURE_OPENAI_ENDPOINT = azure_endpoint
+        self.ACTIVE_LLM_SERVER = active_server
+        self.GEMMA4_AUDIO_ENDPOINT = gemma4_endpoint
+        self.VLLM_ENDPOINT = vllm_endpoint
 
 
 def test_infer_local_provider_variants():
@@ -83,6 +89,26 @@ def test_get_active_llm_runtime_variants():
         DummySettings(service_type="local", endpoint=LOCALHOST_11434)
     )
     assert runtime.provider == "ollama"
+
+    runtime = llm_runtime.get_active_llm_runtime(
+        DummySettings(
+            service_type="local",
+            endpoint="http://localhost:8014/v1",
+            active_server="ollama",
+        )
+    )
+    assert runtime.provider == "ollama"
+    assert runtime.endpoint.endswith("/v1")
+
+    runtime = llm_runtime.get_active_llm_runtime(
+        DummySettings(
+            service_type="local",
+            endpoint=LOCALHOST_11434,
+            active_server="gemma4_audio",
+        )
+    )
+    assert runtime.provider == "gemma4_audio"
+    assert runtime.endpoint == "http://localhost:8014/v1"
 
     runtime = llm_runtime.get_active_llm_runtime(
         DummySettings(service_type="onnx", endpoint=None)

--- a/tests/test_llm_runtime_utils.py
+++ b/tests/test_llm_runtime_utils.py
@@ -111,6 +111,36 @@ def test_get_active_llm_runtime_variants():
     assert runtime.endpoint == "http://localhost:8014/v1"
 
     runtime = llm_runtime.get_active_llm_runtime(
+        DummySettings(
+            service_type="local",
+            endpoint="localhost:8001/v1",
+            active_server=" vLlM ",
+        )
+    )
+    assert runtime.provider == "vllm"
+    assert runtime.endpoint == "http://localhost:8001/v1"
+
+    runtime = llm_runtime.get_active_llm_runtime(
+        DummySettings(
+            service_type="local",
+            endpoint="http://localhost:8014/v1",
+            active_server="ollama",
+        )
+    )
+    assert runtime.provider == "ollama"
+    assert runtime.endpoint == "http://localhost:11434/v1"
+
+    runtime = llm_runtime.get_active_llm_runtime(
+        DummySettings(
+            service_type="local",
+            endpoint="http://localhost:11434/v1",
+            active_server="onnx",
+        )
+    )
+    assert runtime.provider == "onnx"
+    assert runtime.endpoint is None
+
+    runtime = llm_runtime.get_active_llm_runtime(
         DummySettings(service_type="onnx", endpoint=None)
     )
     assert runtime.provider == "onnx"

--- a/tests/test_llm_server_selection.py
+++ b/tests/test_llm_server_selection.py
@@ -10,6 +10,33 @@ from venom_core.api.routes import system_llm as system_routes
 from venom_core.config import SETTINGS
 
 
+class _FakeResponse:
+    def __init__(self, status_code: int, payload=None):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        if isinstance(self._payload, Exception):
+            raise self._payload
+        return self._payload
+
+
+class _FakeAsyncClient:
+    def __init__(self, responses):
+        self._responses = list(responses)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, _url):
+        if self._responses:
+            return self._responses.pop(0)
+        return _FakeResponse(503, {"status": "error"})
+
+
 class DummyController:
     def __init__(self, servers):
         self._servers = servers
@@ -60,6 +87,51 @@ def _restore_settings(snapshot):
     SETTINGS.ONNX_LLM_ENABLED = snapshot["onnx_enabled"]
     if snapshot["config_hash"] is not None:
         SETTINGS.LLM_CONFIG_HASH = snapshot["config_hash"]
+
+
+@pytest.mark.asyncio
+async def test_await_server_health_gemma4_audio_waits_for_ready(monkeypatch):
+    responses = [
+        _FakeResponse(200, {"status": "warming"}),
+        _FakeResponse(200, {"status": "ok"}),
+    ]
+
+    async def _fast_sleep(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(
+        system_routes.httpx,
+        "AsyncClient",
+        lambda timeout=2.0: _FakeAsyncClient(responses),
+    )
+    monkeypatch.setattr(system_routes.asyncio, "sleep", _fast_sleep)
+
+    assert (
+        await system_routes._await_server_health(
+            "gemma4_audio", "http://localhost:8014/health"
+        )
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_await_server_health_non_gemma_accepts_http_200(monkeypatch):
+    responses = [_FakeResponse(200, {"status": "error"})]
+    monkeypatch.setattr(
+        system_routes.httpx,
+        "AsyncClient",
+        lambda timeout=2.0: _FakeAsyncClient(responses),
+    )
+
+    assert (
+        await system_routes._await_server_health("ollama", "http://localhost:11434")
+        is True
+    )
+
+
+def test_extract_health_status_handles_non_json_response():
+    response = _FakeResponse(200, ValueError("invalid json"))
+    assert system_routes._extract_health_status(response) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_model_config_api.py
+++ b/tests/test_model_config_api.py
@@ -183,8 +183,7 @@ class TestModelConfigAPI:
         _set_registry(registry)
 
         response = client.get("/api/v1/models/gemma4:latest/runtime-capabilities")
-
         assert response.status_code == 200
         data = response.json()
         assert data["runtime_capabilities"]["probes"]["show"]["status"] == "verified"
-        assert data["runtime_capabilities"]["probe_status"] == "failed"
+        assert data["runtime_capabilities"]["probe_status"] == "verified"

--- a/tests/test_model_registry_clients_additional.py
+++ b/tests/test_model_registry_clients_additional.py
@@ -609,7 +609,7 @@ async def test_voice_runtime_helpers_cover_branches(monkeypatch):
         endpoint="http://localhost:11434",
     )
     decision = resolve_voice_pipeline(caps)
-    assert caps.probe_status == "verified"
+    assert caps.probe_status == "metadata_only"
     assert decision.reasoning == "think_api"
     assert decision.tools == "policy_gated_tools"
     assert decision.vision == "images_api"

--- a/tests/test_model_registry_clients_additional.py
+++ b/tests/test_model_registry_clients_additional.py
@@ -609,7 +609,7 @@ async def test_voice_runtime_helpers_cover_branches(monkeypatch):
         endpoint="http://localhost:11434",
     )
     decision = resolve_voice_pipeline(caps)
-    assert caps.probe_status == "metadata_only"
+    assert caps.probe_status == "verified"
     assert decision.reasoning == "think_api"
     assert decision.tools == "policy_gated_tools"
     assert decision.vision == "images_api"

--- a/tests/test_ollama_runtime_capabilities.py
+++ b/tests/test_ollama_runtime_capabilities.py
@@ -92,6 +92,15 @@ def test_aggregate_probe_status_prefers_verified_for_optional_probe_failures():
         _aggregate_probe_status(
             {
                 "show": {"status": "verified"},
+                "audio": {"status": "metadata_only"},
+            }
+        )
+        == "metadata_only"
+    )
+    assert (
+        _aggregate_probe_status(
+            {
+                "show": {"status": "verified"},
                 "thinking": {"status": "failed"},
             }
         )

--- a/tests/test_ollama_runtime_capabilities.py
+++ b/tests/test_ollama_runtime_capabilities.py
@@ -82,3 +82,27 @@ def test_normalize_ollama_show_payload_handles_invalid_context_and_to_dict():
     assert payload["model_name"] == "fallback-model"
     assert payload["probe_status"] == "verified"
     assert payload["capabilities"]["text_completion"] is True
+
+
+def test_aggregate_probe_status_prefers_verified_for_optional_probe_failures():
+    from venom_core.core.ollama_runtime_probe import _aggregate_probe_status
+
+    assert _aggregate_probe_status({"show": {"status": "verified"}}) == "verified"
+    assert (
+        _aggregate_probe_status(
+            {
+                "show": {"status": "verified"},
+                "thinking": {"status": "failed"},
+            }
+        )
+        == "verified"
+    )
+    assert (
+        _aggregate_probe_status(
+            {
+                "show": {"status": "metadata_only"},
+                "vision": {"status": "metadata_only"},
+            }
+        )
+        == "metadata_only"
+    )

--- a/tests/test_ollama_runtime_capabilities.py
+++ b/tests/test_ollama_runtime_capabilities.py
@@ -115,3 +115,7 @@ def test_aggregate_probe_status_prefers_verified_for_optional_probe_failures():
         )
         == "metadata_only"
     )
+    assert (
+        _aggregate_probe_status({"show": {"status": "metadata_only"}})
+        == "metadata_only"
+    )

--- a/venom_core/api/routes/system_llm.py
+++ b/venom_core/api/routes/system_llm.py
@@ -282,6 +282,17 @@ async def _await_server_health(_server_name: str, health_url: str) -> bool:
             try:
                 resp = await client.get(health_url)
                 if 200 <= resp.status_code < 300:
+                    if _server_name == "gemma4_audio":
+                        status = _extract_health_status(resp)
+                        if status in {"ok", "ready", "running"}:
+                            logger.info("Serwer LLM gotowy po %.1fs", attempt * 0.5)
+                            return True
+                        if status in {"warming", "initializing", "loading"}:
+                            await asyncio.sleep(0.5)
+                            continue
+                        # Unknown or error-like status in payload - keep waiting.
+                        await asyncio.sleep(0.5)
+                        continue
                     logger.info("Serwer LLM gotowy po %.1fs", attempt * 0.5)
                     return True
             except Exception:
@@ -289,6 +300,20 @@ async def _await_server_health(_server_name: str, health_url: str) -> bool:
             await asyncio.sleep(0.5)
     logger.error("Serwer LLM nie odpowiedział prawidłowo po 30s")
     return False
+
+
+def _extract_health_status(response: httpx.Response) -> str | None:
+    try:
+        payload = response.json()
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    raw = payload.get("status")
+    if raw is None:
+        return None
+    normalized = str(raw).strip().lower()
+    return normalized or None
 
 
 def _resolve_local_endpoint(server_name: str, target: dict) -> str | None:

--- a/venom_core/api/routes/system_llm.py
+++ b/venom_core/api/routes/system_llm.py
@@ -281,18 +281,11 @@ async def _await_server_health(_server_name: str, health_url: str) -> bool:
         for attempt in range(60):
             try:
                 resp = await client.get(health_url)
-                if 200 <= resp.status_code < 300:
-                    if _server_name == "gemma4_audio":
-                        status = _extract_health_status(resp)
-                        if status in {"ok", "ready", "running"}:
-                            logger.info("Serwer LLM gotowy po %.1fs", attempt * 0.5)
-                            return True
-                        if status in {"warming", "initializing", "loading"}:
-                            await asyncio.sleep(0.5)
-                            continue
-                        # Unknown or error-like status in payload - keep waiting.
-                        await asyncio.sleep(0.5)
-                        continue
+                is_ready = _is_health_response_ready(
+                    server_name=_server_name,
+                    response=resp,
+                )
+                if is_ready is True:
                     logger.info("Serwer LLM gotowy po %.1fs", attempt * 0.5)
                     return True
             except Exception:
@@ -314,6 +307,15 @@ def _extract_health_status(response: httpx.Response) -> str | None:
         return None
     normalized = str(raw).strip().lower()
     return normalized or None
+
+
+def _is_health_response_ready(*, server_name: str, response: httpx.Response) -> bool:
+    if not (200 <= response.status_code < 300):
+        return False
+    if server_name != "gemma4_audio":
+        return True
+    status = _extract_health_status(response)
+    return status in {"ok", "ready", "running"}
 
 
 def _resolve_local_endpoint(server_name: str, target: dict) -> str | None:

--- a/venom_core/core/ollama_runtime_probe.py
+++ b/venom_core/core/ollama_runtime_probe.py
@@ -102,11 +102,11 @@ def _aggregate_probe_status(probes: dict[str, dict[str, Any]]) -> str:
         for probe_name, probe in probes.items()
         if probe_name != "show"
     ]
-    if show_status == "verified":
-        return "verified"
     if any(status == "metadata_only" for status in probe_statuses):
         return "metadata_only"
-    return "verified"
+    if show_status == "verified":
+        return "verified"
+    return show_status or "metadata_only"
 
 
 async def _record_optional_probe(

--- a/venom_core/core/ollama_runtime_probe.py
+++ b/venom_core/core/ollama_runtime_probe.py
@@ -102,13 +102,11 @@ def _aggregate_probe_status(probes: dict[str, dict[str, Any]]) -> str:
         for probe_name, probe in probes.items()
         if probe_name != "show"
     ]
-    if any(status == "failed" for status in probe_statuses):
-        return "failed"
-    if any(status == "metadata_only" for status in probe_statuses):
-        return "metadata_only"
     if show_status == "verified":
         return "verified"
-    return "metadata_only"
+    if any(status == "metadata_only" for status in probe_statuses):
+        return "metadata_only"
+    return "verified"
 
 
 async def _record_optional_probe(

--- a/venom_core/utils/llm_runtime.py
+++ b/venom_core/utils/llm_runtime.py
@@ -86,10 +86,24 @@ def get_active_llm_runtime(settings=None) -> LLMRuntimeInfo:
     mode = (settings.AI_MODE or "LOCAL").upper()
     model_name = settings.LLM_MODEL_NAME
     endpoint = settings.LLM_LOCAL_ENDPOINT
+    active_server = (getattr(settings, "ACTIVE_LLM_SERVER", "") or "").strip().lower()
 
     if service_type == "local":
-        endpoint = apply_http_policy_to_url(endpoint)
-        provider = infer_local_provider(endpoint)
+        if active_server == "gemma4_audio":
+            endpoint = getattr(settings, "GEMMA4_AUDIO_ENDPOINT", endpoint)
+            provider = "gemma4_audio"
+        elif active_server == "vllm":
+            endpoint = getattr(settings, "VLLM_ENDPOINT", endpoint)
+            provider = "vllm"
+        elif active_server == "ollama":
+            endpoint = apply_http_policy_to_url("http://localhost:11434/v1")
+            provider = "ollama"
+        elif active_server == "onnx":
+            provider = "onnx"
+            endpoint = None
+        else:
+            endpoint = apply_http_policy_to_url(endpoint)
+            provider = infer_local_provider(endpoint)
     elif service_type == "onnx":
         provider = "onnx"
         endpoint = None

--- a/venom_core/utils/llm_runtime.py
+++ b/venom_core/utils/llm_runtime.py
@@ -89,42 +89,17 @@ def get_active_llm_runtime(settings=None) -> LLMRuntimeInfo:
     active_server = (getattr(settings, "ACTIVE_LLM_SERVER", "") or "").strip().lower()
 
     if service_type == "local":
-        if active_server == "gemma4_audio":
-            endpoint = apply_http_policy_to_url(
-                getattr(settings, "GEMMA4_AUDIO_ENDPOINT", endpoint)
-            )
-            provider = "gemma4_audio"
-        elif active_server == "vllm":
-            endpoint = apply_http_policy_to_url(
-                getattr(settings, "VLLM_ENDPOINT", endpoint)
-            )
-            provider = "vllm"
-        elif active_server == "ollama":
-            candidate = apply_http_policy_to_url(endpoint)
-            if infer_local_provider(candidate) != "ollama":
-                candidate = apply_http_policy_to_url("http://localhost:11434/v1")
-            endpoint = candidate
-            provider = "ollama"
-        elif active_server == "onnx":
-            provider = "onnx"
-            endpoint = None
-        else:
-            endpoint = apply_http_policy_to_url(endpoint)
-            provider = infer_local_provider(endpoint)
-    elif service_type == "onnx":
-        provider = "onnx"
-        endpoint = None
-    elif service_type == "openai":
-        provider = "openai"
-        endpoint = endpoint or "https://api.openai.com/v1"
-    elif service_type == "google":
-        provider = "google-gemini"
-        endpoint = endpoint or "https://generativelanguage.googleapis.com"
-    elif service_type == "azure":
-        provider = "azure-openai"
-        endpoint = endpoint or getattr(settings, "AZURE_OPENAI_ENDPOINT", None)
+        provider, endpoint = _resolve_local_runtime(
+            active_server=active_server,
+            endpoint=endpoint,
+            settings=settings,
+        )
     else:
-        provider = service_type
+        provider, endpoint = _resolve_non_local_runtime(
+            service_type=service_type,
+            endpoint=endpoint,
+            settings=settings,
+        )
 
     config_hash = compute_llm_config_hash(provider, endpoint, model_name)
     runtime_id = compute_runtime_id(provider, endpoint)
@@ -138,6 +113,48 @@ def get_active_llm_runtime(settings=None) -> LLMRuntimeInfo:
         config_hash=config_hash,
         runtime_id=runtime_id,
     )
+
+
+def _resolve_local_runtime(
+    *, active_server: str, endpoint: Optional[str], settings
+) -> Tuple[str, Optional[str]]:
+    if active_server == "gemma4_audio":
+        return (
+            "gemma4_audio",
+            apply_http_policy_to_url(
+                getattr(settings, "GEMMA4_AUDIO_ENDPOINT", endpoint)
+            ),
+        )
+    if active_server == "vllm":
+        return (
+            "vllm",
+            apply_http_policy_to_url(getattr(settings, "VLLM_ENDPOINT", endpoint)),
+        )
+    if active_server == "ollama":
+        candidate = apply_http_policy_to_url(endpoint)
+        if infer_local_provider(candidate) != "ollama":
+            candidate = apply_http_policy_to_url("http://localhost:11434/v1")
+        return "ollama", candidate
+    if active_server == "onnx":
+        return "onnx", None
+    normalized_endpoint = apply_http_policy_to_url(endpoint)
+    return infer_local_provider(normalized_endpoint), normalized_endpoint
+
+
+def _resolve_non_local_runtime(
+    *, service_type: str, endpoint: Optional[str], settings
+) -> Tuple[str, Optional[str]]:
+    if service_type == "onnx":
+        return "onnx", None
+    if service_type == "openai":
+        return "openai", endpoint or "https://api.openai.com/v1"
+    if service_type == "google":
+        return "google-gemini", endpoint or "https://generativelanguage.googleapis.com"
+    if service_type == "azure":
+        return "azure-openai", endpoint or getattr(
+            settings, "AZURE_OPENAI_ENDPOINT", None
+        )
+    return service_type, endpoint
 
 
 def format_runtime_label(runtime: LLMRuntimeInfo) -> str:

--- a/venom_core/utils/llm_runtime.py
+++ b/venom_core/utils/llm_runtime.py
@@ -90,13 +90,20 @@ def get_active_llm_runtime(settings=None) -> LLMRuntimeInfo:
 
     if service_type == "local":
         if active_server == "gemma4_audio":
-            endpoint = getattr(settings, "GEMMA4_AUDIO_ENDPOINT", endpoint)
+            endpoint = apply_http_policy_to_url(
+                getattr(settings, "GEMMA4_AUDIO_ENDPOINT", endpoint)
+            )
             provider = "gemma4_audio"
         elif active_server == "vllm":
-            endpoint = getattr(settings, "VLLM_ENDPOINT", endpoint)
+            endpoint = apply_http_policy_to_url(
+                getattr(settings, "VLLM_ENDPOINT", endpoint)
+            )
             provider = "vllm"
         elif active_server == "ollama":
-            endpoint = apply_http_policy_to_url("http://localhost:11434/v1")
+            candidate = apply_http_policy_to_url(endpoint)
+            if infer_local_provider(candidate) != "ollama":
+                candidate = apply_http_policy_to_url("http://localhost:11434/v1")
+            endpoint = candidate
             provider = "ollama"
         elif active_server == "onnx":
             provider = "onnx"

--- a/web-next/components/gemma4/gemma4-runtime-control.tsx
+++ b/web-next/components/gemma4/gemma4-runtime-control.tsx
@@ -25,22 +25,56 @@ const CACHE_OPTIONS = [
 
 type Variant = "cockpit" | "voice";
 
+type RuntimeSnapshotLike = Readonly<{
+  runtime_id?: string | null;
+  provider?: string | null;
+  model_name?: string | null;
+  endpoint?: string | null;
+  config_hash?: string | null;
+  runtime_capabilities?: {
+    compatibility_profile?: string | null;
+    probe_status?: string | null;
+    capabilities?: Record<string, boolean | string | null | undefined>;
+    probes?: Record<string, { status?: string | null; reason?: string | null }>;
+    fallbacks?: Record<string, string | null | undefined>;
+  } | null;
+  voice_pipeline?: {
+    profile?: string | null;
+    stt?: string | null;
+    reasoning?: string | null;
+    tools?: string | null;
+    vision?: string | null;
+    tts?: string | null;
+    notes?: string[] | null;
+  } | null;
+  error?: string | null;
+}> | null;
+
 type Props = Readonly<{
   variant?: Variant;
   pollingIntervalMs?: number;
+  runtimeSnapshot?: RuntimeSnapshotLike;
 }>;
 
 export function Gemma4RuntimeControl({
   variant = "voice",
   pollingIntervalMs,
+  runtimeSnapshot = null,
 }: Props) {
   const daemon = useGemma4Daemon(pollingIntervalMs);
-  return <Gemma4RuntimeControlInner daemon={daemon} variant={variant} />;
+  return (
+    <Gemma4RuntimeControlInner
+      daemon={daemon}
+      variant={variant}
+      runtimeSnapshot={runtimeSnapshot}
+    />
+  );
 }
 
 type InnerProps = Readonly<{
   daemon: Gemma4DaemonState;
   variant: Variant;
+  runtimeSnapshot?: RuntimeSnapshotLike;
 }>;
 
 function vramBarColor(pct: number): string {
@@ -54,7 +88,11 @@ function parseTokenInput(raw: string): number | undefined {
   return Number.isNaN(n) || n <= 0 ? undefined : n;
 }
 
-export function Gemma4RuntimeControlInner({ daemon, variant }: InnerProps) {
+export function Gemma4RuntimeControlInner({
+  daemon,
+  variant,
+  runtimeSnapshot = null,
+}: InnerProps) {
   const t = useTranslation();
   const { status, loading, error, actionPending } = daemon;
 
@@ -115,10 +153,14 @@ export function Gemma4RuntimeControlInner({ daemon, variant }: InnerProps) {
   }
 
   if (error && !status) {
+    const hasRuntimeSnapshot = Boolean(runtimeSnapshot?.provider || runtimeSnapshot?.model_name);
     return (
       <DaemonCard variant={variant}>
         <p className="text-xs text-rose-400 py-1">{t("voice.daemon.daemonUnavailable")}</p>
         <p className="text-[10px] text-zinc-500 truncate">{error}</p>
+        {hasRuntimeSnapshot && (
+          <RuntimeSnapshotSummary snapshot={runtimeSnapshot} />
+        )}
       </DaemonCard>
     );
   }
@@ -156,6 +198,10 @@ export function Gemma4RuntimeControlInner({ daemon, variant }: InnerProps) {
           <span className="font-semibold">{t("voice.daemon.reloadRequired")}: </span>
           {status.reload_reason}
         </div>
+      )}
+
+      {runtimeSnapshot && (
+        <RuntimeSnapshotSummary snapshot={runtimeSnapshot} compact />
       )}
 
       {/* Params */}
@@ -358,6 +404,49 @@ function VramSection({
             style={{ width: `${vramPercent}%` }}
           />
         </div>
+      )}
+    </div>
+  );
+}
+
+type RuntimeSnapshotSummaryProps = Readonly<{
+  snapshot: RuntimeSnapshotLike;
+  compact?: boolean;
+}>;
+
+function RuntimeSnapshotSummary({
+  snapshot,
+  compact = false,
+}: RuntimeSnapshotSummaryProps) {
+  const t = useTranslation();
+  if (!snapshot) return null;
+
+  const provider = snapshot.provider ?? "—";
+  const model = snapshot.model_name ?? "—";
+  const profile = snapshot.runtime_capabilities?.compatibility_profile ?? snapshot.voice_pipeline?.profile ?? null;
+  const title = t("voice.daemon.runtimeSnapshot");
+
+  return (
+    <div className={`mb-3 rounded-lg border border-white/[0.06] bg-white/[0.02] p-2.5 ${compact ? "" : "mt-2"}`}>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[10px] uppercase tracking-widest text-zinc-500">{title}</span>
+        {snapshot.runtime_capabilities?.probe_status && (
+          <span className="text-[10px] text-zinc-400">
+            {snapshot.runtime_capabilities.probe_status}
+          </span>
+        )}
+      </div>
+      <p className="mt-1 text-xs text-white truncate">
+        {provider} / {model}
+      </p>
+      {profile && (
+        <p className="mt-0.5 text-[10px] text-zinc-500 truncate">profile: {profile}</p>
+      )}
+      {snapshot.voice_pipeline?.tts && (
+        <p className="mt-0.5 text-[10px] text-zinc-500 truncate">tts: {snapshot.voice_pipeline.tts}</p>
+      )}
+      {snapshot.error && (
+        <p className="mt-0.5 text-[10px] text-rose-400 truncate">{snapshot.error}</p>
       )}
     </div>
   );

--- a/web-next/components/gemma4/gemma4-runtime-control.tsx
+++ b/web-next/components/gemma4/gemma4-runtime-control.tsx
@@ -288,48 +288,34 @@ export function Gemma4RuntimeControlInner({
             : t("voice.daemon.applyConfig")}
         </Button>
 
-        <ConfirmDialog>
-          <ConfirmDialogTrigger asChild>
-            <Button size="xs" variant="secondary" disabled={busy} data-testid="reload-button">
-              {actionPending === "reload"
-                ? t("voice.daemon.reloading")
-                : t("voice.daemon.reload")}
-            </Button>
-          </ConfirmDialogTrigger>
-          <ConfirmDialogContent>
-            <ConfirmDialogTitle>{t("voice.daemon.confirmReloadTitle")}</ConfirmDialogTitle>
-            <ConfirmDialogDescription>
-              {t("voice.daemon.confirmReloadDesc")}
-            </ConfirmDialogDescription>
-            <ConfirmDialogActions
-              onConfirm={daemon.reload}
-              onCancel={() => {}}
-              confirmLabel={t("voice.daemon.reload")}
-            />
-          </ConfirmDialogContent>
-        </ConfirmDialog>
+        <DaemonConfirmActionButton
+          buttonVariant="secondary"
+          busy={busy}
+          actionPending={actionPending}
+          actionName="reload"
+          pendingLabel={t("voice.daemon.reloading")}
+          buttonLabel={t("voice.daemon.reload")}
+          title={t("voice.daemon.confirmReloadTitle")}
+          description={t("voice.daemon.confirmReloadDesc")}
+          confirmLabel={t("voice.daemon.reload")}
+          onConfirm={daemon.reload}
+          testId="reload-button"
+        />
 
-        <ConfirmDialog>
-          <ConfirmDialogTrigger asChild>
-            <Button size="xs" variant="ghost" disabled={busy} data-testid="restart-button">
-              {actionPending === "restart"
-                ? t("voice.daemon.restarting")
-                : t("voice.daemon.restart")}
-            </Button>
-          </ConfirmDialogTrigger>
-          <ConfirmDialogContent>
-            <ConfirmDialogTitle>{t("voice.daemon.confirmRestartTitle")}</ConfirmDialogTitle>
-            <ConfirmDialogDescription>
-              {t("voice.daemon.confirmRestartDesc")}
-            </ConfirmDialogDescription>
-            <ConfirmDialogActions
-              onConfirm={daemon.restart}
-              onCancel={() => {}}
-              confirmLabel={t("voice.daemon.restart")}
-              confirmVariant="danger"
-            />
-          </ConfirmDialogContent>
-        </ConfirmDialog>
+        <DaemonConfirmActionButton
+          buttonVariant="ghost"
+          busy={busy}
+          actionPending={actionPending}
+          actionName="restart"
+          pendingLabel={t("voice.daemon.restarting")}
+          buttonLabel={t("voice.daemon.restart")}
+          title={t("voice.daemon.confirmRestartTitle")}
+          description={t("voice.daemon.confirmRestartDesc")}
+          confirmLabel={t("voice.daemon.restart")}
+          confirmVariant="danger"
+          onConfirm={daemon.restart}
+          testId="restart-button"
+        />
 
         <Button
           size="xs"
@@ -553,5 +539,55 @@ function DaemonCard({
       </p>
       {children}
     </div>
+  );
+}
+
+type DaemonConfirmActionButtonProps = Readonly<{
+  busy: boolean;
+  actionPending: string | null;
+  actionName: string;
+  pendingLabel: string;
+  buttonLabel: string;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  onConfirm: () => void | Promise<void>;
+  buttonVariant: "ghost" | "secondary";
+  confirmVariant?: "default" | "danger";
+  testId: string;
+}>;
+
+function DaemonConfirmActionButton({
+  busy,
+  actionPending,
+  actionName,
+  pendingLabel,
+  buttonLabel,
+  title,
+  description,
+  confirmLabel,
+  onConfirm,
+  buttonVariant,
+  confirmVariant,
+  testId,
+}: DaemonConfirmActionButtonProps) {
+  return (
+    <ConfirmDialog>
+      <ConfirmDialogTrigger asChild>
+        <Button size="xs" variant={buttonVariant} disabled={busy} data-testid={testId}>
+          {actionPending === actionName ? pendingLabel : buttonLabel}
+        </Button>
+      </ConfirmDialogTrigger>
+      <ConfirmDialogContent>
+        <ConfirmDialogTitle>{title}</ConfirmDialogTitle>
+        <ConfirmDialogDescription>{description}</ConfirmDialogDescription>
+        <ConfirmDialogActions
+          onConfirm={onConfirm}
+          onCancel={() => {}}
+          confirmLabel={confirmLabel}
+          confirmVariant={confirmVariant}
+        />
+      </ConfirmDialogContent>
+    </ConfirmDialog>
   );
 }

--- a/web-next/components/gemma4/gemma4-runtime-control.tsx
+++ b/web-next/components/gemma4/gemma4-runtime-control.tsx
@@ -288,33 +288,7 @@ export function Gemma4RuntimeControlInner({
             : t("voice.daemon.applyConfig")}
         </Button>
 
-        {[
-          {
-            key: "reload",
-            buttonVariant: "secondary" as const,
-            actionName: "reload",
-            pendingLabel: t("voice.daemon.reloading"),
-            buttonLabel: t("voice.daemon.reload"),
-            title: t("voice.daemon.confirmReloadTitle"),
-            description: t("voice.daemon.confirmReloadDesc"),
-            confirmLabel: t("voice.daemon.reload"),
-            onConfirm: daemon.reload,
-            testId: "reload-button",
-          },
-          {
-            key: "restart",
-            buttonVariant: "ghost" as const,
-            actionName: "restart",
-            pendingLabel: t("voice.daemon.restarting"),
-            buttonLabel: t("voice.daemon.restart"),
-            title: t("voice.daemon.confirmRestartTitle"),
-            description: t("voice.daemon.confirmRestartDesc"),
-            confirmLabel: t("voice.daemon.restart"),
-            confirmVariant: "danger" as const,
-            onConfirm: daemon.restart,
-            testId: "restart-button",
-          },
-        ].map((action) => (
+        {buildDaemonConfirmActions({ t, daemon }).map((action) => (
           <DaemonConfirmActionButton
             key={action.key}
             buttonVariant={action.buttonVariant}
@@ -539,22 +513,73 @@ function DaemonCard({
   children,
 }: Readonly<{ variant: Variant; children: React.ReactNode }>) {
   const t = useTranslation();
-  if (variant === "voice") {
-    return (
-      <div className="rounded-2xl border border-white/[0.07] bg-white/[0.03] p-3 text-xs text-zinc-300">
-        <p className="eyebrow mb-2">{t("voice.daemon.title")}</p>
-        {children}
-      </div>
-    );
-  }
+  const cardClass =
+    variant === "voice"
+      ? "rounded-2xl border border-white/[0.07] bg-white/[0.03] p-3 text-xs text-zinc-300"
+      : "mt-3 rounded-xl border border-white/10 bg-white/[0.03] p-3 text-xs text-zinc-400";
+  const titleClass =
+    variant === "voice"
+      ? "eyebrow mb-2"
+      : "mb-2 text-[10px] uppercase tracking-widest text-zinc-500";
+
   return (
-    <div className="mt-3 rounded-xl border border-white/10 bg-white/[0.03] p-3 text-xs text-zinc-400">
-      <p className="mb-2 text-[10px] uppercase tracking-widest text-zinc-500">
-        {t("voice.daemon.title")}
-      </p>
+    <div className={cardClass}>
+      <p className={titleClass}>{t("voice.daemon.title")}</p>
       {children}
     </div>
   );
+}
+
+type ConfirmActionDefinition = Readonly<{
+  key: "reload" | "restart";
+  buttonVariant: "ghost" | "secondary";
+  confirmVariant?: "default" | "danger";
+  onConfirm: () => void | Promise<void>;
+}>;
+
+function buildDaemonConfirmActions({
+  t,
+  daemon,
+}: Readonly<{
+  t: (key: string) => string;
+  daemon: Gemma4DaemonState;
+}>): Array<DaemonConfirmActionButtonProps & { key: string }> {
+  const defs: ConfirmActionDefinition[] = [
+    {
+      key: "reload",
+      buttonVariant: "secondary",
+      onConfirm: daemon.reload,
+    },
+    {
+      key: "restart",
+      buttonVariant: "ghost",
+      confirmVariant: "danger",
+      onConfirm: daemon.restart,
+    },
+  ];
+
+  return defs.map((def) => {
+    const isReload = def.key === "reload";
+    return {
+      key: def.key,
+      buttonVariant: def.buttonVariant,
+      busy: false, // overridden at render call site
+      actionPending: null, // overridden at render call site
+      actionName: def.key,
+      pendingLabel: isReload ? t("voice.daemon.reloading") : t("voice.daemon.restarting"),
+      buttonLabel: isReload ? t("voice.daemon.reload") : t("voice.daemon.restart"),
+      title: isReload
+        ? t("voice.daemon.confirmReloadTitle")
+        : t("voice.daemon.confirmRestartTitle"),
+      description: isReload
+        ? t("voice.daemon.confirmReloadDesc")
+        : t("voice.daemon.confirmRestartDesc"),
+      confirmLabel: isReload ? t("voice.daemon.reload") : t("voice.daemon.restart"),
+      onConfirm: def.onConfirm,
+      confirmVariant: def.confirmVariant,
+      testId: isReload ? "reload-button" : "restart-button",
+    };
+  });
 }
 
 type DaemonConfirmActionButtonProps = Readonly<{

--- a/web-next/components/gemma4/gemma4-runtime-control.tsx
+++ b/web-next/components/gemma4/gemma4-runtime-control.tsx
@@ -440,10 +440,14 @@ function RuntimeSnapshotSummary({
         {provider} / {model}
       </p>
       {profile && (
-        <p className="mt-0.5 text-[10px] text-zinc-500 truncate">profile: {profile}</p>
+        <p className="mt-0.5 text-[10px] text-zinc-500 truncate">
+          {t("voice.controls.profile")}: {profile}
+        </p>
       )}
       {snapshot.voice_pipeline?.tts && (
-        <p className="mt-0.5 text-[10px] text-zinc-500 truncate">tts: {snapshot.voice_pipeline.tts}</p>
+        <p className="mt-0.5 text-[10px] text-zinc-500 truncate">
+          {t("voice.controls.tts")}: {snapshot.voice_pipeline.tts}
+        </p>
       )}
       {snapshot.error && (
         <p className="mt-0.5 text-[10px] text-rose-400 truncate">{snapshot.error}</p>

--- a/web-next/components/gemma4/gemma4-runtime-control.tsx
+++ b/web-next/components/gemma4/gemma4-runtime-control.tsx
@@ -288,34 +288,49 @@ export function Gemma4RuntimeControlInner({
             : t("voice.daemon.applyConfig")}
         </Button>
 
-        <DaemonConfirmActionButton
-          buttonVariant="secondary"
-          busy={busy}
-          actionPending={actionPending}
-          actionName="reload"
-          pendingLabel={t("voice.daemon.reloading")}
-          buttonLabel={t("voice.daemon.reload")}
-          title={t("voice.daemon.confirmReloadTitle")}
-          description={t("voice.daemon.confirmReloadDesc")}
-          confirmLabel={t("voice.daemon.reload")}
-          onConfirm={daemon.reload}
-          testId="reload-button"
-        />
-
-        <DaemonConfirmActionButton
-          buttonVariant="ghost"
-          busy={busy}
-          actionPending={actionPending}
-          actionName="restart"
-          pendingLabel={t("voice.daemon.restarting")}
-          buttonLabel={t("voice.daemon.restart")}
-          title={t("voice.daemon.confirmRestartTitle")}
-          description={t("voice.daemon.confirmRestartDesc")}
-          confirmLabel={t("voice.daemon.restart")}
-          confirmVariant="danger"
-          onConfirm={daemon.restart}
-          testId="restart-button"
-        />
+        {[
+          {
+            key: "reload",
+            buttonVariant: "secondary" as const,
+            actionName: "reload",
+            pendingLabel: t("voice.daemon.reloading"),
+            buttonLabel: t("voice.daemon.reload"),
+            title: t("voice.daemon.confirmReloadTitle"),
+            description: t("voice.daemon.confirmReloadDesc"),
+            confirmLabel: t("voice.daemon.reload"),
+            onConfirm: daemon.reload,
+            testId: "reload-button",
+          },
+          {
+            key: "restart",
+            buttonVariant: "ghost" as const,
+            actionName: "restart",
+            pendingLabel: t("voice.daemon.restarting"),
+            buttonLabel: t("voice.daemon.restart"),
+            title: t("voice.daemon.confirmRestartTitle"),
+            description: t("voice.daemon.confirmRestartDesc"),
+            confirmLabel: t("voice.daemon.restart"),
+            confirmVariant: "danger" as const,
+            onConfirm: daemon.restart,
+            testId: "restart-button",
+          },
+        ].map((action) => (
+          <DaemonConfirmActionButton
+            key={action.key}
+            buttonVariant={action.buttonVariant}
+            busy={busy}
+            actionPending={actionPending}
+            actionName={action.actionName}
+            pendingLabel={action.pendingLabel}
+            buttonLabel={action.buttonLabel}
+            title={action.title}
+            description={action.description}
+            confirmLabel={action.confirmLabel}
+            confirmVariant={action.confirmVariant}
+            onConfirm={action.onConfirm}
+            testId={action.testId}
+          />
+        ))}
 
         <Button
           size="xs"

--- a/web-next/components/ui/dynamic-parameter-form.tsx
+++ b/web-next/components/ui/dynamic-parameter-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import type { GenerationSchema, GenerationParameterSchema } from "@/lib/types";
 export type { GenerationSchema } from "@/lib/types";
@@ -174,19 +174,6 @@ export function DynamicParameterForm({
   );
   const values = isControlled ? initialValues : localValues;
 
-  // Wywołaj onChange gdy wartości się zmienią
-  // Używamy ref aby uniknąć problemów z zależnościami i potencjalnych pętli
-  const onChangeRef = useRef(onChange);
-  useEffect(() => {
-    onChangeRef.current = onChange;
-  }, [onChange]);
-
-  useEffect(() => {
-    if (onChangeRef.current) {
-      onChangeRef.current(values);
-    }
-  }, [values]);
-
   const handleValueChange = (
     name: string,
     value: ParameterValue,
@@ -198,8 +185,8 @@ export function DynamicParameterForm({
     if (!isControlled) {
       setLocalValues(nextValues);
     }
-    if (onChangeRef.current) {
-      onChangeRef.current(nextValues);
+    if (onChange) {
+      onChange(nextValues);
     }
   };
 
@@ -207,8 +194,8 @@ export function DynamicParameterForm({
     if (!isControlled) {
       setLocalValues(defaultValues);
     }
-    if (onChangeRef.current) {
-      onChangeRef.current(defaultValues);
+    if (onChange) {
+      onChange(defaultValues);
     }
     if (onReset) {
       onReset();

--- a/web-next/components/voice/voice-status-sidebar.tsx
+++ b/web-next/components/voice/voice-status-sidebar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { Badge } from "@/components/ui/badge";
-import { Gemma4RuntimeControl } from "@/components/gemma4/gemma4-runtime-control";
 import type { VoiceStatusUpdate } from "@/components/voice/voice-command-center";
 import { useTranslation } from "@/lib/i18n";
 
@@ -35,32 +34,35 @@ function Row({ label, value }: Readonly<{ label: string; value: React.ReactNode 
 
 export function VoiceStatusSidebar({ status }: VoiceStatusSidebarProps) {
   const t = useTranslation();
+  const runtime = status?.runtime_snapshot ?? null;
 
   if (!status) {
     return (
       <div className="space-y-3">
-        <Gemma4RuntimeControl variant="voice" />
+        <RuntimeOverviewCard
+          runtime={null}
+          title={t("voice.controls.runtime")}
+          loadingLabel={t("voice.status.channelConnecting")}
+        />
         <StatusCard title={`${t("voice.controls.stt")} / ${t("voice.controls.tts")}`}>
           <p className="text-hint text-xs py-2">{t("voice.status.channelConnecting")}</p>
         </StatusCard>
-        <StatusCard title={t("voice.controls.runtime")}>
+        <StatusCard title={t("voice.controls.tts")}>
           <p className="text-hint text-xs py-2">{t("voice.status.noData")}</p>
         </StatusCard>
       </div>
     );
   }
 
-  const runtime = status.runtime_snapshot;
-  const pipeline = runtime?.voice_pipeline;
-  const caps = runtime?.runtime_capabilities;
-  const probeStatus = caps?.probe_status;
   const deps = status.dependencies ?? {};
   const depKeys = Object.keys(deps);
 
   return (
     <div className="space-y-3">
-      {/* Gemma 4 daemon controls */}
-      <Gemma4RuntimeControl variant="voice" />
+      <RuntimeOverviewCard
+        runtime={runtime}
+        title={t("voice.controls.runtime")}
+      />
 
       {/* STT / TTS box */}
       <StatusCard title={`${t("voice.controls.stt")} / ${t("voice.controls.tts")}`}>
@@ -107,38 +109,58 @@ export function VoiceStatusSidebar({ status }: VoiceStatusSidebarProps) {
         )}
       </StatusCard>
 
-      {/* Runtime box */}
-      <StatusCard title={t("voice.controls.runtime")}>
-        {runtime ? (
-          <>
-            <div className="flex items-center justify-between gap-2 mb-2">
-              <span className="text-sm font-semibold text-white truncate">
-                {runtime.model_name ?? t("voice.controls.unknownModel")}
-              </span>
-              {probeStatus && (
-                <Badge tone={getProbeTone(probeStatus)} className="shrink-0 text-[10px]">
-                  {probeStatus}
-                </Badge>
-              )}
-            </div>
-            {runtime.provider && (
-              <Row label={t("voice.controls.provider")} value={runtime.provider} />
-            )}
-            {caps?.compatibility_profile && (
-              <Row label={t("voice.controls.profile")} value={caps.compatibility_profile} />
-            )}
-            {pipeline?.stt && <Row label={t("voice.controls.stt")} value={pipeline.stt} />}
-            {pipeline?.reasoning && <Row label={t("voice.controls.pipeline")} value={pipeline.reasoning} />}
-            {pipeline?.tts && <Row label={t("voice.controls.tts")} value={pipeline.tts} />}
-            {runtime.error && (
-              <p className="mt-1 text-[11px] text-rose-300">{runtime.error}</p>
-            )}
-          </>
-        ) : (
-          <p className="text-hint text-xs py-2">{t("voice.controls.noRuntimeSnapshot")}</p>
-        )}
-      </StatusCard>
     </div>
+  );
+}
+
+function RuntimeOverviewCard({
+  runtime,
+  title,
+  loadingLabel,
+}: Readonly<{
+  runtime: VoiceStatusUpdate["runtime_snapshot"];
+  title: string;
+  loadingLabel?: string;
+}>) {
+  const profile = runtime?.runtime_capabilities?.compatibility_profile ?? runtime?.voice_pipeline?.profile ?? null;
+  const provider = runtime?.provider ?? null;
+  const model = runtime?.model_name ?? null;
+  const endpoint = runtime?.endpoint ?? null;
+  const probeStatus = runtime?.runtime_capabilities?.probe_status ?? null;
+  const t = useTranslation();
+
+  return (
+    <StatusCard title={title}>
+      {runtime ? (
+        <>
+          <div className="flex items-center justify-between gap-2 mb-2">
+            <span className="text-sm font-semibold text-white truncate">
+              {provider ?? t("voice.controls.unknownModel")} / {model ?? "—"}
+            </span>
+            {probeStatus && (
+              <Badge tone={getProbeTone(probeStatus)} className="shrink-0 text-[10px]">
+                {probeStatus}
+              </Badge>
+            )}
+          </div>
+          {provider && <Row label={t("voice.controls.provider")} value={provider} />}
+          {endpoint && <Row label="endpoint" value={endpoint} />}
+          {profile && <Row label={t("voice.controls.profile")} value={profile} />}
+          {runtime.voice_pipeline?.stt && (
+            <Row label={t("voice.controls.stt")} value={runtime.voice_pipeline.stt} />
+          )}
+          {runtime.voice_pipeline?.reasoning && (
+            <Row label={t("voice.controls.pipeline")} value={runtime.voice_pipeline.reasoning} />
+          )}
+          {runtime.voice_pipeline?.tts && (
+            <Row label={t("voice.controls.tts")} value={runtime.voice_pipeline.tts} />
+          )}
+          {runtime.error && <p className="mt-1 text-[11px] text-rose-300">{runtime.error}</p>}
+        </>
+      ) : (
+        <p className="text-hint text-xs py-2">{loadingLabel ?? t("voice.status.noData")}</p>
+      )}
+    </StatusCard>
   );
 }
 

--- a/web-next/components/voice/voice-status-sidebar.tsx
+++ b/web-next/components/voice/voice-status-sidebar.tsx
@@ -47,9 +47,6 @@ export function VoiceStatusSidebar({ status }: VoiceStatusSidebarProps) {
         <StatusCard title={`${t("voice.controls.stt")} / ${t("voice.controls.tts")}`}>
           <p className="text-hint text-xs py-2">{t("voice.status.channelConnecting")}</p>
         </StatusCard>
-        <StatusCard title={t("voice.controls.tts")}>
-          <p className="text-hint text-xs py-2">{t("voice.status.noData")}</p>
-        </StatusCard>
       </div>
     );
   }
@@ -135,7 +132,7 @@ function RuntimeOverviewCard({
         <>
           <div className="flex items-center justify-between gap-2 mb-2">
             <span className="text-sm font-semibold text-white truncate">
-              {provider ?? t("voice.controls.unknownModel")} / {model ?? "—"}
+              {provider ?? "—"} / {model ?? t("voice.controls.unknownModel")}
             </span>
             {probeStatus && (
               <Badge tone={getProbeTone(probeStatus)} className="shrink-0 text-[10px]">
@@ -144,7 +141,7 @@ function RuntimeOverviewCard({
             )}
           </div>
           {provider && <Row label={t("voice.controls.provider")} value={provider} />}
-          {endpoint && <Row label="endpoint" value={endpoint} />}
+          {endpoint && <Row label={t("voice.controls.endpoint")} value={endpoint} />}
           {profile && <Row label={t("voice.controls.profile")} value={profile} />}
           {runtime.voice_pipeline?.stt && (
             <Row label={t("voice.controls.stt")} value={runtime.voice_pipeline.stt} />

--- a/web-next/components/voice/voice-status-sidebar.tsx
+++ b/web-next/components/voice/voice-status-sidebar.tsx
@@ -1,8 +1,13 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { SelectMenu } from "@/components/ui/select-menu";
+import { Gemma4RuntimeControl } from "@/components/gemma4/gemma4-runtime-control";
 import type { VoiceStatusUpdate } from "@/components/voice/voice-command-center";
 import { useTranslation } from "@/lib/i18n";
+import { useRuntime } from "@/components/models/hooks/use-runtime";
 
 type VoiceStatusSidebarProps = Readonly<{
   status: VoiceStatusUpdate | null;
@@ -35,15 +40,20 @@ function Row({ label, value }: Readonly<{ label: string; value: React.ReactNode 
 export function VoiceStatusSidebar({ status }: VoiceStatusSidebarProps) {
   const t = useTranslation();
   const runtime = status?.runtime_snapshot ?? null;
+  const isGemma4AudioRuntime =
+    (runtime?.provider ?? "").toLowerCase() === "gemma4_audio" ||
+    (runtime?.runtime_id ?? "").toLowerCase() === "gemma4_audio";
 
   if (!status) {
     return (
       <div className="space-y-3">
+        <RuntimeSwitchCard />
         <RuntimeOverviewCard
           runtime={null}
           title={t("voice.controls.runtime")}
           loadingLabel={t("voice.status.channelConnecting")}
         />
+        <Gemma4RuntimeControl variant="voice" runtimeSnapshot={null} />
         <StatusCard title={`${t("voice.controls.stt")} / ${t("voice.controls.tts")}`}>
           <p className="text-hint text-xs py-2">{t("voice.status.channelConnecting")}</p>
         </StatusCard>
@@ -56,10 +66,14 @@ export function VoiceStatusSidebar({ status }: VoiceStatusSidebarProps) {
 
   return (
     <div className="space-y-3">
+      <RuntimeSwitchCard />
       <RuntimeOverviewCard
         runtime={runtime}
         title={t("voice.controls.runtime")}
       />
+      {isGemma4AudioRuntime && (
+        <Gemma4RuntimeControl variant="voice" runtimeSnapshot={runtime} />
+      )}
 
       {/* STT / TTS box */}
       <StatusCard title={`${t("voice.controls.stt")} / ${t("voice.controls.tts")}`}>
@@ -107,6 +121,104 @@ export function VoiceStatusSidebar({ status }: VoiceStatusSidebarProps) {
       </StatusCard>
 
     </div>
+  );
+}
+
+function RuntimeSwitchCard() {
+  const t = useTranslation();
+  const runtime = useRuntime();
+  const [pending, setPending] = useState(false);
+  const selectedRuntime = runtime.selectedServer ?? "";
+  const selectedModel = runtime.selectedModel ?? "";
+  const applyDisabled = pending || !selectedRuntime || !selectedModel;
+  const runtimeError = runtime.activeServer.error ?? runtime.llmServers.error;
+
+  const serverOptions = useMemo(
+    () => runtime.serverOptions.map((item) => ({ value: item.value, label: item.label })),
+    [runtime.serverOptions],
+  );
+  const modelOptions = useMemo(
+    () => runtime.modelOptions.map((item) => ({ value: item.value, label: item.label })),
+    [runtime.modelOptions],
+  );
+
+  const handleApply = async () => {
+    if (applyDisabled) return;
+    setPending(true);
+    try {
+      await runtime.activateRuntimeSelection(selectedRuntime, selectedModel);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <StatusCard title={t("voice.controls.runtime")}>
+      <div className="space-y-2.5">
+        <div>
+          <p className="text-caption mb-1">{t("voice.controls.provider")}</p>
+          <SelectMenu
+            value={selectedRuntime}
+            options={serverOptions}
+            onChange={(value) => runtime.setSelectedServer(value || null)}
+            placeholder={t("voice.controls.runtime")}
+            className="w-full"
+            disabled={pending || serverOptions.length === 0}
+            buttonClassName="w-full justify-between rounded-full border border-[color:var(--ui-border)] bg-[color:var(--ui-surface)] px-3 py-1.5 text-xs font-medium normal-case tracking-normal text-[color:var(--text-primary)] hover:border-[color:var(--ui-border-strong)] hover:bg-[color:var(--ui-surface-hover)] overflow-hidden"
+            renderButton={(opt) => (
+              <span className="flex-1 truncate text-left text-[color:var(--text-primary)]">
+                {opt?.label ?? t("voice.controls.runtime")}
+              </span>
+            )}
+            renderOption={(opt) => (
+              <span className="w-full text-left text-sm normal-case tracking-normal text-[color:var(--text-primary)]">
+                {opt.label}
+              </span>
+            )}
+          />
+        </div>
+
+        <div>
+          <p className="text-caption mb-1">Model</p>
+          <SelectMenu
+            value={selectedModel}
+            options={modelOptions}
+            onChange={(value) => runtime.setSelectedModel(value || null)}
+            placeholder={t("voice.controls.runtime")}
+            className="w-full"
+            disabled={pending || modelOptions.length === 0}
+            buttonClassName="w-full justify-between rounded-full border border-[color:var(--ui-border)] bg-[color:var(--ui-surface)] px-3 py-1.5 text-xs font-medium normal-case tracking-normal text-[color:var(--text-primary)] hover:border-[color:var(--ui-border-strong)] hover:bg-[color:var(--ui-surface-hover)] overflow-hidden"
+            renderButton={(opt) => (
+              <span className="flex-1 truncate text-left text-[color:var(--text-primary)]">
+                {opt?.label ?? t("voice.controls.runtime")}
+              </span>
+            )}
+            renderOption={(opt) => (
+              <span className="w-full text-left text-sm normal-case tracking-normal text-[color:var(--text-primary)]">
+                {opt.label}
+              </span>
+            )}
+          />
+        </div>
+
+        <Button
+          type="button"
+          size="xs"
+          variant="primary"
+          onClick={handleApply}
+          disabled={applyDisabled}
+          className="w-full"
+        >
+          {pending ? t("voice.controls.refreshing") : t("voice.controls.refresh")}
+        </Button>
+
+        {runtimeError && (
+          <p className="text-[11px] text-rose-300 truncate">
+            {runtimeError.message}
+          </p>
+        )}
+      </div>
+    </StatusCard>
   );
 }
 

--- a/web-next/lib/i18n/locales/voice/de.ts
+++ b/web-next/lib/i18n/locales/voice/de.ts
@@ -48,6 +48,7 @@ export const voice = {
     noRuntimeSnapshot: "Noch kein Runtime-Snapshot. Status nach Backend-Start aktualisieren.",
     unknownModel: "Unbekanntes Modell",
     provider: "Provider",
+    endpoint: "Endpoint",
     profile: "Profil",
     pipeline: "Pipeline",
     probes: "Probes",

--- a/web-next/lib/i18n/locales/voice/en.ts
+++ b/web-next/lib/i18n/locales/voice/en.ts
@@ -48,6 +48,7 @@ export const voice = {
     noRuntimeSnapshot: "No runtime snapshot yet. Refresh the status after the backend starts.",
     unknownModel: "Unknown model",
     provider: "Provider",
+    endpoint: "Endpoint",
     profile: "Profile",
     pipeline: "Pipeline",
     probes: "Probes",

--- a/web-next/lib/i18n/locales/voice/pl.ts
+++ b/web-next/lib/i18n/locales/voice/pl.ts
@@ -48,6 +48,7 @@ export const voice = {
     noRuntimeSnapshot: "Brak snapshotu runtime. Odśwież status po starcie backendu.",
     unknownModel: "Nieznany model",
     provider: "Provider",
+    endpoint: "Endpoint",
     profile: "Profil",
     pipeline: "Pipeline",
     probes: "Probe",

--- a/web-next/tests/dynamic-parameter-form.component.test.tsx
+++ b/web-next/tests/dynamic-parameter-form.component.test.tsx
@@ -1,0 +1,59 @@
+import "./component-test-setup";
+
+import assert from "node:assert/strict";
+import { afterEach, describe, it, mock } from "node:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { DynamicParameterForm } from "../components/ui/dynamic-parameter-form";
+
+afterEach(() => cleanup());
+
+describe("DynamicParameterForm", () => {
+  it("does not emit onChange on mount", () => {
+    const onChange = mock.fn(() => undefined);
+
+    render(
+      <DynamicParameterForm
+        schema={{
+          temperature: {
+            type: "float",
+            default: 0.7,
+            min: 0,
+            max: 2,
+            desc: "Controls randomness",
+          },
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    assert.equal(onChange.mock.callCount(), 0);
+  });
+
+  it("emits onChange after user interaction", () => {
+    const onChange = mock.fn(() => undefined);
+
+    render(
+      <DynamicParameterForm
+        schema={{
+          top_k: {
+            type: "int",
+            default: 64,
+            min: 1,
+            max: 128,
+            desc: "Top-k sampling",
+          },
+        }}
+        onChange={onChange}
+      />,
+    );
+
+    const [spinbox] = screen.getAllByRole("spinbutton");
+    fireEvent.change(spinbox, { target: { value: "32" } });
+
+    assert.equal(onChange.mock.callCount(), 1);
+    const call = onChange.mock.calls[0];
+    assert.ok(call);
+    const [payload] = ((call.arguments ?? []) as unknown) as [Record<string, unknown>];
+    assert.equal(payload.top_k, 32);
+  });
+});

--- a/web-next/tests/gemma4-runtime-control.component.test.tsx
+++ b/web-next/tests/gemma4-runtime-control.component.test.tsx
@@ -55,8 +55,26 @@ function makeState(overrides: Partial<Gemma4DaemonState> = {}): Gemma4DaemonStat
 function renderControl(
   state: Gemma4DaemonState,
   variant: "cockpit" | "voice" = "voice",
+  runtimeSnapshot?: {
+    provider?: string | null;
+    model_name?: string | null;
+    runtime_capabilities?: {
+      compatibility_profile?: string | null;
+      probe_status?: string | null;
+    } | null;
+    voice_pipeline?: {
+      profile?: string | null;
+      tts?: string | null;
+    } | null;
+  } | null,
 ) {
-  return render(<Gemma4RuntimeControlInner daemon={state} variant={variant} />);
+  return render(
+    <Gemma4RuntimeControlInner
+      daemon={state}
+      variant={variant}
+      runtimeSnapshot={runtimeSnapshot ?? null}
+    />,
+  );
 }
 
 describe("Gemma4RuntimeControl — loading state", () => {
@@ -73,6 +91,33 @@ describe("Gemma4RuntimeControl — error state", () => {
       document.body.textContent?.toLowerCase().includes("niedostępny") ||
       document.body.textContent?.toLowerCase().includes("unavailable"),
     );
+  });
+
+  it("shows runtime snapshot details when daemon is unavailable", () => {
+    renderControl(
+      makeState({
+        status: null,
+        loading: false,
+        error: "Failed to fetch",
+      }),
+      "voice",
+      {
+        provider: "ollama",
+        model_name: "gemma2:2b",
+        runtime_capabilities: {
+          compatibility_profile: "gemma4_audio_native",
+          probe_status: "verified",
+        },
+        voice_pipeline: {
+          profile: "gemma4_audio_native",
+          tts: "piper",
+        },
+      },
+    );
+    assert.ok(
+      document.body.textContent?.toLowerCase().includes("failed to fetch"),
+    );
+    assert.ok(document.body.textContent?.includes("ollama / gemma2:2b"));
   });
 });
 

--- a/web-next/tests/voice-status-sidebar.component.test.tsx
+++ b/web-next/tests/voice-status-sidebar.component.test.tsx
@@ -2,6 +2,7 @@ import "./component-test-setup";
 import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
 import { cleanup, render, screen } from "@testing-library/react";
+import { ToastProvider } from "../components/ui/toast";
 import { VoiceStatusSidebar } from "../components/voice/voice-status-sidebar";
 
 afterEach(() => cleanup());
@@ -37,7 +38,11 @@ const voiceStatus = {
 
 describe("VoiceStatusSidebar", () => {
   it("shows active runtime details and does not surface Gemma 4 controls for ollama", () => {
-    render(<VoiceStatusSidebar status={voiceStatus as never} />);
+    render(
+      <ToastProvider>
+        <VoiceStatusSidebar status={voiceStatus as never} />
+      </ToastProvider>,
+    );
 
     assert.ok(screen.getByText(/ollama \/ gemma2:2b/i));
     assert.ok(screen.getAllByText("piper").length >= 2);

--- a/web-next/tests/voice-status-sidebar.component.test.tsx
+++ b/web-next/tests/voice-status-sidebar.component.test.tsx
@@ -1,0 +1,47 @@
+import "./component-test-setup";
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { cleanup, render, screen } from "@testing-library/react";
+import { VoiceStatusSidebar } from "../components/voice/voice-status-sidebar";
+
+afterEach(() => cleanup());
+
+const voiceStatus = {
+  enabled: true,
+  connected_clients: 1,
+  active_recordings: 0,
+  stt_ready: true,
+  whisper_model_size: "medium",
+  tts_ready: true,
+  tts_backend: "piper",
+  tts_fallback: false,
+  dependencies: { ffmpeg: true, faster_whisper: true, piper: true },
+  runtime_snapshot: {
+    runtime_id: "ollama@http://localhost:11434/v1",
+    provider: "ollama",
+    model_name: "gemma2:2b",
+    endpoint: "http://localhost:11434/v1",
+    config_hash: "cfg123",
+    runtime_capabilities: {
+      compatibility_profile: "legacy_text_only",
+      probe_status: "verified",
+    },
+    voice_pipeline: {
+      profile: "legacy_text_only",
+      stt: "faster_whisper",
+      reasoning: "prompt_fallback",
+      tts: "piper",
+    },
+  },
+} as const;
+
+describe("VoiceStatusSidebar", () => {
+  it("shows active runtime details and does not surface Gemma 4 controls for ollama", () => {
+    render(<VoiceStatusSidebar status={voiceStatus as never} />);
+
+    assert.ok(screen.getByText(/ollama \/ gemma2:2b/i));
+    assert.ok(screen.getAllByText("piper").length >= 2);
+    assert.ok(screen.getAllByText("faster_whisper").length >= 2);
+    assert.equal(screen.queryByText(/Gemma 4 Runtime/i), null);
+  });
+});


### PR DESCRIPTION
## Zakres
Implementacja 214C: spójne sterowanie runtime Gemma 4 i parametrami generacji oraz stabilizacja UX `/voice`.

## Zmiany
1. Poprawione mapowanie aktywnego runtime LLM (`ACTIVE_LLM_SERVER`) tak, aby UI i backend raportowały właściwy provider/endpoint.
2. Korekta agregacji `probe_status` dla Ollama capabilities (opcjonalne probe fail nie oznacza globalnego fail przy `show=verified`).
3. Rozszerzenie kontrolki Gemma Runtime o wsparcie `runtimeSnapshot` i reużycie powierzchni sterowania.
4. Przebudowa panelu statusu voice pod czytelny podział STT / LLM runtime / TTS.
5. Naprawa pętli React (`Maximum update depth exceeded`) w formularzu parametrów.
6. Uzupełnienie testów backend i frontend dla nowych ścieżek.

## Testy lokalne
- `npm --prefix web-next run lint` ✅
- `npm --prefix web-next run test:unit:ci-lite` ✅
- `make test-fast-coverage` ✅
