### PR TITLE
[codex] 217DB: aktywacja runtime diagnostics i routing polityk

### DIFF
--- a/config/pytest-groups/fast.txt
+++ b/config/pytest-groups/fast.txt
@@ -17,6 +17,7 @@ tests/test_214a_gemma4_daemon.py
 tests/test_217a_multi_runtime_migration_contracts.py
 tests/test_217b_api_multi_runtime_profile.py
 tests/test_217b_daemon_profile_endpoints.py
+tests/test_217da_multi_runtime_pipeline_basics.py
 tests/test_academy_202c_signing_coverage.py
 tests/test_academy_202d_lora_onnx_deploy.py
 tests/test_academy_adapter_runtime_service.py

--- a/config/pytest-groups/sonar-new-code.txt
+++ b/config/pytest-groups/sonar-new-code.txt
@@ -9,6 +9,7 @@ tests/test_214a_gemma4_daemon.py
 tests/test_217a_multi_runtime_migration_contracts.py
 tests/test_217b_api_multi_runtime_profile.py
 tests/test_217b_daemon_profile_endpoints.py
+tests/test_217da_multi_runtime_pipeline_basics.py
 tests/test_academy_202c_signing_coverage.py
 tests/test_academy_202d_lora_onnx_deploy.py
 tests/test_academy_adapter_runtime_service.py

--- a/config/testing/lane_assignments.yaml
+++ b/config/testing/lane_assignments.yaml
@@ -31,6 +31,12 @@
       "test": "tests/test_env_contracts.py",
       "lane": "ci-lite",
       "rationale": "Environment contracts must stay in fast new-code guard when changed."
+    },
+    {
+      "group": "sonar-new-code",
+      "test": "tests/test_217da_multi_runtime_pipeline_basics.py",
+      "lane": "new-code",
+      "rationale": "217DA runtime pipeline baseline must remain eligible for changed-lines quality gate."
     }
   ]
 }

--- a/config/testing/test_catalog.json
+++ b/config/testing/test_catalog.json
@@ -353,6 +353,46 @@
       "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
     },
     {
+      "path": "tests/test_217b_api_multi_runtime_profile.py",
+      "domain": "api",
+      "test_type": "route_contract",
+      "intent": "contract",
+      "primary_lane": "new-code",
+      "allowed_lanes": [
+        "new-code",
+        "ci-lite",
+        "release"
+      ],
+      "legacy_targeted": false,
+      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
+    },
+    {
+      "path": "tests/test_217b_daemon_profile_endpoints.py",
+      "domain": "runtime",
+      "test_type": "unit",
+      "intent": "regression",
+      "primary_lane": "new-code",
+      "allowed_lanes": [
+        "new-code",
+        "ci-lite",
+        "release"
+      ],
+      "legacy_targeted": false,
+      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
+    },
+    {
+      "path": "tests/test_217da_multi_runtime_pipeline_basics.py",
+      "domain": "runtime",
+      "test_type": "unit",
+      "intent": "regression",
+      "primary_lane": "release",
+      "allowed_lanes": [
+        "release"
+      ],
+      "legacy_targeted": false,
+      "rationale": "Default release-lane regression coverage."
+    },
+    {
       "path": "tests/test_academy_202c_signing_coverage.py",
       "domain": "academy",
       "test_type": "route_contract",
@@ -3884,6 +3924,20 @@
       "rationale": "Integration-heavy behavior delegated to release lane."
     },
     {
+      "path": "tests/test_multi_runtime_profile_service.py",
+      "domain": "runtime",
+      "test_type": "service_contract",
+      "intent": "contract",
+      "primary_lane": "new-code",
+      "allowed_lanes": [
+        "new-code",
+        "ci-lite",
+        "release"
+      ],
+      "legacy_targeted": false,
+      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
+    },
+    {
       "path": "tests/test_new_chat_session_api.py",
       "domain": "api",
       "test_type": "unit",
@@ -6003,48 +6057,6 @@
       ],
       "legacy_targeted": false,
       "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
-    },
-    {
-      "path": "tests/test_multi_runtime_profile_service.py",
-      "domain": "runtime",
-      "test_type": "unit",
-      "intent": "contract",
-      "primary_lane": "new-code",
-      "allowed_lanes": [
-        "new-code",
-        "ci-lite",
-        "release"
-      ],
-      "legacy_targeted": false,
-      "rationale": "217B Faza 1: kontrakt multi_runtime_profile — apply matrix, walidacja, rozdzielenie od systemu."
-    },
-    {
-      "path": "tests/test_217b_daemon_profile_endpoints.py",
-      "domain": "runtime",
-      "test_type": "unit",
-      "intent": "contract",
-      "primary_lane": "new-code",
-      "allowed_lanes": [
-        "new-code",
-        "ci-lite",
-        "release"
-      ],
-      "legacy_targeted": false,
-      "rationale": "217B Faza 3: endpointy /v1/daemon/profile — GET profilu, POST partial update z apply_mode, backward compat /v1/daemon/config."
-    },
-    {
-      "path": "tests/test_217b_api_multi_runtime_profile.py",
-      "domain": "runtime",
-      "test_type": "unit",
-      "intent": "contract",
-      "primary_lane": "new-code",
-      "allowed_lanes": [
-        "new-code",
-        "ci-lite",
-        "release"
-      ],
-      "legacy_targeted": false,
-      "rationale": "217B Faza 4: API systemowe GET/POST /api/v1/runtime/multi-runtime/profile — proxy do daemona z graceful fallback."
     }
   ]
 }

--- a/config/testing/test_catalog.json
+++ b/config/testing/test_catalog.json
@@ -385,12 +385,14 @@
       "domain": "runtime",
       "test_type": "unit",
       "intent": "regression",
-      "primary_lane": "release",
+      "primary_lane": "new-code",
       "allowed_lanes": [
+        "new-code",
+        "ci-lite",
         "release"
       ],
       "legacy_targeted": false,
-      "rationale": "Default release-lane regression coverage."
+      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
     },
     {
       "path": "tests/test_academy_202c_signing_coverage.py",

--- a/scripts/dev/217da_component_registry_probe.py
+++ b/scripts/dev/217da_component_registry_probe.py
@@ -1,0 +1,18 @@
+"""Probe current component snapshot from local multi_runtime daemon."""
+
+from __future__ import annotations
+
+import json
+
+import requests
+
+
+def main() -> None:
+    base_url = "http://127.0.0.1:8014"
+    resp = requests.get(f"{base_url}/v1/components", timeout=3)
+    resp.raise_for_status()
+    print(json.dumps(resp.json(), indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/217da_diagnostics_snapshot.py
+++ b/scripts/dev/217da_diagnostics_snapshot.py
@@ -1,0 +1,28 @@
+"""Snapshot runtime diagnostics endpoints for quick review."""
+
+from __future__ import annotations
+
+import json
+
+import requests
+
+
+def main() -> None:
+    base = "http://127.0.0.1:8014"
+    status = requests.get(f"{base}/status", timeout=5)
+    daemon_status = requests.get(f"{base}/v1/daemon/status", timeout=5)
+    components = requests.get(f"{base}/v1/components", timeout=5)
+
+    for response in (status, daemon_status, components):
+        response.raise_for_status()
+
+    snapshot = {
+        "status": status.json(),
+        "daemon_status": daemon_status.json(),
+        "components": components.json(),
+    }
+    print(json.dumps(snapshot, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/217da_image_pipeline_probe.py
+++ b/scripts/dev/217da_image_pipeline_probe.py
@@ -1,0 +1,46 @@
+"""Probe image pipeline behavior via OpenAI-compatible chat endpoint."""
+
+from __future__ import annotations
+
+import json
+
+import requests
+
+
+def _request_payload(image_data_url: str, text: str | None) -> dict:
+    user_content: list[dict[str, object]] = [
+        {"type": "image_url", "image_url": image_data_url}
+    ]
+    if text:
+        user_content.insert(0, {"type": "text", "text": text})
+    return {
+        "model": "multi_runtime",
+        "messages": [{"role": "user", "content": user_content}],
+        "max_tokens": 64,
+    }
+
+
+def main() -> None:
+    base_url = "http://127.0.0.1:8014/v1/chat/completions"
+    placeholder_image = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4////fwAJ+wP9fYzWxQAAAABJRU5ErkJggg=="
+
+    image_only = requests.post(
+        base_url,
+        json=_request_payload(placeholder_image, None),
+        timeout=10,
+    )
+    image_with_text = requests.post(
+        base_url,
+        json=_request_payload(placeholder_image, "Opisz obraz"),
+        timeout=10,
+    )
+
+    result = {
+        "image_only_status": image_only.status_code,
+        "image_text_status": image_with_text.status_code,
+    }
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/217da_policy_smoke.py
+++ b/scripts/dev/217da_policy_smoke.py
@@ -1,0 +1,40 @@
+"""Smoke test for execution policy update and readback."""
+
+from __future__ import annotations
+
+import json
+
+import requests
+
+
+def main() -> None:
+    base_url = "http://127.0.0.1:8014/v1/daemon/profile"
+    payload = {
+        "execution_mode": "balanced",
+        "image_strategy": "vlm_only",
+        "retrieval_mode": "auto",
+        "audio_output_mode": "off",
+        "assistant_mode": "conditional",
+        "economy_mode": "auto",
+    }
+
+    update_resp = requests.post(base_url, json=payload, timeout=5)
+    update_resp.raise_for_status()
+
+    read_resp = requests.get(base_url, timeout=5)
+    read_resp.raise_for_status()
+
+    print(
+        json.dumps(
+            {
+                "update": update_resp.json(),
+                "profile": read_resp.json().get("profile", {}),
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/217da_profile_to_runtime_audit.py
+++ b/scripts/dev/217da_profile_to_runtime_audit.py
@@ -1,0 +1,94 @@
+"""Audit mapping from profile contract to daemon runtime parameters."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _extract_update_params_fields(engine_path: Path) -> set[str]:
+    tree = ast.parse(engine_path.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if not isinstance(node, ast.ClassDef) or node.name != "MultiRuntimeDaemon":
+            continue
+        for class_node in node.body:
+            if (
+                isinstance(class_node, ast.FunctionDef)
+                and class_node.name == "update_params"
+            ):
+                fields: set[str] = set()
+                for arg in class_node.args.args:
+                    if arg.arg != "self":
+                        fields.add(arg.arg)
+                return fields
+    return set()
+
+
+def _extract_apply_matrix_fields(service_path: Path) -> dict[str, str]:
+    tree = ast.parse(service_path.read_text(encoding="utf-8"))
+    for node in tree.body:
+        target_name: str | None = None
+        value_node: ast.AST | None = None
+
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if isinstance(target, ast.Name):
+                target_name = target.id
+                value_node = node.value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            target_name = node.target.id
+            value_node = node.value
+
+        if target_name != "APPLY_MATRIX":
+            continue
+        if not isinstance(value_node, ast.Dict):
+            continue
+
+        matrix: dict[str, str] = {}
+        for key_node, mode_node in zip(value_node.keys, value_node.values):
+            if not isinstance(key_node, ast.Constant) or not isinstance(
+                mode_node, ast.Constant
+            ):
+                continue
+            if isinstance(key_node.value, str) and isinstance(mode_node.value, str):
+                matrix[key_node.value] = mode_node.value
+        return matrix
+    return {}
+
+
+def main() -> None:
+    engine_path = REPO_ROOT / "services" / "multi_runtime" / "engine.py"
+    profile_service_path = (
+        REPO_ROOT / "venom_core" / "services" / "multi_runtime_profile_service.py"
+    )
+    daemon_fields = _extract_update_params_fields(engine_path)
+    apply_matrix = _extract_apply_matrix_fields(profile_service_path)
+
+    profile_fields = set(apply_matrix.keys())
+    live_or_reload_fields = {
+        field
+        for field, mode in apply_matrix.items()
+        if mode in {"live", "soft_reload", "hard_restart"}
+    }
+
+    report = {
+        "phase": "217DA/F0",
+        "daemon_update_params_fields": sorted(daemon_fields),
+        "profile_fields": sorted(profile_fields),
+        "accepted_profile_fields": sorted(live_or_reload_fields),
+        "mapped_live_fields": sorted(live_or_reload_fields & daemon_fields),
+        "missing_in_daemon_update_params": sorted(
+            live_or_reload_fields - daemon_fields
+        ),
+        "unsupported_profile_fields": sorted(
+            field for field, mode in apply_matrix.items() if mode == "unsupported"
+        ),
+    }
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/217da_retrieval_probe.py
+++ b/scripts/dev/217da_retrieval_probe.py
@@ -1,0 +1,44 @@
+"""Probe retrieval mode behavior in runtime response diagnostics."""
+
+from __future__ import annotations
+
+import json
+
+import requests
+
+
+def _set_mode(mode: str) -> None:
+    url = "http://127.0.0.1:8014/v1/daemon/profile"
+    resp = requests.post(url, json={"retrieval_mode": mode}, timeout=5)
+    resp.raise_for_status()
+
+
+def _respond() -> dict:
+    url = "http://127.0.0.1:8014/v1/respond"
+    payload = {
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "Krótka odpowiedź testowa."}],
+            }
+        ],
+    }
+    resp = requests.post(url, json=payload, timeout=20)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def main() -> None:
+    summary: dict[str, object] = {}
+    for mode in ("off", "auto", "always"):
+        _set_mode(mode)
+        response = _respond()
+        summary[mode] = {
+            "retrieval_used": response.get("retrieval_used"),
+            "execution_trace": response.get("execution_trace", []),
+        }
+    print(json.dumps(summary, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/217da_runtime_flow_audit.py
+++ b/scripts/dev/217da_runtime_flow_audit.py
@@ -1,0 +1,63 @@
+"""Audit current multi_runtime request flow for 217DA phase 0."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+
+def _function_calls(module_path: Path, function_name: str) -> list[str]:
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    stack = list(tree.body)
+    while stack:
+        node = stack.pop()
+        if isinstance(node, ast.ClassDef):
+            stack.extend(node.body)
+            continue
+        if (
+            isinstance(node, ast.AsyncFunctionDef | ast.FunctionDef)
+            and node.name == function_name
+        ):
+            calls: list[str] = []
+            for inner in ast.walk(node):
+                if isinstance(inner, ast.Call):
+                    func = inner.func
+                    if isinstance(func, ast.Name):
+                        calls.append(func.id)
+                    elif isinstance(func, ast.Attribute):
+                        calls.append(func.attr)
+            return sorted(set(calls))
+    return []
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    main_py = repo_root / "services" / "multi_runtime" / "main.py"
+    engine_py = repo_root / "services" / "multi_runtime" / "engine.py"
+
+    respond_calls = _function_calls(main_py, "respond")
+    engine_calls = _function_calls(engine_py, "respond")
+
+    report = {
+        "phase": "217DA/F0",
+        "request_flow": [
+            "request",
+            "parse",
+            "route",
+            "infer",
+            "response",
+            "status",
+        ],
+        "main.respond.calls": respond_calls,
+        "engine.respond.calls": engine_calls,
+        "notes": [
+            "Pipeline orchestration should stay outside heavy model loader internals.",
+            "Model infer call remains delegated to engine.respond.",
+        ],
+    }
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dev/217db_assistant_mode_probe.py
+++ b/scripts/dev/217db_assistant_mode_probe.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""217DB probe: assistant_mode execution and fallback behavior."""
+
+from __future__ import annotations
+
+from _217db_probe_utils import print_json, request_json
+
+
+def set_profile(mode: str) -> None:
+    request_json(
+        "POST",
+        "/daemon/profile",
+        {
+            "assistant_mode": mode,
+            "retrieval_mode": "off",
+            "economy_mode": "off",
+        },
+    )
+
+
+def respond(prompt: str) -> dict:
+    return request_json(
+        "POST",
+        "/respond",
+        {"messages": [{"role": "user", "content": [{"type": "text", "text": prompt}]}]},
+    )
+
+
+def main() -> int:
+    summary: dict[str, dict[str, object]] = {}
+    for mode in ("off", "attached", "conditional"):
+        set_profile(mode)
+        response = respond("Napisz krótką odpowiedź testową.")
+        summary[mode] = {
+            "assistant_used": response.get("assistant_used"),
+            "selected_policy": response.get("selected_policy"),
+            "degradation_reasons": response.get("degradation_reasons", []),
+        }
+    print_json(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/217db_component_live_probe.py
+++ b/scripts/dev/217db_component_live_probe.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""217DB probe: live component snapshot from multi_runtime daemon."""
+
+from __future__ import annotations
+
+from _217db_probe_utils import print_json, request_json
+
+
+def main() -> int:
+    payload = request_json("GET", "/components")
+    print_json(
+        {
+            "runtime_id": payload.get("runtime_id"),
+            "timestamp_ms": payload.get("timestamp_ms"),
+            "components": payload.get("components", []),
+        }
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/217db_economy_mode_probe.py
+++ b/scripts/dev/217db_economy_mode_probe.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""217DB probe: economy_mode impact on runtime execution."""
+
+from __future__ import annotations
+
+from _217db_probe_utils import print_json, request_json
+
+
+def set_profile(mode: str) -> None:
+    request_json(
+        "POST", "/daemon/profile", {"economy_mode": mode, "retrieval_mode": "auto"}
+    )
+
+
+def respond(prompt: str) -> dict:
+    return request_json(
+        "POST",
+        "/respond",
+        {"messages": [{"role": "user", "content": [{"type": "text", "text": prompt}]}]},
+    )
+
+
+def main() -> int:
+    summary: dict[str, dict[str, object]] = {}
+    for mode in ("off", "auto"):
+        set_profile(mode)
+        response = respond("Dlaczego to działa?")
+        summary[mode] = {
+            "economy_mode_activated": response.get("economy_mode_activated"),
+            "retrieval_used": response.get("retrieval_used"),
+            "assistant_used": response.get("assistant_used"),
+            "degradation_reasons": response.get("degradation_reasons", []),
+        }
+    print_json(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/217db_image_strategy_probe.py
+++ b/scripts/dev/217db_image_strategy_probe.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""217DB probe: image_strategy behavior and OCR/VLM routing."""
+
+from __future__ import annotations
+
+from _217db_probe_utils import print_json, request_json
+
+PLACEHOLDER_IMAGE = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4"
+    "////fwAJ+wP9fYzWxQAAAABJRU5ErkJggg=="
+)
+
+
+def set_profile(strategy: str) -> None:
+    request_json("POST", "/daemon/profile", {"image_strategy": strategy})
+
+
+def respond(prompt: str) -> dict:
+    return request_json(
+        "POST",
+        "/respond",
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image", "data": PLACEHOLDER_IMAGE},
+                        {"type": "text", "text": prompt},
+                    ],
+                }
+            ]
+        },
+    )
+
+
+def main() -> int:
+    summary: dict[str, dict[str, object]] = {}
+    for strategy in ("vlm_only", "ocr_first", "hybrid"):
+        set_profile(strategy)
+        response = respond("Opisz obraz i wyciągnij tekst.")
+        summary[strategy] = {
+            "selected_image_strategy": response.get("selected_image_strategy"),
+            "execution_trace": response.get("execution_trace", []),
+            "degradation_reasons": response.get("degradation_reasons", []),
+            "component_snapshot_size": len(response.get("component_snapshot", [])),
+        }
+    print_json(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/217db_retrieval_mode_probe.py
+++ b/scripts/dev/217db_retrieval_mode_probe.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""217DB probe: retrieval_mode on/off/always diagnostics."""
+
+from __future__ import annotations
+
+from _217db_probe_utils import print_json, request_json
+
+
+def set_profile(mode: str) -> None:
+    request_json("POST", "/daemon/profile", {"retrieval_mode": mode})
+
+
+def respond(prompt: str) -> dict:
+    return request_json(
+        "POST",
+        "/respond",
+        {"messages": [{"role": "user", "content": [{"type": "text", "text": prompt}]}]},
+    )
+
+
+def main() -> int:
+    summary: dict[str, dict[str, object]] = {}
+    for mode in ("off", "auto", "always"):
+        set_profile(mode)
+        response = respond("Jaki jest związek między A i B?")
+        summary[mode] = {
+            "retrieval_used": response.get("retrieval_used"),
+            "retrieval_route": response.get("retrieval_route"),
+            "retrieval_context_items": response.get("retrieval_context_items"),
+            "degradation_reasons": response.get("degradation_reasons", []),
+        }
+    print_json(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/_217db_probe_utils.py
+++ b/scripts/dev/_217db_probe_utils.py
@@ -1,0 +1,39 @@
+"""Shared helpers for 217DB probe scripts."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, is_dataclass
+from typing import Any
+
+import requests
+
+
+def base_url_from_args(default_port: int = 8014) -> str:
+    raw = os.getenv("VENOM_MULTI_RUNTIME_BASE_URL", "").strip()
+    if raw:
+        return raw.rstrip("/")
+    port = os.getenv("VENOM_MULTI_RUNTIME_PORT", str(default_port)).strip()
+    return f"http://127.0.0.1:{port}"
+
+
+def daemon_base_url() -> str:
+    return f"{base_url_from_args()}/v1"
+
+
+def request_json(method: str, path: str, payload: dict[str, Any] | None = None) -> Any:
+    response = requests.request(
+        method,
+        f"{daemon_base_url()}{path}",
+        json=payload,
+        timeout=15,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def print_json(payload: Any) -> None:
+    if is_dataclass(payload):
+        payload = asdict(payload)
+    print(json.dumps(payload, indent=2, ensure_ascii=False))

--- a/services/multi_runtime/components.py
+++ b/services/multi_runtime/components.py
@@ -69,6 +69,12 @@ def _resolve_retrieval_status() -> tuple[bool, str, str | None]:
     return True, "lancedb", None
 
 
+def _resolve_ocr_status() -> tuple[bool, str, str | None]:
+    if _module_available("pytesseract"):
+        return True, "pytesseract", None
+    return False, "pytesseract", "pytesseract package unavailable"
+
+
 def build_component_snapshot(
     daemon_status: dict[str, Any],
     *,
@@ -100,12 +106,13 @@ def build_component_snapshot(
     retrieval_available, retrieval_backend, retrieval_error = (
         _resolve_retrieval_status()
     )
+    ocr_available, ocr_backend, ocr_error = _resolve_ocr_status()
     assistant_enabled = assistant_mode != "off" and bool(
         daemon_status.get("assistant_model")
     )
     image_last_error = (
-        "OCR-first strategy requested but OCR backend not configured"
-        if image_strategy in {"ocr_first", "hybrid"}
+        "OCR-first strategy requested but OCR backend unavailable"
+        if image_strategy in {"ocr_first", "hybrid"} and not ocr_available
         else None
     )
 
@@ -145,6 +152,19 @@ def build_component_snapshot(
             device_target="cpu",
             health=_component_health(True, supports_image_input),
             last_error=image_last_error,
+        ),
+        RuntimeComponent(
+            component_id="ocr_component",
+            component_type="vision",
+            enabled=image_strategy in {"ocr_first", "hybrid"},
+            available=ocr_available,
+            backend=ocr_backend,
+            model_id=None,
+            device_target="cpu",
+            health=_component_health(
+                image_strategy in {"ocr_first", "hybrid"}, ocr_available
+            ),
+            last_error=ocr_error if image_strategy in {"ocr_first", "hybrid"} else None,
         ),
         RuntimeComponent(
             component_id="stt_component",

--- a/services/multi_runtime/components.py
+++ b/services/multi_runtime/components.py
@@ -1,0 +1,110 @@
+"""Component registry for multi_runtime runtime diagnostics."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any
+
+
+@dataclass(slots=True)
+class RuntimeComponent:
+    component_id: str
+    component_type: str
+    enabled: bool
+    available: bool
+    backend: str
+    model_id: str | None
+    device_target: str
+    health: str
+    last_error: str | None = None
+
+
+def _component_health(enabled: bool, available: bool) -> str:
+    if enabled and available:
+        return "ok"
+    if enabled and not available:
+        return "degraded"
+    return "disabled"
+
+
+def build_component_snapshot(daemon_status: dict[str, Any]) -> list[dict[str, object]]:
+    vram_backend = str(daemon_status.get("vram", {}).get("backend", "cpu"))
+    target_loaded = bool(daemon_status.get("target_loaded", False))
+    assistant_loaded = bool(daemon_status.get("assistant_loaded", False))
+    supports_image_input = bool(daemon_status.get("supports_image_input", True))
+
+    components = [
+        RuntimeComponent(
+            component_id="main_model",
+            component_type="model",
+            enabled=True,
+            available=target_loaded,
+            backend=vram_backend,
+            model_id=daemon_status.get("target_model"),
+            device_target=vram_backend,
+            health=_component_health(True, target_loaded),
+        ),
+        RuntimeComponent(
+            component_id="assistant_model",
+            component_type="model",
+            enabled=bool(daemon_status.get("assistant_model")),
+            available=assistant_loaded,
+            backend=vram_backend,
+            model_id=daemon_status.get("assistant_model"),
+            device_target=vram_backend,
+            health=_component_health(
+                bool(daemon_status.get("assistant_model")), assistant_loaded
+            ),
+        ),
+        RuntimeComponent(
+            component_id="image_input",
+            component_type="vision",
+            enabled=True,
+            available=supports_image_input,
+            backend="builtin",
+            model_id=None,
+            device_target="cpu",
+            health=_component_health(True, supports_image_input),
+        ),
+        RuntimeComponent(
+            component_id="stt_component",
+            component_type="audio",
+            enabled=True,
+            available=target_loaded,
+            backend="builtin",
+            model_id=None,
+            device_target="cpu",
+            health=_component_health(True, target_loaded),
+        ),
+        RuntimeComponent(
+            component_id="tts_component",
+            component_type="audio",
+            enabled=False,
+            available=False,
+            backend="stub",
+            model_id=None,
+            device_target="cpu",
+            health="disabled",
+        ),
+        RuntimeComponent(
+            component_id="embedding_component",
+            component_type="retrieval",
+            enabled=False,
+            available=False,
+            backend="stub",
+            model_id=None,
+            device_target="cpu",
+            health="disabled",
+        ),
+        RuntimeComponent(
+            component_id="retrieval_component",
+            component_type="retrieval",
+            enabled=False,
+            available=False,
+            backend="stub",
+            model_id=None,
+            device_target="cpu",
+            health="disabled",
+        ),
+    ]
+    return [asdict(component) for component in components]

--- a/services/multi_runtime/components.py
+++ b/services/multi_runtime/components.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import importlib.util
+import os
 from dataclasses import asdict, dataclass
+from pathlib import Path
 from typing import Any
 
 
@@ -27,11 +30,84 @@ def _component_health(enabled: bool, available: bool) -> str:
     return "disabled"
 
 
-def build_component_snapshot(daemon_status: dict[str, Any]) -> list[dict[str, object]]:
+def _module_available(module_name: str) -> bool:
+    return importlib.util.find_spec(module_name) is not None
+
+
+def _resolve_tts_status() -> tuple[bool, str, str | None]:
+    configured_path = str(os.getenv("TTS_MODEL_PATH", "")).strip()
+    if configured_path:
+        path = Path(configured_path)
+        if path.exists():
+            return True, "piper", None
+        return False, "piper", f"TTS model path missing: {path}"
+
+    default_dir = Path("data/models/piper")
+    if default_dir.exists() and any(default_dir.glob("*.onnx")):
+        return True, "piper", None
+    return False, "piper", "No Piper voice model detected"
+
+
+def _resolve_embedding_status() -> tuple[bool, str, str | None]:
+    if _module_available("sentence_transformers"):
+        return True, "sentence_transformers", None
+    return (
+        True,
+        "fallback",
+        "sentence-transformers unavailable; deterministic fallback active",
+    )
+
+
+def _resolve_retrieval_status() -> tuple[bool, str, str | None]:
+    if not _module_available("lancedb"):
+        return False, "lancedb", "lancedb package unavailable"
+
+    memory_root = Path("data/memory")
+    if not memory_root.exists():
+        return False, "lancedb", "data/memory directory not found"
+
+    return True, "lancedb", None
+
+
+def build_component_snapshot(
+    daemon_status: dict[str, Any],
+    *,
+    request_overrides: dict[str, Any] | None = None,
+) -> list[dict[str, object]]:
     vram_backend = str(daemon_status.get("vram", {}).get("backend", "cpu"))
     target_loaded = bool(daemon_status.get("target_loaded", False))
     assistant_loaded = bool(daemon_status.get("assistant_loaded", False))
     supports_image_input = bool(daemon_status.get("supports_image_input", True))
+    params = daemon_status.get("params", {})
+    overrides = request_overrides or {}
+    retrieval_mode = str(
+        overrides.get("retrieval_mode", params.get("retrieval_mode", "off"))
+    )
+    audio_output_mode = str(
+        overrides.get("audio_output_mode", params.get("audio_output_mode", "off"))
+    )
+    assistant_mode = str(
+        overrides.get("assistant_mode", params.get("assistant_mode", "off"))
+    )
+    image_strategy = str(
+        overrides.get("image_strategy", params.get("image_strategy", "vlm_only"))
+    )
+
+    tts_available, tts_backend, tts_error = _resolve_tts_status()
+    embedding_available, embedding_backend, embedding_error = (
+        _resolve_embedding_status()
+    )
+    retrieval_available, retrieval_backend, retrieval_error = (
+        _resolve_retrieval_status()
+    )
+    assistant_enabled = assistant_mode != "off" and bool(
+        daemon_status.get("assistant_model")
+    )
+    image_last_error = (
+        "OCR-first strategy requested but OCR backend not configured"
+        if image_strategy in {"ocr_first", "hybrid"}
+        else None
+    )
 
     components = [
         RuntimeComponent(
@@ -47,13 +123,16 @@ def build_component_snapshot(daemon_status: dict[str, Any]) -> list[dict[str, ob
         RuntimeComponent(
             component_id="assistant_model",
             component_type="model",
-            enabled=bool(daemon_status.get("assistant_model")),
+            enabled=assistant_enabled,
             available=assistant_loaded,
             backend=vram_backend,
             model_id=daemon_status.get("assistant_model"),
             device_target=vram_backend,
-            health=_component_health(
-                bool(daemon_status.get("assistant_model")), assistant_loaded
+            health=_component_health(assistant_enabled, assistant_loaded),
+            last_error=(
+                "Assistant policy requires an attached model"
+                if assistant_mode != "off" and not daemon_status.get("assistant_model")
+                else None
             ),
         ),
         RuntimeComponent(
@@ -65,6 +144,7 @@ def build_component_snapshot(daemon_status: dict[str, Any]) -> list[dict[str, ob
             model_id=None,
             device_target="cpu",
             health=_component_health(True, supports_image_input),
+            last_error=image_last_error,
         ),
         RuntimeComponent(
             component_id="stt_component",
@@ -79,32 +159,35 @@ def build_component_snapshot(daemon_status: dict[str, Any]) -> list[dict[str, ob
         RuntimeComponent(
             component_id="tts_component",
             component_type="audio",
-            enabled=False,
-            available=False,
-            backend="stub",
+            enabled=audio_output_mode == "voice_first",
+            available=tts_available,
+            backend=tts_backend,
             model_id=None,
             device_target="cpu",
-            health="disabled",
+            health=_component_health(audio_output_mode == "voice_first", tts_available),
+            last_error=tts_error,
         ),
         RuntimeComponent(
             component_id="embedding_component",
             component_type="retrieval",
-            enabled=False,
-            available=False,
-            backend="stub",
+            enabled=retrieval_mode != "off",
+            available=embedding_available,
+            backend=embedding_backend,
             model_id=None,
             device_target="cpu",
-            health="disabled",
+            health=_component_health(retrieval_mode != "off", embedding_available),
+            last_error=embedding_error,
         ),
         RuntimeComponent(
             component_id="retrieval_component",
             component_type="retrieval",
-            enabled=False,
-            available=False,
-            backend="stub",
+            enabled=retrieval_mode != "off",
+            available=retrieval_available,
+            backend=retrieval_backend,
             model_id=None,
             device_target="cpu",
-            health="disabled",
+            health=_component_health(retrieval_mode != "off", retrieval_available),
+            last_error=retrieval_error,
         ),
     ]
     return [asdict(component) for component in components]

--- a/services/multi_runtime/diagnostics.py
+++ b/services/multi_runtime/diagnostics.py
@@ -1,0 +1,35 @@
+"""Diagnostics primitives for multi_runtime pipeline execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from time import perf_counter
+
+
+@dataclass(slots=True)
+class StageTrace:
+    name: str
+    duration_ms: int
+    outcome: str
+
+
+@dataclass(slots=True)
+class ExecutionDiagnostics:
+    execution_trace: list[StageTrace] = field(default_factory=list)
+    selected_policy: str | None = None
+    selected_image_strategy: str | None = None
+    retrieval_used: bool = False
+    assistant_used: bool = False
+    economy_mode_activated: bool = False
+    component_snapshot: list[dict[str, object]] = field(default_factory=list)
+
+    def push_trace(
+        self, stage_name: str, started_at: float, outcome: str = "ok"
+    ) -> None:
+        duration_ms = int((perf_counter() - started_at) * 1000)
+        self.execution_trace.append(
+            StageTrace(name=stage_name, duration_ms=duration_ms, outcome=outcome)
+        )
+
+    def trace_names(self) -> list[str]:
+        return [item.name for item in self.execution_trace]

--- a/services/multi_runtime/diagnostics.py
+++ b/services/multi_runtime/diagnostics.py
@@ -19,8 +19,10 @@ class ExecutionDiagnostics:
     selected_policy: str | None = None
     selected_image_strategy: str | None = None
     retrieval_used: bool = False
+    retrieval_context_items: int = 0
     assistant_used: bool = False
     economy_mode_activated: bool = False
+    degradation_reasons: list[str] = field(default_factory=list)
     component_snapshot: list[dict[str, object]] = field(default_factory=list)
 
     def push_trace(
@@ -33,3 +35,8 @@ class ExecutionDiagnostics:
 
     def trace_names(self) -> list[str]:
         return [item.name for item in self.execution_trace]
+
+    def add_degradation(self, reason: str) -> None:
+        normalized = str(reason or "").strip()
+        if normalized and normalized not in self.degradation_reasons:
+            self.degradation_reasons.append(normalized)

--- a/services/multi_runtime/diagnostics.py
+++ b/services/multi_runtime/diagnostics.py
@@ -20,6 +20,7 @@ class ExecutionDiagnostics:
     selected_image_strategy: str | None = None
     retrieval_used: bool = False
     retrieval_context_items: int = 0
+    retrieval_route: str | None = None
     assistant_used: bool = False
     economy_mode_activated: bool = False
     degradation_reasons: list[str] = field(default_factory=list)

--- a/services/multi_runtime/engine.py
+++ b/services/multi_runtime/engine.py
@@ -597,6 +597,25 @@ class MultiRuntimeDaemon:
         assert self._target_engine is not None
         return self._target_engine
 
+    def respond_with_assistant(
+        self,
+        *,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        max_new_tokens: Optional[int] = None,
+    ) -> tuple[str, float]:
+        """Run a lightweight text-only pass on the attached assistant model."""
+        if self._assistant_engine is None or not self._assistant_engine.is_loaded():
+            raise RuntimeError("Assistant model is not available")
+        return self._assistant_engine.respond(
+            None,
+            prompt=prompt,
+            system_prompt=system_prompt,
+            max_new_tokens=max_new_tokens or self._params.max_new_tokens,
+            enable_thinking=False,
+            cache_implementation=self._params.cache_implementation,
+        )
+
     def status(self) -> dict[str, Any]:
         raw_thinking_available = bool(
             self._target_engine is not None

--- a/services/multi_runtime/engine.py
+++ b/services/multi_runtime/engine.py
@@ -46,6 +46,12 @@ class DaemonParams:
     emotion_detection_enabled: bool = False
     emotion_response_style_enabled: bool = False
     cache_implementation: Optional[str] = None
+    execution_mode: str = "balanced"
+    image_strategy: str = "vlm_only"
+    retrieval_mode: str = "off"
+    audio_output_mode: str = "off"
+    assistant_mode: str = "off"
+    economy_mode: str = "off"
 
 
 @dataclass
@@ -492,6 +498,12 @@ class MultiRuntimeDaemon:
         emotion_detection_enabled: Optional[bool] = None,
         emotion_response_style_enabled: Optional[bool] = None,
         cache_implementation: Optional[str] = None,
+        execution_mode: Optional[str] = None,
+        image_strategy: Optional[str] = None,
+        retrieval_mode: Optional[str] = None,
+        audio_output_mode: Optional[str] = None,
+        assistant_mode: Optional[str] = None,
+        economy_mode: Optional[str] = None,
     ) -> ReloadSignal:
         """Apply parameter changes. Returns the minimum reload action required."""
         reload_signal = ReloadSignal.NONE
@@ -527,6 +539,24 @@ class MultiRuntimeDaemon:
                 f"cache_implementation changed to '{cache_implementation}'"
             )
             reload_signal = ReloadSignal.SOFT_RELOAD
+
+        if execution_mode is not None:
+            self._params.execution_mode = execution_mode
+
+        if image_strategy is not None:
+            self._params.image_strategy = image_strategy
+
+        if retrieval_mode is not None:
+            self._params.retrieval_mode = retrieval_mode
+
+        if audio_output_mode is not None:
+            self._params.audio_output_mode = audio_output_mode
+
+        if assistant_mode is not None:
+            self._params.assistant_mode = assistant_mode
+
+        if economy_mode is not None:
+            self._params.economy_mode = economy_mode
 
         return reload_signal
 
@@ -590,6 +620,12 @@ class MultiRuntimeDaemon:
                 "emotion_detection_enabled": self._params.emotion_detection_enabled,
                 "emotion_response_style_enabled": self._params.emotion_response_style_enabled,
                 "cache_implementation": self._params.cache_implementation,
+                "execution_mode": self._params.execution_mode,
+                "image_strategy": self._params.image_strategy,
+                "retrieval_mode": self._params.retrieval_mode,
+                "audio_output_mode": self._params.audio_output_mode,
+                "assistant_mode": self._params.assistant_mode,
+                "economy_mode": self._params.economy_mode,
             },
             "vram": _get_vram_info().__dict__,
             "raw_thinking_available": raw_thinking_available,

--- a/services/multi_runtime/main.py
+++ b/services/multi_runtime/main.py
@@ -847,6 +847,7 @@ async def respond(request: Request) -> RespondResponse:
         selected_image_strategy=pipeline_result.diagnostics.selected_image_strategy,
         retrieval_used=pipeline_result.diagnostics.retrieval_used,
         retrieval_context_items=pipeline_result.diagnostics.retrieval_context_items,
+        retrieval_route=pipeline_result.diagnostics.retrieval_route,
         assistant_used=pipeline_result.diagnostics.assistant_used,
         economy_mode_activated=pipeline_result.diagnostics.economy_mode_activated,
         degradation_reasons=pipeline_result.diagnostics.degradation_reasons,

--- a/services/multi_runtime/main.py
+++ b/services/multi_runtime/main.py
@@ -439,19 +439,7 @@ async def daemon_get_profile() -> MultiRuntimeProfileResponse:
     profile = build_profile_from_daemon_params(
         target_model=raw["target_model"],
         assistant_model=raw["assistant_model"],
-        max_new_tokens=p["max_new_tokens"],
-        enable_thinking=p["enable_thinking"],
-        image_token_budget=p["image_token_budget"],
-        reasoning_summary_enabled=p["reasoning_summary_enabled"],
-        emotion_detection_enabled=p["emotion_detection_enabled"],
-        emotion_response_style_enabled=p["emotion_response_style_enabled"],
-        cache_implementation=p["cache_implementation"],
-        execution_mode=p.get("execution_mode", "balanced"),
-        image_strategy=p.get("image_strategy", "vlm_only"),
-        retrieval_mode=p.get("retrieval_mode", "off"),
-        audio_output_mode=p.get("audio_output_mode", "off"),
-        assistant_mode=p.get("assistant_mode", "off"),
-        economy_mode=p.get("economy_mode", "off"),
+        daemon_params=p,
     )
     return build_profile_response(profile, daemon_reachable=True)
 

--- a/services/multi_runtime/main.py
+++ b/services/multi_runtime/main.py
@@ -779,7 +779,7 @@ async def respond(request: Request) -> RespondResponse:
 
     try:
         pipeline_result = await asyncio.to_thread(
-            MultiRuntimePipeline(engine).execute,
+            MultiRuntimePipeline(engine, daemon).execute,
             daemon_status=daemon_status,
             request=PipelineRequestData(
                 request_payload=request_payload,
@@ -846,8 +846,10 @@ async def respond(request: Request) -> RespondResponse:
         selected_policy=pipeline_result.diagnostics.selected_policy,
         selected_image_strategy=pipeline_result.diagnostics.selected_image_strategy,
         retrieval_used=pipeline_result.diagnostics.retrieval_used,
+        retrieval_context_items=pipeline_result.diagnostics.retrieval_context_items,
         assistant_used=pipeline_result.diagnostics.assistant_used,
         economy_mode_activated=pipeline_result.diagnostics.economy_mode_activated,
+        degradation_reasons=pipeline_result.diagnostics.degradation_reasons,
         component_snapshot=pipeline_result.diagnostics.component_snapshot,
     )
 

--- a/services/multi_runtime/main.py
+++ b/services/multi_runtime/main.py
@@ -37,12 +37,15 @@ from venom_core.services.multi_runtime_profile_service import (
 from venom_core.utils.voice_metadata import build_voice_session_insights
 
 from .audio import audio_from_bytes, audio_from_file, get_audio_duration
+from .components import build_component_snapshot
 from .engine import InferenceError, ModelLoadError, MultiRuntimeDaemon, ReloadSignal
+from .pipeline import MultiRuntimePipeline, PipelineRequestData
 from .schemas import (
     AssistantAttachRequest,
     AssistantAttachResponse,
     AudioMetadata,
     Capabilities,
+    ComponentListResponse,
     DaemonConfigRequest,
     DaemonConfigResponse,
     DaemonParamsInfo,
@@ -318,12 +321,14 @@ async def status() -> StatusResponse:
             )
 
         status_val = "warming" if _warming else ("running" if is_loaded else "error")
+        component_snapshot = build_component_snapshot(daemon.status())
         return StatusResponse(
             service="multi_runtime",
             status=status_val,
             model_loaded=is_loaded,
             model_info=model_info,
             timestamp_ms=int(time.time() * 1000),
+            component_snapshot=component_snapshot,
         )
     except RuntimeError:
         return StatusResponse(
@@ -384,6 +389,7 @@ async def daemon_status() -> DaemonStatusResponse:
         raise HTTPException(status_code=503, detail="Daemon not initialized")
 
     raw = daemon.status()
+    component_snapshot = build_component_snapshot(raw)
     return DaemonStatusResponse(
         target_model=raw["target_model"],
         assistant_model=raw["assistant_model"],
@@ -401,6 +407,22 @@ async def daemon_status() -> DaemonStatusResponse:
         pending_reload=raw["pending_reload"],
         reload_reason=raw["reload_reason"],
         supports_image_input=bool(raw.get("supports_image_input", True)),
+        component_snapshot=component_snapshot,
+    )
+
+
+@app.get("/v1/components", response_model=ComponentListResponse)
+async def components() -> ComponentListResponse:
+    try:
+        daemon = get_daemon()
+    except RuntimeError:
+        raise HTTPException(status_code=503, detail="Daemon not initialized")
+
+    raw = daemon.status()
+    return ComponentListResponse(
+        runtime_id="multi_runtime",
+        timestamp_ms=int(time.time() * 1000),
+        components=build_component_snapshot(raw),
     )
 
 
@@ -424,6 +446,12 @@ async def daemon_get_profile() -> MultiRuntimeProfileResponse:
         emotion_detection_enabled=p["emotion_detection_enabled"],
         emotion_response_style_enabled=p["emotion_response_style_enabled"],
         cache_implementation=p["cache_implementation"],
+        execution_mode=p.get("execution_mode", "balanced"),
+        image_strategy=p.get("image_strategy", "vlm_only"),
+        retrieval_mode=p.get("retrieval_mode", "off"),
+        audio_output_mode=p.get("audio_output_mode", "off"),
+        assistant_mode=p.get("assistant_mode", "off"),
+        economy_mode=p.get("economy_mode", "off"),
     )
     return build_profile_response(profile, daemon_reachable=True)
 
@@ -438,6 +466,12 @@ _UPDATE_PARAMS_FIELDS = frozenset(
         "emotion_detection_enabled",
         "emotion_response_style_enabled",
         "cache_implementation",
+        "execution_mode",
+        "image_strategy",
+        "retrieval_mode",
+        "audio_output_mode",
+        "assistant_mode",
+        "economy_mode",
     }
 )
 
@@ -515,6 +549,12 @@ async def daemon_config(body: DaemonConfigRequest) -> DaemonConfigResponse:
         emotion_detection_enabled=body.emotion_detection_enabled,
         emotion_response_style_enabled=body.emotion_response_style_enabled,
         cache_implementation=body.cache_implementation,
+        execution_mode=body.execution_mode,
+        image_strategy=body.image_strategy,
+        retrieval_mode=body.retrieval_mode,
+        audio_output_mode=body.audio_output_mode,
+        assistant_mode=body.assistant_mode,
+        economy_mode=body.economy_mode,
     )
 
     raw = daemon.status()
@@ -677,7 +717,6 @@ async def respond(request: Request) -> RespondResponse:
         request
     )
 
-    start_time = time.time()
     audio_array = None
     sample_rate = 16000
     text_content = None
@@ -736,32 +775,28 @@ async def respond(request: Request) -> RespondResponse:
             status_code=400, detail="No audio, text, or image content provided"
         )
 
-    prompt = text_content or request_payload.system_prompt or "Respond to the audio"
-
     daemon_status = daemon.status()
-    daemon_params = daemon_status["params"]
 
     try:
-        generated_text, duration = await asyncio.to_thread(
-            engine.respond,
-            audio_array,
-            sample_rate=sample_rate,
-            prompt=prompt,
-            images=images or None,
-            task=request_payload.task,
-            question=request_payload.question,
-            system_prompt=request_payload.system_prompt,
-            max_new_tokens=request_payload.max_new_tokens,
-            temperature=request_payload.temperature,
-            top_p=request_payload.top_p,
-            do_sample=request_payload.do_sample,
-            enable_thinking=bool(daemon_params["enable_thinking"]),
-            cache_implementation=daemon_params["cache_implementation"],
+        pipeline_result = await asyncio.to_thread(
+            MultiRuntimePipeline(engine).execute,
+            daemon_status=daemon_status,
+            request=PipelineRequestData(
+                request_payload=request_payload,
+                text_content=text_content,
+                audio_array=audio_array,
+                sample_rate=sample_rate,
+                images=images,
+            ),
         )
     except InferenceError as e:
         raise HTTPException(status_code=500, detail=f"Inference failed: {e}")
 
-    total_duration_ms = int((time.time() - start_time) * 1000)
+    daemon_params = daemon_status["params"]
+    generated_text = pipeline_result.generated_text
+    duration = pipeline_result.audio_duration_sec
+
+    total_duration_ms = pipeline_result.total_duration_ms
     voice_insights = build_voice_session_insights(
         transcript=text_content or "",
         response=generated_text,
@@ -785,15 +820,7 @@ async def respond(request: Request) -> RespondResponse:
             if audio_array is not None
             else None
         ),
-        input_modalities=(
-            ["text", "audio", "image"]
-            if audio_array is not None and images
-            else (
-                ["text", "audio"]
-                if audio_array is not None
-                else (["text", "image"] if images else ["text"])
-            )
-        ),
+        input_modalities=pipeline_result.input_modalities,
         output_modalities=["text"],
         runtime_mode="processor_model",
         capabilities=Capabilities(
@@ -815,6 +842,13 @@ async def respond(request: Request) -> RespondResponse:
         emotion_label=voice_insights.get("emotion_label"),
         emotion_confidence=voice_insights.get("emotion_confidence"),
         emotion_source=voice_insights.get("emotion_source"),
+        execution_trace=pipeline_result.diagnostics.trace_names(),
+        selected_policy=pipeline_result.diagnostics.selected_policy,
+        selected_image_strategy=pipeline_result.diagnostics.selected_image_strategy,
+        retrieval_used=pipeline_result.diagnostics.retrieval_used,
+        assistant_used=pipeline_result.diagnostics.assistant_used,
+        economy_mode_activated=pipeline_result.diagnostics.economy_mode_activated,
+        component_snapshot=pipeline_result.diagnostics.component_snapshot,
     )
 
 

--- a/services/multi_runtime/pipeline.py
+++ b/services/multi_runtime/pipeline.py
@@ -1,0 +1,107 @@
+"""Pipeline orchestration for multi_runtime execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from time import perf_counter
+from typing import Any
+
+from .components import build_component_snapshot
+from .diagnostics import ExecutionDiagnostics
+from .policies import RuntimePolicyResolver
+from .stages import (
+    AssistantPostprocessStage,
+    AudioOutputStage,
+    ImagePreprocessorStage,
+    InputRouterStage,
+    MainGenerationStage,
+    OcrOrVisionStage,
+    RetrievalStage,
+    StageContext,
+)
+
+
+@dataclass(slots=True)
+class PipelineRequestData:
+    request_payload: Any
+    text_content: str | None
+    audio_array: Any
+    sample_rate: int
+    images: list[Any]
+
+
+@dataclass(slots=True)
+class PipelineResult:
+    generated_text: str
+    audio_duration_sec: float
+    total_duration_ms: int
+    input_modalities: list[str]
+    diagnostics: ExecutionDiagnostics
+
+
+class MultiRuntimePipeline:
+    """Runtime pipeline preserving current behavior while exposing clear stages."""
+
+    def __init__(self, engine: Any):
+        self._engine = engine
+        self._policy_resolver = RuntimePolicyResolver()
+
+    def execute(
+        self,
+        *,
+        daemon_status: dict[str, Any],
+        request: PipelineRequestData,
+    ) -> PipelineResult:
+        started = perf_counter()
+        diagnostics = ExecutionDiagnostics()
+        diagnostics.component_snapshot = build_component_snapshot(daemon_status)
+
+        policy = self._policy_resolver.resolve(
+            daemon_status=daemon_status,
+            has_images=bool(request.images),
+            has_audio=request.audio_array is not None,
+        )
+        diagnostics.selected_policy = policy.policy_name()
+        diagnostics.selected_image_strategy = policy.image_strategy
+        diagnostics.retrieval_used = False
+        diagnostics.assistant_used = False
+        diagnostics.economy_mode_activated = policy.economy_mode == "auto"
+
+        context = StageContext(
+            request_payload=request.request_payload,
+            daemon_status=daemon_status,
+            text_content=request.text_content,
+            audio_array=request.audio_array,
+            sample_rate=request.sample_rate,
+            images=request.images,
+            diagnostics=diagnostics,
+            state={"policy": policy},
+        )
+
+        InputRouterStage().run(context)
+        ImagePreprocessorStage().run(context)
+        OcrOrVisionStage().run(context)
+        RetrievalStage().run(context)
+        MainGenerationStage(self._engine).run(context)
+        AssistantPostprocessStage().run(context)
+        AudioOutputStage().run(context)
+
+        audio_present = request.audio_array is not None
+        image_present = bool(request.images)
+
+        if audio_present and image_present:
+            modalities = ["text", "audio", "image"]
+        elif audio_present:
+            modalities = ["text", "audio"]
+        elif image_present:
+            modalities = ["text", "image"]
+        else:
+            modalities = ["text"]
+
+        return PipelineResult(
+            generated_text=str(context.state["generated_text"]),
+            audio_duration_sec=float(context.state["audio_duration_sec"]),
+            total_duration_ms=int((perf_counter() - started) * 1000),
+            input_modalities=modalities,
+            diagnostics=diagnostics,
+        )

--- a/services/multi_runtime/pipeline.py
+++ b/services/multi_runtime/pipeline.py
@@ -108,8 +108,8 @@ class MultiRuntimePipeline:
             modalities = ["text"]
 
         return PipelineResult(
-            generated_text=str(context.state["generated_text"]),
-            audio_duration_sec=float(context.state["audio_duration_sec"]),
+            generated_text=str(context.state.get("generated_text", "")),
+            audio_duration_sec=float(context.state.get("audio_duration_sec", 0.0)),
             total_duration_ms=int((perf_counter() - started) * 1000),
             input_modalities=modalities,
             diagnostics=diagnostics,

--- a/services/multi_runtime/pipeline.py
+++ b/services/multi_runtime/pipeline.py
@@ -42,8 +42,9 @@ class PipelineResult:
 class MultiRuntimePipeline:
     """Runtime pipeline preserving current behavior while exposing clear stages."""
 
-    def __init__(self, engine: Any):
+    def __init__(self, engine: Any, daemon: Any | None = None):
         self._engine = engine
+        self._daemon = daemon
         self._policy_resolver = RuntimePolicyResolver()
 
     def execute(
@@ -54,18 +55,26 @@ class MultiRuntimePipeline:
     ) -> PipelineResult:
         started = perf_counter()
         diagnostics = ExecutionDiagnostics()
-        diagnostics.component_snapshot = build_component_snapshot(daemon_status)
 
         policy = self._policy_resolver.resolve(
             daemon_status=daemon_status,
             has_images=bool(request.images),
             has_audio=request.audio_array is not None,
         )
+        diagnostics.component_snapshot = build_component_snapshot(
+            daemon_status,
+            request_overrides={
+                "retrieval_mode": policy.retrieval_mode,
+                "audio_output_mode": policy.audio_output_mode,
+                "assistant_mode": policy.assistant_mode,
+                "image_strategy": policy.image_strategy,
+            },
+        )
         diagnostics.selected_policy = policy.policy_name()
         diagnostics.selected_image_strategy = policy.image_strategy
         diagnostics.retrieval_used = False
         diagnostics.assistant_used = False
-        diagnostics.economy_mode_activated = policy.economy_mode == "auto"
+        diagnostics.economy_mode_activated = False
 
         context = StageContext(
             request_payload=request.request_payload,
@@ -83,7 +92,7 @@ class MultiRuntimePipeline:
         OcrOrVisionStage().run(context)
         RetrievalStage().run(context)
         MainGenerationStage(self._engine).run(context)
-        AssistantPostprocessStage().run(context)
+        AssistantPostprocessStage(self._daemon).run(context)
         AudioOutputStage().run(context)
 
         audio_present = request.audio_array is not None

--- a/services/multi_runtime/policies.py
+++ b/services/multi_runtime/policies.py
@@ -1,0 +1,104 @@
+"""Execution policy resolution for multi_runtime pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+ExecutionMode = Literal["balanced", "vision_priority", "voice_priority"]
+ImageStrategy = Literal["vlm_only", "ocr_first", "hybrid"]
+RetrievalMode = Literal["off", "auto", "always"]
+AudioOutputMode = Literal["off", "text_first", "voice_first"]
+AssistantMode = Literal["off", "attached", "conditional"]
+EconomyMode = Literal["off", "auto"]
+
+
+@dataclass(slots=True)
+class ExecutionPolicy:
+    execution_mode: ExecutionMode = "balanced"
+    image_strategy: ImageStrategy = "vlm_only"
+    retrieval_mode: RetrievalMode = "off"
+    audio_output_mode: AudioOutputMode = "off"
+    assistant_mode: AssistantMode = "off"
+    economy_mode: EconomyMode = "off"
+
+    def policy_name(self) -> str:
+        return (
+            f"{self.execution_mode}|{self.image_strategy}|{self.retrieval_mode}|"
+            f"{self.audio_output_mode}|{self.assistant_mode}|{self.economy_mode}"
+        )
+
+
+class RuntimePolicyResolver:
+    """Resolve runtime policy from daemon state and request modalities.
+
+    Current implementation preserves existing behavior and defaults to a safe,
+    lightweight policy. It is intentionally minimal for phase 1.
+    """
+
+    def resolve(
+        self,
+        *,
+        daemon_status: dict[str, Any],
+        has_images: bool,
+        has_audio: bool,
+    ) -> ExecutionPolicy:
+        params = daemon_status.get("params", {})
+        vram_backend = str(daemon_status.get("vram", {}).get("backend", "cpu"))
+        assistant_attached = bool(daemon_status.get("assistant_model"))
+
+        profile_execution_mode = params.get("execution_mode")
+        if profile_execution_mode in {
+            "balanced",
+            "vision_priority",
+            "voice_priority",
+        }:
+            execution_mode: ExecutionMode = profile_execution_mode
+        elif has_images and not has_audio:
+            execution_mode: ExecutionMode = "vision_priority"
+        elif has_audio and not has_images:
+            execution_mode = "voice_priority"
+        else:
+            execution_mode = "balanced"
+
+        profile_image_strategy = params.get("image_strategy")
+        image_strategy: ImageStrategy = (
+            profile_image_strategy
+            if profile_image_strategy in {"vlm_only", "ocr_first", "hybrid"}
+            else "vlm_only"
+        )
+
+        profile_retrieval_mode = params.get("retrieval_mode")
+        retrieval_mode: RetrievalMode = (
+            profile_retrieval_mode
+            if profile_retrieval_mode in {"off", "auto", "always"}
+            else "off"
+        )
+
+        profile_audio_output_mode = params.get("audio_output_mode")
+        audio_output_mode: AudioOutputMode = (
+            profile_audio_output_mode
+            if profile_audio_output_mode in {"off", "text_first", "voice_first"}
+            else "off"
+        )
+
+        profile_assistant_mode = params.get("assistant_mode")
+        if profile_assistant_mode in {"off", "attached", "conditional"}:
+            assistant_mode: AssistantMode = profile_assistant_mode
+        else:
+            assistant_mode = "attached" if assistant_attached else "off"
+
+        profile_economy_mode = params.get("economy_mode")
+        if profile_economy_mode in {"off", "auto"}:
+            economy_mode: EconomyMode = profile_economy_mode
+        else:
+            economy_mode = "auto" if vram_backend != "cuda" else "off"
+
+        return ExecutionPolicy(
+            execution_mode=execution_mode,
+            image_strategy=image_strategy,
+            retrieval_mode=retrieval_mode,
+            audio_output_mode=audio_output_mode,
+            assistant_mode=assistant_mode,
+            economy_mode=economy_mode,
+        )

--- a/services/multi_runtime/retrieval_policy_resolver.py
+++ b/services/multi_runtime/retrieval_policy_resolver.py
@@ -1,0 +1,135 @@
+"""Policy resolver for retrieval routing in the multi_runtime pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+RetrievalRoute = Literal["graph", "vector"]
+
+
+@dataclass(slots=True)
+class RetrievalPolicyDecision:
+    mode: str
+    should_use: bool
+    route_hint: RetrievalRoute
+    reason: str | None = None
+
+
+class RetrievalPolicyResolver:
+    """Resolve whether retrieval should run and which route should be preferred."""
+
+    _graph_hints = (
+        "związek",
+        "zwiazek",
+        "powiaz",
+        "powiąz",
+        "relac",
+        "między",
+        "miedzy",
+        "between",
+        "relationship",
+        "compare",
+        "porown",
+        "porówn",
+        "zależ",
+        "zalezn",
+        "dependency",
+        "edge",
+        "graph",
+    )
+
+    _vector_hints = (
+        "co to",
+        "dlaczego",
+        "jak",
+        "kiedy",
+        "gdzie",
+        "przypomnij",
+        "znajd",
+        "sprawdz",
+        "wyjaś",
+        "wyjas",
+        "explain",
+        "why",
+        "what",
+        "how",
+    )
+
+    def _should_use_graph(self, normalized_text: str) -> bool:
+        return any(token in normalized_text for token in self._graph_hints)
+
+    def _should_use_auto(self, normalized_text: str) -> bool:
+        return (
+            "?" in normalized_text
+            or len(normalized_text) >= 48
+            or any(token in normalized_text for token in self._vector_hints)
+        )
+
+    def resolve(
+        self,
+        *,
+        text: str,
+        mode: str,
+        primary_modality: str | None,
+        economy_mode: str | None,
+        request_overrides: dict[str, Any] | None = None,
+    ) -> RetrievalPolicyDecision:
+        normalized_text = str(text or "").strip().lower()
+        normalized_mode = str(mode or "off").strip().lower()
+        modality = str(primary_modality or "text").strip().lower()
+        normalized_economy = str(economy_mode or "off").strip().lower()
+
+        if normalized_mode == "off":
+            return RetrievalPolicyDecision(
+                mode=normalized_mode,
+                should_use=False,
+                route_hint="vector",
+                reason="retrieval disabled",
+            )
+
+        if not normalized_text:
+            return RetrievalPolicyDecision(
+                mode=normalized_mode,
+                should_use=False,
+                route_hint="vector",
+                reason="empty text content",
+            )
+
+        if modality == "image" and normalized_mode != "always":
+            return RetrievalPolicyDecision(
+                mode=normalized_mode,
+                should_use=False,
+                route_hint="vector",
+                reason="image-only request skips auto retrieval",
+            )
+
+        if normalized_mode == "auto":
+            if normalized_economy == "auto":
+                return RetrievalPolicyDecision(
+                    mode=normalized_mode,
+                    should_use=False,
+                    route_hint="vector",
+                    reason="economy mode suppresses auto retrieval",
+                )
+            if not self._should_use_auto(normalized_text):
+                return RetrievalPolicyDecision(
+                    mode=normalized_mode,
+                    should_use=False,
+                    route_hint="vector",
+                    reason="auto retrieval heuristics did not match",
+                )
+
+        preferred_route: RetrievalRoute = (
+            "graph" if self._should_use_graph(normalized_text) else "vector"
+        )
+        return RetrievalPolicyDecision(
+            mode=normalized_mode,
+            should_use=True,
+            route_hint=preferred_route,
+            reason=(
+                "graph relationship query"
+                if preferred_route == "graph"
+                else "vector semantic query"
+            ),
+        )

--- a/services/multi_runtime/router.py
+++ b/services/multi_runtime/router.py
@@ -1,0 +1,44 @@
+"""Input routing for multi_runtime pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .policies import ImageStrategy
+
+
+@dataclass(slots=True)
+class InputRoute:
+    has_text: bool
+    has_audio: bool
+    has_images: bool
+    primary_modality: str
+    image_strategy: ImageStrategy
+
+
+def route_inputs(
+    *,
+    text_content: str | None,
+    has_audio: bool,
+    image_count: int,
+    image_strategy: ImageStrategy,
+) -> InputRoute:
+    has_text = bool((text_content or "").strip())
+    has_images = image_count > 0
+
+    if has_audio:
+        primary_modality = "audio"
+    elif has_images and has_text:
+        primary_modality = "image_text"
+    elif has_images:
+        primary_modality = "image"
+    else:
+        primary_modality = "text"
+
+    return InputRoute(
+        has_text=has_text,
+        has_audio=has_audio,
+        has_images=has_images,
+        primary_modality=primary_modality,
+        image_strategy=image_strategy,
+    )

--- a/services/multi_runtime/schemas.py
+++ b/services/multi_runtime/schemas.py
@@ -150,6 +150,10 @@ class RespondResponse(BaseModel):
         0,
         description="How many retrieval snippets were attached to generation context",
     )
+    retrieval_route: Optional[str] = Field(
+        None,
+        description="Retrieval route used by runtime (e.g. vector, graph, vector_fallback)",
+    )
     assistant_used: bool = Field(
         False,
         description="Whether assistant model participated in execution",

--- a/services/multi_runtime/schemas.py
+++ b/services/multi_runtime/schemas.py
@@ -146,6 +146,10 @@ class RespondResponse(BaseModel):
         False,
         description="Whether retrieval stage was used",
     )
+    retrieval_context_items: int = Field(
+        0,
+        description="How many retrieval snippets were attached to generation context",
+    )
     assistant_used: bool = Field(
         False,
         description="Whether assistant model participated in execution",
@@ -153,6 +157,10 @@ class RespondResponse(BaseModel):
     economy_mode_activated: bool = Field(
         False,
         description="Whether economy mode was activated for this request",
+    )
+    degradation_reasons: list[str] = Field(
+        default_factory=list,
+        description="Reasons why runtime degraded or simplified the pipeline",
     )
     component_snapshot: list[dict[str, object]] = Field(
         default_factory=list,

--- a/services/multi_runtime/schemas.py
+++ b/services/multi_runtime/schemas.py
@@ -130,6 +130,34 @@ class RespondResponse(BaseModel):
     )
     warnings: list[str] = Field(default_factory=list, description="Any warnings")
     trace_id: Optional[str] = Field(None, description="Request trace ID")
+    execution_trace: list[str] = Field(
+        default_factory=list,
+        description="Ordered pipeline stages executed for this request",
+    )
+    selected_policy: Optional[str] = Field(
+        None,
+        description="Execution policy selected by runtime",
+    )
+    selected_image_strategy: Optional[str] = Field(
+        None,
+        description="Image processing strategy selected for the request",
+    )
+    retrieval_used: bool = Field(
+        False,
+        description="Whether retrieval stage was used",
+    )
+    assistant_used: bool = Field(
+        False,
+        description="Whether assistant model participated in execution",
+    )
+    economy_mode_activated: bool = Field(
+        False,
+        description="Whether economy mode was activated for this request",
+    )
+    component_snapshot: list[dict[str, object]] = Field(
+        default_factory=list,
+        description="Runtime component snapshot captured during execution",
+    )
 
 
 class TranscribeRequest(BaseModel):
@@ -170,6 +198,10 @@ class StatusResponse(BaseModel):
     model_loaded: bool = Field(..., description="Whether model is currently loaded")
     model_info: Optional[ModelInfo] = Field(None, description="Loaded model info")
     timestamp_ms: int = Field(..., description="Server timestamp in ms")
+    component_snapshot: list[dict[str, object]] = Field(
+        default_factory=list,
+        description="Current runtime component snapshot",
+    )
 
 
 class HealthResponse(BaseModel):
@@ -200,6 +232,12 @@ class DaemonParamsInfo(BaseModel):
     emotion_detection_enabled: bool = False
     emotion_response_style_enabled: bool = False
     cache_implementation: Optional[str] = None
+    execution_mode: str = "balanced"
+    image_strategy: str = "vlm_only"
+    retrieval_mode: str = "off"
+    audio_output_mode: str = "off"
+    assistant_mode: str = "off"
+    economy_mode: str = "off"
 
 
 class DaemonStatusResponse(BaseModel):
@@ -234,6 +272,16 @@ class DaemonStatusResponse(BaseModel):
     pending_reload: bool
     reload_reason: Optional[str] = None
     supports_image_input: bool = True
+    component_snapshot: list[dict[str, object]] = Field(
+        default_factory=list,
+        description="Current runtime component snapshot",
+    )
+
+
+class ComponentListResponse(BaseModel):
+    runtime_id: str = Field("multi_runtime")
+    timestamp_ms: int
+    components: list[dict[str, object]] = Field(default_factory=list)
 
 
 class DaemonConfigRequest(BaseModel):
@@ -246,6 +294,12 @@ class DaemonConfigRequest(BaseModel):
     emotion_detection_enabled: Optional[bool] = None
     emotion_response_style_enabled: Optional[bool] = None
     cache_implementation: Optional[str] = None
+    execution_mode: Optional[str] = None
+    image_strategy: Optional[str] = None
+    retrieval_mode: Optional[str] = None
+    audio_output_mode: Optional[str] = None
+    assistant_mode: Optional[str] = None
+    economy_mode: Optional[str] = None
 
 
 class DaemonConfigResponse(BaseModel):

--- a/services/multi_runtime/stages/__init__.py
+++ b/services/multi_runtime/stages/__init__.py
@@ -1,0 +1,21 @@
+"""Pipeline stages for multi_runtime."""
+
+from .assistant_postprocess import AssistantPostprocessStage
+from .audio_output import AudioOutputStage
+from .base import StageContext
+from .image_preprocessor import ImagePreprocessorStage
+from .input_router import InputRouterStage
+from .main_generation import MainGenerationStage
+from .ocr_or_vision import OcrOrVisionStage
+from .retrieval import RetrievalStage
+
+__all__ = [
+    "StageContext",
+    "InputRouterStage",
+    "ImagePreprocessorStage",
+    "OcrOrVisionStage",
+    "RetrievalStage",
+    "MainGenerationStage",
+    "AssistantPostprocessStage",
+    "AudioOutputStage",
+]

--- a/services/multi_runtime/stages/assistant_postprocess.py
+++ b/services/multi_runtime/stages/assistant_postprocess.py
@@ -1,0 +1,21 @@
+"""Assistant postprocess stage placeholder."""
+
+from __future__ import annotations
+
+from time import perf_counter
+
+from .base import StageContext
+
+
+class AssistantPostprocessStage:
+    name = "assistant_postprocess"
+
+    def run(self, context: StageContext) -> None:
+        started = perf_counter()
+        mode = str(context.state["policy"].assistant_mode)
+        context.diagnostics.assistant_used = mode != "off"
+        context.diagnostics.push_trace(
+            self.name,
+            started,
+            outcome="stub" if mode != "off" else "skipped",
+        )

--- a/services/multi_runtime/stages/assistant_postprocess.py
+++ b/services/multi_runtime/stages/assistant_postprocess.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from time import perf_counter
+from typing import Any
 
 from .base import StageContext
 
@@ -10,12 +11,70 @@ from .base import StageContext
 class AssistantPostprocessStage:
     name = "assistant_postprocess"
 
+    def __init__(self, daemon: Any | None = None):
+        self._daemon = daemon
+
     def run(self, context: StageContext) -> None:
         started = perf_counter()
         mode = str(context.state["policy"].assistant_mode)
-        context.diagnostics.assistant_used = mode != "off"
-        context.diagnostics.push_trace(
-            self.name,
-            started,
-            outcome="stub" if mode != "off" else "skipped",
-        )
+        if mode == "off":
+            context.diagnostics.assistant_used = False
+            context.diagnostics.push_trace(self.name, started, outcome="skipped")
+            return
+
+        assistant_model = context.daemon_status.get("assistant_model")
+        assistant_loaded = bool(context.daemon_status.get("assistant_loaded"))
+        if not assistant_model or not assistant_loaded or self._daemon is None:
+            context.diagnostics.assistant_used = False
+            context.diagnostics.add_degradation(
+                "assistant policy active but assistant model unavailable"
+            )
+            context.diagnostics.push_trace(self.name, started, outcome="degraded")
+            return
+
+        if (
+            mode == "conditional"
+            and not context.diagnostics.retrieval_used
+            and not bool(context.images)
+        ):
+            context.diagnostics.assistant_used = False
+            context.diagnostics.push_trace(self.name, started, outcome="skipped")
+            return
+
+        if context.state["policy"].economy_mode == "auto" and mode == "conditional":
+            context.diagnostics.assistant_used = False
+            context.diagnostics.economy_mode_activated = True
+            context.diagnostics.add_degradation(
+                "economy_mode skipped conditional assistant postprocess"
+            )
+            context.diagnostics.push_trace(self.name, started, outcome="degraded")
+            return
+
+        generated_text = str(context.state.get("generated_text", "")).strip()
+        if not generated_text:
+            context.diagnostics.assistant_used = False
+            context.diagnostics.push_trace(self.name, started, outcome="skipped")
+            return
+
+        try:
+            revised_text, _duration = self._daemon.respond_with_assistant(
+                prompt=generated_text,
+                system_prompt=(
+                    "Review the draft answer. Return the same answer if it is already "
+                    "clear and concise. Otherwise return a minimally improved version."
+                ),
+                max_new_tokens=min(192, max(64, len(generated_text.split()) * 8)),
+            )
+        except Exception as exc:
+            context.diagnostics.assistant_used = False
+            context.diagnostics.add_degradation(
+                f"assistant postprocess failed: {type(exc).__name__}"
+            )
+            context.diagnostics.push_trace(self.name, started, outcome="fallback")
+            return
+
+        revised_text = str(revised_text or "").strip()
+        if revised_text:
+            context.state["generated_text"] = revised_text
+        context.diagnostics.assistant_used = True
+        context.diagnostics.push_trace(self.name, started, outcome="ok")

--- a/services/multi_runtime/stages/audio_output.py
+++ b/services/multi_runtime/stages/audio_output.py
@@ -14,8 +14,29 @@ class AudioOutputStage:
         started = perf_counter()
         mode = str(context.state["policy"].audio_output_mode)
         context.state["audio_output_mode"] = mode
+        if mode == "off":
+            context.diagnostics.push_trace(self.name, started, outcome="skipped")
+            return
+
+        components = context.diagnostics.component_snapshot
+        tts_component = next(
+            (
+                item
+                for item in components
+                if str(item.get("component_id", "")) == "tts_component"
+            ),
+            None,
+        )
+        tts_available = bool(tts_component and tts_component.get("available"))
+        if not tts_available:
+            context.diagnostics.add_degradation(
+                "audio output requested but TTS backend unavailable"
+            )
+            context.diagnostics.push_trace(self.name, started, outcome="degraded")
+            return
+
         context.diagnostics.push_trace(
             self.name,
             started,
-            outcome="stub" if mode != "off" else "skipped",
+            outcome="stub",
         )

--- a/services/multi_runtime/stages/audio_output.py
+++ b/services/multi_runtime/stages/audio_output.py
@@ -1,0 +1,21 @@
+"""Audio output stage placeholder."""
+
+from __future__ import annotations
+
+from time import perf_counter
+
+from .base import StageContext
+
+
+class AudioOutputStage:
+    name = "audio_output"
+
+    def run(self, context: StageContext) -> None:
+        started = perf_counter()
+        mode = str(context.state["policy"].audio_output_mode)
+        context.state["audio_output_mode"] = mode
+        context.diagnostics.push_trace(
+            self.name,
+            started,
+            outcome="stub" if mode != "off" else "skipped",
+        )

--- a/services/multi_runtime/stages/base.py
+++ b/services/multi_runtime/stages/base.py
@@ -1,0 +1,20 @@
+"""Base pipeline stage contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..diagnostics import ExecutionDiagnostics
+
+
+@dataclass(slots=True)
+class StageContext:
+    request_payload: Any
+    daemon_status: dict[str, Any]
+    text_content: str | None
+    audio_array: Any
+    sample_rate: int
+    images: list[Any]
+    diagnostics: ExecutionDiagnostics
+    state: dict[str, Any] = field(default_factory=dict)

--- a/services/multi_runtime/stages/image_preprocessor.py
+++ b/services/multi_runtime/stages/image_preprocessor.py
@@ -1,0 +1,21 @@
+"""Image preprocessing stage for multimodal pipeline."""
+
+from __future__ import annotations
+
+from time import perf_counter
+
+from .base import StageContext
+
+
+class ImagePreprocessorStage:
+    name = "image_preprocessor"
+
+    def run(self, context: StageContext) -> None:
+        started = perf_counter()
+        if not context.images:
+            context.state["preprocessed_images"] = []
+            context.diagnostics.push_trace(self.name, started, outcome="skipped")
+            return
+
+        context.state["preprocessed_images"] = context.images
+        context.diagnostics.push_trace(self.name, started)

--- a/services/multi_runtime/stages/input_router.py
+++ b/services/multi_runtime/stages/input_router.py
@@ -1,0 +1,24 @@
+"""Input router stage for multimodal routing decisions."""
+
+from __future__ import annotations
+
+from time import perf_counter
+
+from ..router import route_inputs
+from .base import StageContext
+
+
+class InputRouterStage:
+    name = "input_router"
+
+    def run(self, context: StageContext) -> None:
+        started = perf_counter()
+        route = route_inputs(
+            text_content=context.text_content,
+            has_audio=context.audio_array is not None,
+            image_count=len(context.images),
+            image_strategy=context.state["policy"].image_strategy,
+        )
+        context.state["route"] = route
+        context.diagnostics.selected_image_strategy = route.image_strategy
+        context.diagnostics.push_trace(self.name, started)

--- a/services/multi_runtime/stages/main_generation.py
+++ b/services/multi_runtime/stages/main_generation.py
@@ -24,6 +24,12 @@ class MainGenerationStage:
             or request_payload.system_prompt
             or "Respond to the audio"
         )
+        ocr_text = str(context.state.get("ocr_text", "")).strip()
+        image_execution_path = str(
+            context.state.get("image_execution_path", "")
+        ).strip()
+        if ocr_text:
+            prompt = f"{prompt}\n\n[ocr_context path={image_execution_path or 'ocr'}]\n{ocr_text[:2000]}"
         retrieval_context = str(context.state.get("retrieval_context", "")).strip()
         if retrieval_context:
             prompt = f"{prompt}\n\n[retrieval_context]\n{retrieval_context}"

--- a/services/multi_runtime/stages/main_generation.py
+++ b/services/multi_runtime/stages/main_generation.py
@@ -6,6 +6,7 @@ from time import perf_counter
 from typing import Any
 
 from .base import StageContext
+from .ocr_or_vision import OCRResult
 
 
 class MainGenerationStage:
@@ -24,12 +25,21 @@ class MainGenerationStage:
             or request_payload.system_prompt
             or "Respond to the audio"
         )
-        ocr_text = str(context.state.get("ocr_text", "")).strip()
         image_execution_path = str(
             context.state.get("image_execution_path", "")
         ).strip()
-        if ocr_text:
-            prompt = f"{prompt}\n\n[ocr_context path={image_execution_path or 'ocr'}]\n{ocr_text[:2000]}"
+        ocr_result = context.state.get("ocr_result")
+        if isinstance(ocr_result, OCRResult):
+            ocr_block = ocr_result.prompt_block()
+            if ocr_block:
+                prompt = f"{prompt}\n\n{ocr_block}"
+        else:
+            ocr_text = str(context.state.get("ocr_text", "")).strip()
+            if ocr_text:
+                prompt = (
+                    f"{prompt}\n\n[ocr_context path={image_execution_path or 'ocr'}]\n"
+                    f"{ocr_text[:2000]}"
+                )
         retrieval_context = str(context.state.get("retrieval_context", "")).strip()
         if retrieval_context:
             prompt = f"{prompt}\n\n[retrieval_context]\n{retrieval_context}"

--- a/services/multi_runtime/stages/main_generation.py
+++ b/services/multi_runtime/stages/main_generation.py
@@ -1,0 +1,49 @@
+"""Main generation stage for the target model inference."""
+
+from __future__ import annotations
+
+from time import perf_counter
+from typing import Any
+
+from .base import StageContext
+
+
+class MainGenerationStage:
+    name = "main_generation"
+
+    def __init__(self, engine: Any):
+        self._engine = engine
+
+    def run(self, context: StageContext) -> None:
+        started = perf_counter()
+        daemon_params = context.daemon_status["params"]
+        request_payload = context.request_payload
+
+        prompt = (
+            context.text_content
+            or request_payload.system_prompt
+            or "Respond to the audio"
+        )
+        retrieval_context = str(context.state.get("retrieval_context", "")).strip()
+        if retrieval_context:
+            prompt = f"{prompt}\n\n[retrieval_context]\n{retrieval_context}"
+
+        generated_text, duration = self._engine.respond(
+            context.audio_array,
+            sample_rate=context.sample_rate,
+            prompt=prompt,
+            images=context.images or None,
+            task=request_payload.task,
+            question=request_payload.question,
+            system_prompt=request_payload.system_prompt,
+            max_new_tokens=request_payload.max_new_tokens,
+            temperature=request_payload.temperature,
+            top_p=request_payload.top_p,
+            do_sample=request_payload.do_sample,
+            enable_thinking=bool(daemon_params["enable_thinking"]),
+            cache_implementation=daemon_params["cache_implementation"],
+        )
+
+        context.state["generated_text"] = generated_text
+        context.state["audio_duration_sec"] = duration
+        context.diagnostics.push_trace(self.name, started)

--- a/services/multi_runtime/stages/ocr_or_vision.py
+++ b/services/multi_runtime/stages/ocr_or_vision.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib.util
 from time import perf_counter
 
+from PIL import Image
+
 from .base import StageContext
 
 
@@ -15,17 +17,30 @@ class OcrOrVisionStage:
     def _ocr_available() -> bool:
         return importlib.util.find_spec("pytesseract") is not None
 
+    @staticmethod
+    def _extract_ocr_text(images: list[Image.Image]) -> str:
+        import pytesseract  # type: ignore[import-not-found]
+
+        chunks: list[str] = []
+        for image in images:
+            text = str(pytesseract.image_to_string(image) or "").strip()
+            if text:
+                chunks.append(text)
+        return "\n\n".join(chunks).strip()
+
     def run(self, context: StageContext) -> None:
         started = perf_counter()
         images = context.state.get("preprocessed_images", [])
         if not images:
             context.state["image_execution_path"] = "none"
+            context.state["ocr_text"] = ""
             context.diagnostics.push_trace(self.name, started, outcome="skipped")
             return
 
         strategy = str(context.state["policy"].image_strategy)
         ocr_available = self._ocr_available()
         selected = strategy
+        ocr_text = ""
 
         if strategy == "ocr_first" and not ocr_available:
             selected = "vlm_only"
@@ -43,8 +58,21 @@ class OcrOrVisionStage:
             context.diagnostics.add_degradation(
                 "economy_mode simplified hybrid image path to vlm_only"
             )
+        elif strategy in {"ocr_first", "hybrid"} and ocr_available:
+            try:
+                ocr_text = self._extract_ocr_text(images)
+            except Exception as exc:
+                selected = "vlm_only" if strategy == "ocr_first" else selected
+                context.diagnostics.add_degradation(
+                    f"OCR extraction failed: {type(exc).__name__}"
+                )
+                if strategy == "ocr_first":
+                    context.diagnostics.add_degradation(
+                        "ocr_first fell back to vlm_only after OCR failure"
+                    )
 
         context.state["image_execution_path"] = selected
+        context.state["ocr_text"] = ocr_text
         context.diagnostics.selected_image_strategy = selected
         outcome = "ok" if selected == strategy else "degraded"
         context.diagnostics.push_trace(self.name, started, outcome=outcome)

--- a/services/multi_runtime/stages/ocr_or_vision.py
+++ b/services/multi_runtime/stages/ocr_or_vision.py
@@ -1,0 +1,32 @@
+"""Select OCR or direct vision path based on policy and availability."""
+
+from __future__ import annotations
+
+from time import perf_counter
+
+from .base import StageContext
+
+
+class OcrOrVisionStage:
+    name = "ocr_or_vision"
+
+    def run(self, context: StageContext) -> None:
+        started = perf_counter()
+        images = context.state.get("preprocessed_images", [])
+        if not images:
+            context.state["image_execution_path"] = "none"
+            context.diagnostics.push_trace(self.name, started, outcome="skipped")
+            return
+
+        strategy = str(context.state["policy"].image_strategy)
+        ocr_available = False
+        selected = strategy
+
+        if strategy == "ocr_first" and not ocr_available:
+            selected = "vlm_only"
+        elif strategy == "hybrid" and not ocr_available:
+            selected = "vlm_only"
+
+        context.state["image_execution_path"] = selected
+        context.diagnostics.selected_image_strategy = selected
+        context.diagnostics.push_trace(self.name, started)

--- a/services/multi_runtime/stages/ocr_or_vision.py
+++ b/services/multi_runtime/stages/ocr_or_vision.py
@@ -3,11 +3,55 @@
 from __future__ import annotations
 
 import importlib.util
+from dataclasses import dataclass, field
 from time import perf_counter
 
 from PIL import Image
 
 from .base import StageContext
+
+
+@dataclass(slots=True)
+class OCRToken:
+    text: str
+    confidence: float | None = None
+    bbox: tuple[int, int, int, int] | None = None
+    page: int | None = None
+    block: int | None = None
+    par: int | None = None
+    line: int | None = None
+    word: int | None = None
+
+
+@dataclass(slots=True)
+class OCRResult:
+    backend: str
+    available: bool
+    execution_path: str
+    text: str
+    lines: list[str] = field(default_factory=list)
+    tokens: list[OCRToken] = field(default_factory=list)
+    error: str | None = None
+
+    def prompt_block(self, limit: int = 12) -> str:
+        if not (self.lines or self.text or self.tokens or self.error):
+            return ""
+        parts: list[str] = [
+            f"[ocr_context backend={self.backend} path={self.execution_path} available={self.available}]"
+        ]
+        if self.lines:
+            for index, line in enumerate(self.lines[:limit], start=1):
+                parts.append(f"{index}. {line}")
+        elif self.text:
+            parts.append(self.text[:2000])
+        token_preview = ", ".join(
+            token.text for token in self.tokens[:24] if token.text.strip()
+        )
+        if token_preview:
+            parts.append(f"[tokens] {token_preview}")
+        if self.error:
+            parts.append(f"[ocr_error] {self.error}")
+        return "\n".join(parts).strip()
 
 
 class OcrOrVisionStage:
@@ -18,21 +62,114 @@ class OcrOrVisionStage:
         return importlib.util.find_spec("pytesseract") is not None
 
     @staticmethod
-    def _extract_ocr_text(images: list[Image.Image]) -> str:
+    def _extract_ocr_result(
+        images: list[Image.Image], execution_path: str
+    ) -> OCRResult:
         import pytesseract  # type: ignore[import-not-found]
 
         chunks: list[str] = []
+        lines: list[str] = []
+        tokens: list[OCRToken] = []
+
+        def _normalize_confidence(value: object) -> float | None:
+            try:
+                conf = float(value)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                return None
+            return conf if conf >= 0 else None
+
         for image in images:
             text = str(pytesseract.image_to_string(image) or "").strip()
             if text:
                 chunks.append(text)
-        return "\n\n".join(chunks).strip()
+            try:
+                data = pytesseract.image_to_data(
+                    image, output_type=pytesseract.Output.DICT
+                )
+            except Exception:
+                data = None
+            if not data:
+                if text:
+                    lines.extend(line for line in text.splitlines() if line.strip())
+                continue
+
+            group_order: list[tuple[int, int, int, int]] = []
+            group_tokens: dict[tuple[int, int, int, int], list[OCRToken]] = {}
+            page_numbers = data.get("page_num", [])
+            block_numbers = data.get("block_num", [])
+            par_numbers = data.get("par_num", [])
+            line_numbers = data.get("line_num", [])
+            word_numbers = data.get("word_num", [])
+            left_values = data.get("left", [])
+            top_values = data.get("top", [])
+            width_values = data.get("width", [])
+            height_values = data.get("height", [])
+            confidence_values = data.get("conf", [])
+            text_values = data.get("text", [])
+
+            for index, raw_token in enumerate(text_values):
+                token_text = str(raw_token or "").strip()
+                if not token_text:
+                    continue
+                group_key = (
+                    int(page_numbers[index] or 0),
+                    int(block_numbers[index] or 0),
+                    int(par_numbers[index] or 0),
+                    int(line_numbers[index] or 0),
+                )
+                token = OCRToken(
+                    text=token_text,
+                    confidence=_normalize_confidence(
+                        confidence_values[index]
+                        if index < len(confidence_values)
+                        else None
+                    ),
+                    bbox=(
+                        int(left_values[index] or 0),
+                        int(top_values[index] or 0),
+                        int(width_values[index] or 0),
+                        int(height_values[index] or 0),
+                    ),
+                    page=int(page_numbers[index] or 0),
+                    block=int(block_numbers[index] or 0),
+                    par=int(par_numbers[index] or 0),
+                    line=int(line_numbers[index] or 0),
+                    word=int(word_numbers[index] or 0),
+                )
+                tokens.append(token)
+                if group_key not in group_tokens:
+                    group_order.append(group_key)
+                    group_tokens[group_key] = []
+                group_tokens[group_key].append(token)
+
+            for group_key in group_order:
+                grouped_tokens = group_tokens.get(group_key, [])
+                line_text = " ".join(
+                    token.text for token in grouped_tokens if token.text.strip()
+                ).strip()
+                if line_text:
+                    lines.append(line_text)
+
+        return OCRResult(
+            backend="pytesseract",
+            available=True,
+            execution_path=execution_path,
+            text="\n\n".join(chunk for chunk in chunks if chunk).strip(),
+            lines=lines,
+            tokens=tokens,
+        )
 
     def run(self, context: StageContext) -> None:
         started = perf_counter()
         images = context.state.get("preprocessed_images", [])
         if not images:
             context.state["image_execution_path"] = "none"
+            context.state["ocr_result"] = OCRResult(
+                backend="pytesseract",
+                available=False,
+                execution_path="none",
+                text="",
+            )
             context.state["ocr_text"] = ""
             context.diagnostics.push_trace(self.name, started, outcome="skipped")
             return
@@ -40,29 +177,44 @@ class OcrOrVisionStage:
         strategy = str(context.state["policy"].image_strategy)
         ocr_available = self._ocr_available()
         selected = strategy
-        ocr_text = ""
+        ocr_result = OCRResult(
+            backend="pytesseract",
+            available=ocr_available,
+            execution_path=strategy,
+            text="",
+        )
 
         if strategy == "ocr_first" and not ocr_available:
             selected = "vlm_only"
+            ocr_result.execution_path = selected
             context.diagnostics.add_degradation(
                 "ocr_first requested but OCR backend unavailable; falling back to vlm_only"
             )
         elif strategy == "hybrid" and not ocr_available:
             selected = "vlm_only"
+            ocr_result.execution_path = selected
             context.diagnostics.add_degradation(
                 "hybrid requested but OCR backend unavailable; falling back to vlm_only"
             )
         elif context.state["policy"].economy_mode == "auto" and strategy == "hybrid":
             selected = "vlm_only"
+            ocr_result.execution_path = selected
             context.diagnostics.economy_mode_activated = True
             context.diagnostics.add_degradation(
                 "economy_mode simplified hybrid image path to vlm_only"
             )
         elif strategy in {"ocr_first", "hybrid"} and ocr_available:
             try:
-                ocr_text = self._extract_ocr_text(images)
+                ocr_result = self._extract_ocr_result(images, execution_path=strategy)
             except Exception as exc:
                 selected = "vlm_only" if strategy == "ocr_first" else selected
+                ocr_result = OCRResult(
+                    backend="pytesseract",
+                    available=True,
+                    execution_path=selected,
+                    text="",
+                    error=f"{type(exc).__name__}: {exc}",
+                )
                 context.diagnostics.add_degradation(
                     f"OCR extraction failed: {type(exc).__name__}"
                 )
@@ -72,7 +224,8 @@ class OcrOrVisionStage:
                     )
 
         context.state["image_execution_path"] = selected
-        context.state["ocr_text"] = ocr_text
+        context.state["ocr_result"] = ocr_result
+        context.state["ocr_text"] = ocr_result.text
         context.diagnostics.selected_image_strategy = selected
         outcome = "ok" if selected == strategy else "degraded"
         context.diagnostics.push_trace(self.name, started, outcome=outcome)

--- a/services/multi_runtime/stages/ocr_or_vision.py
+++ b/services/multi_runtime/stages/ocr_or_vision.py
@@ -78,6 +78,14 @@ class OcrOrVisionStage:
                 return None
             return conf if conf >= 0 else None
 
+        def _safe_int(values: object, index: int) -> int:
+            if not isinstance(values, list) or index >= len(values):
+                return 0
+            try:
+                return int(values[index] or 0)
+            except (TypeError, ValueError):
+                return 0
+
         for image in images:
             text = str(pytesseract.image_to_string(image) or "").strip()
             if text:
@@ -112,10 +120,10 @@ class OcrOrVisionStage:
                 if not token_text:
                     continue
                 group_key = (
-                    int(page_numbers[index] or 0),
-                    int(block_numbers[index] or 0),
-                    int(par_numbers[index] or 0),
-                    int(line_numbers[index] or 0),
+                    _safe_int(page_numbers, index),
+                    _safe_int(block_numbers, index),
+                    _safe_int(par_numbers, index),
+                    _safe_int(line_numbers, index),
                 )
                 token = OCRToken(
                     text=token_text,
@@ -125,16 +133,16 @@ class OcrOrVisionStage:
                         else None
                     ),
                     bbox=(
-                        int(left_values[index] or 0),
-                        int(top_values[index] or 0),
-                        int(width_values[index] or 0),
-                        int(height_values[index] or 0),
+                        _safe_int(left_values, index),
+                        _safe_int(top_values, index),
+                        _safe_int(width_values, index),
+                        _safe_int(height_values, index),
                     ),
-                    page=int(page_numbers[index] or 0),
-                    block=int(block_numbers[index] or 0),
-                    par=int(par_numbers[index] or 0),
-                    line=int(line_numbers[index] or 0),
-                    word=int(word_numbers[index] or 0),
+                    page=_safe_int(page_numbers, index),
+                    block=_safe_int(block_numbers, index),
+                    par=_safe_int(par_numbers, index),
+                    line=_safe_int(line_numbers, index),
+                    word=_safe_int(word_numbers, index),
                 )
                 tokens.append(token)
                 if group_key not in group_tokens:

--- a/services/multi_runtime/stages/ocr_or_vision.py
+++ b/services/multi_runtime/stages/ocr_or_vision.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 from time import perf_counter
 
 from .base import StageContext
@@ -9,6 +10,10 @@ from .base import StageContext
 
 class OcrOrVisionStage:
     name = "ocr_or_vision"
+
+    @staticmethod
+    def _ocr_available() -> bool:
+        return importlib.util.find_spec("pytesseract") is not None
 
     def run(self, context: StageContext) -> None:
         started = perf_counter()
@@ -19,14 +24,27 @@ class OcrOrVisionStage:
             return
 
         strategy = str(context.state["policy"].image_strategy)
-        ocr_available = False
+        ocr_available = self._ocr_available()
         selected = strategy
 
         if strategy == "ocr_first" and not ocr_available:
             selected = "vlm_only"
+            context.diagnostics.add_degradation(
+                "ocr_first requested but OCR backend unavailable; falling back to vlm_only"
+            )
         elif strategy == "hybrid" and not ocr_available:
             selected = "vlm_only"
+            context.diagnostics.add_degradation(
+                "hybrid requested but OCR backend unavailable; falling back to vlm_only"
+            )
+        elif context.state["policy"].economy_mode == "auto" and strategy == "hybrid":
+            selected = "vlm_only"
+            context.diagnostics.economy_mode_activated = True
+            context.diagnostics.add_degradation(
+                "economy_mode simplified hybrid image path to vlm_only"
+            )
 
         context.state["image_execution_path"] = selected
         context.diagnostics.selected_image_strategy = selected
-        context.diagnostics.push_trace(self.name, started)
+        outcome = "ok" if selected == strategy else "degraded"
+        context.diagnostics.push_trace(self.name, started, outcome=outcome)

--- a/services/multi_runtime/stages/retrieval.py
+++ b/services/multi_runtime/stages/retrieval.py
@@ -1,0 +1,33 @@
+"""Retrieval hook stage for multi_runtime pipeline."""
+
+from __future__ import annotations
+
+from time import perf_counter
+
+from .base import StageContext
+
+
+class RetrievalStage:
+    name = "retrieval"
+
+    def run(self, context: StageContext) -> None:
+        started = perf_counter()
+        mode = str(context.state["policy"].retrieval_mode)
+
+        if mode == "off":
+            context.state["retrieval_context"] = ""
+            context.diagnostics.retrieval_used = False
+            context.diagnostics.push_trace(self.name, started, outcome="skipped")
+            return
+
+        text = str(context.text_content or "").strip()
+        should_use = mode == "always" or (mode == "auto" and bool(text))
+        if not should_use:
+            context.state["retrieval_context"] = ""
+            context.diagnostics.retrieval_used = False
+            context.diagnostics.push_trace(self.name, started, outcome="skipped")
+            return
+
+        context.state["retrieval_context"] = ""
+        context.diagnostics.retrieval_used = True
+        context.diagnostics.push_trace(self.name, started, outcome="stub")

--- a/services/multi_runtime/stages/retrieval.py
+++ b/services/multi_runtime/stages/retrieval.py
@@ -15,8 +15,26 @@ from .base import StageContext
 class RetrievalStage:
     name = "retrieval"
 
-    def __init__(self, resolver: RetrievalPolicyResolver | None = None):
+    def __init__(
+        self,
+        resolver: RetrievalPolicyResolver | None = None,
+        graph_service: GraphRAGService | None = None,
+        vector_store: VectorStore | None = None,
+    ):
         self._resolver = resolver or RetrievalPolicyResolver()
+        self._graph_service = graph_service or GraphRAGService()
+        self._vector_store = vector_store or VectorStore()
+
+    @staticmethod
+    def _run_async(coro: object) -> object:
+        if not asyncio.iscoroutine(coro):
+            return coro
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(coro)
+        coro.close()  # type: ignore[union-attr]
+        raise RuntimeError("active_event_loop")
 
     def run(self, context: StageContext) -> None:
         started = perf_counter()
@@ -56,8 +74,8 @@ class RetrievalStage:
         retrieval_context = ""
         try:
             if route_name == "graph":
-                graph_result = asyncio.run(
-                    GraphRAGService().local_search(text, max_hops=2, limit=4)
+                graph_result = self._run_async(
+                    self._graph_service.local_search(text, max_hops=2, limit=4)
                 )
                 graph_result = str(graph_result or "").strip()
                 if graph_result and "Nie znaleziono" not in graph_result:
@@ -66,7 +84,7 @@ class RetrievalStage:
                 else:
                     route_name = "vector_fallback"
             if not retrieval_context:
-                results = VectorStore().search(text, limit=3)
+                results = self._vector_store.search(text, limit=3)
                 snippets = [
                     str(item.get("text", "")).strip()
                     for item in results

--- a/services/multi_runtime/stages/retrieval.py
+++ b/services/multi_runtime/stages/retrieval.py
@@ -8,56 +8,15 @@ from time import perf_counter
 from venom_core.memory.graph_rag_service import GraphRAGService
 from venom_core.memory.vector_store import VectorStore
 
+from ..retrieval_policy_resolver import RetrievalPolicyResolver
 from .base import StageContext
 
 
 class RetrievalStage:
     name = "retrieval"
 
-    @staticmethod
-    def _should_use_graph(query: str) -> bool:
-        normalized = query.lower()
-        return any(
-            token in normalized
-            for token in (
-                "związek",
-                "zwiazek",
-                "powiaz",
-                "relac",
-                "między",
-                "miedzy",
-                "between",
-                "relationship",
-                "compare",
-                "porown",
-            )
-        )
-
-    def _should_use_auto(self, text: str, context: StageContext) -> bool:
-        normalized = text.lower()
-        route = context.state.get("route")
-        if getattr(route, "primary_modality", None) == "image":
-            return False
-        return (
-            "?" in text
-            or len(text) >= 48
-            or any(
-                token in normalized
-                for token in (
-                    "co to",
-                    "dlaczego",
-                    "jak",
-                    "kiedy",
-                    "gdzie",
-                    "przypomnij",
-                    "znajd",
-                    "sprawdz",
-                    "explain",
-                    "why",
-                    "what",
-                )
-            )
-        )
+    def __init__(self, resolver: RetrievalPolicyResolver | None = None):
+        self._resolver = resolver or RetrievalPolicyResolver()
 
     def run(self, context: StageContext) -> None:
         started = perf_counter()
@@ -66,32 +25,37 @@ class RetrievalStage:
         if mode == "off":
             context.state["retrieval_context"] = ""
             context.diagnostics.retrieval_used = False
+            context.diagnostics.retrieval_context_items = 0
+            context.diagnostics.retrieval_route = "none"
             context.diagnostics.push_trace(self.name, started, outcome="skipped")
             return
 
         text = str(context.text_content or "").strip()
-        should_use = mode == "always" or (
-            mode == "auto" and self._should_use_auto(text, context)
+        route = context.state.get("route")
+        primary_modality = getattr(route, "primary_modality", None)
+        decision = self._resolver.resolve(
+            text=text,
+            mode=mode,
+            primary_modality=primary_modality,
+            economy_mode=context.state["policy"].economy_mode,
         )
-        if not should_use:
+        context.state["retrieval_policy_decision"] = decision
+
+        if not decision.should_use:
             context.state["retrieval_context"] = ""
             context.diagnostics.retrieval_used = False
+            context.diagnostics.retrieval_context_items = 0
+            context.diagnostics.retrieval_route = "none"
+            if "economy" in str(decision.reason or "").lower():
+                context.diagnostics.economy_mode_activated = True
+                context.diagnostics.add_degradation(str(decision.reason or ""))
             context.diagnostics.push_trace(self.name, started, outcome="skipped")
             return
 
-        if context.state["policy"].economy_mode == "auto" and mode == "auto":
-            context.state["retrieval_context"] = ""
-            context.diagnostics.retrieval_used = False
-            context.diagnostics.economy_mode_activated = True
-            context.diagnostics.add_degradation("economy_mode skipped auto retrieval")
-            context.diagnostics.push_trace(self.name, started, outcome="degraded")
-            return
-
-        route = "vector"
+        route_name = decision.route_hint
         retrieval_context = ""
         try:
-            if self._should_use_graph(text):
-                route = "graph"
+            if route_name == "graph":
                 graph_result = asyncio.run(
                     GraphRAGService().local_search(text, max_hops=2, limit=4)
                 )
@@ -100,7 +64,7 @@ class RetrievalStage:
                     retrieval_context = graph_result[:2400]
                     context.diagnostics.retrieval_context_items = 1
                 else:
-                    route = "vector_fallback"
+                    route_name = "vector_fallback"
             if not retrieval_context:
                 results = VectorStore().search(text, limit=3)
                 snippets = [
@@ -114,6 +78,8 @@ class RetrievalStage:
         except Exception as exc:
             context.state["retrieval_context"] = ""
             context.diagnostics.retrieval_used = False
+            context.diagnostics.retrieval_context_items = 0
+            context.diagnostics.retrieval_route = "none"
             context.diagnostics.add_degradation(
                 f"retrieval unavailable: {type(exc).__name__}"
             )
@@ -123,10 +89,12 @@ class RetrievalStage:
         if not retrieval_context:
             context.state["retrieval_context"] = ""
             context.diagnostics.retrieval_used = False
+            context.diagnostics.retrieval_context_items = 0
+            context.diagnostics.retrieval_route = route_name
             context.diagnostics.push_trace(self.name, started, outcome="empty")
             return
 
         context.state["retrieval_context"] = retrieval_context
         context.diagnostics.retrieval_used = True
-        context.diagnostics.retrieval_route = route
+        context.diagnostics.retrieval_route = route_name
         context.diagnostics.push_trace(self.name, started, outcome="ok")

--- a/services/multi_runtime/stages/retrieval.py
+++ b/services/multi_runtime/stages/retrieval.py
@@ -4,11 +4,39 @@ from __future__ import annotations
 
 from time import perf_counter
 
+from venom_core.memory.vector_store import VectorStore
+
 from .base import StageContext
 
 
 class RetrievalStage:
     name = "retrieval"
+
+    def _should_use_auto(self, text: str, context: StageContext) -> bool:
+        normalized = text.lower()
+        route = context.state.get("route")
+        if getattr(route, "primary_modality", None) == "image":
+            return False
+        return (
+            "?" in text
+            or len(text) >= 48
+            or any(
+                token in normalized
+                for token in (
+                    "co to",
+                    "dlaczego",
+                    "jak",
+                    "kiedy",
+                    "gdzie",
+                    "przypomnij",
+                    "znajd",
+                    "sprawdz",
+                    "explain",
+                    "why",
+                    "what",
+                )
+            )
+        )
 
     def run(self, context: StageContext) -> None:
         started = perf_counter()
@@ -21,13 +49,47 @@ class RetrievalStage:
             return
 
         text = str(context.text_content or "").strip()
-        should_use = mode == "always" or (mode == "auto" and bool(text))
+        should_use = mode == "always" or (
+            mode == "auto" and self._should_use_auto(text, context)
+        )
         if not should_use:
             context.state["retrieval_context"] = ""
             context.diagnostics.retrieval_used = False
             context.diagnostics.push_trace(self.name, started, outcome="skipped")
             return
 
-        context.state["retrieval_context"] = ""
+        if context.state["policy"].economy_mode == "auto" and mode == "auto":
+            context.state["retrieval_context"] = ""
+            context.diagnostics.retrieval_used = False
+            context.diagnostics.economy_mode_activated = True
+            context.diagnostics.add_degradation("economy_mode skipped auto retrieval")
+            context.diagnostics.push_trace(self.name, started, outcome="degraded")
+            return
+
+        try:
+            results = VectorStore().search(text, limit=3)
+        except Exception as exc:
+            context.state["retrieval_context"] = ""
+            context.diagnostics.retrieval_used = False
+            context.diagnostics.add_degradation(
+                f"retrieval unavailable: {type(exc).__name__}"
+            )
+            context.diagnostics.push_trace(self.name, started, outcome="fallback")
+            return
+
+        snippets = [
+            str(item.get("text", "")).strip()
+            for item in results
+            if str(item.get("text", "")).strip()
+        ]
+        if not snippets:
+            context.state["retrieval_context"] = ""
+            context.diagnostics.retrieval_used = False
+            context.diagnostics.push_trace(self.name, started, outcome="empty")
+            return
+
+        limited = snippets[:2]
+        context.state["retrieval_context"] = "\n\n".join(limited)
         context.diagnostics.retrieval_used = True
-        context.diagnostics.push_trace(self.name, started, outcome="stub")
+        context.diagnostics.retrieval_context_items = len(limited)
+        context.diagnostics.push_trace(self.name, started, outcome="ok")

--- a/services/multi_runtime/stages/retrieval.py
+++ b/services/multi_runtime/stages/retrieval.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 from time import perf_counter
 
+from venom_core.memory.graph_rag_service import GraphRAGService
 from venom_core.memory.vector_store import VectorStore
 
 from .base import StageContext
@@ -11,6 +13,25 @@ from .base import StageContext
 
 class RetrievalStage:
     name = "retrieval"
+
+    @staticmethod
+    def _should_use_graph(query: str) -> bool:
+        normalized = query.lower()
+        return any(
+            token in normalized
+            for token in (
+                "związek",
+                "zwiazek",
+                "powiaz",
+                "relac",
+                "między",
+                "miedzy",
+                "between",
+                "relationship",
+                "compare",
+                "porown",
+            )
+        )
 
     def _should_use_auto(self, text: str, context: StageContext) -> bool:
         normalized = text.lower()
@@ -66,8 +87,30 @@ class RetrievalStage:
             context.diagnostics.push_trace(self.name, started, outcome="degraded")
             return
 
+        route = "vector"
+        retrieval_context = ""
         try:
-            results = VectorStore().search(text, limit=3)
+            if self._should_use_graph(text):
+                route = "graph"
+                graph_result = asyncio.run(
+                    GraphRAGService().local_search(text, max_hops=2, limit=4)
+                )
+                graph_result = str(graph_result or "").strip()
+                if graph_result and "Nie znaleziono" not in graph_result:
+                    retrieval_context = graph_result[:2400]
+                    context.diagnostics.retrieval_context_items = 1
+                else:
+                    route = "vector_fallback"
+            if not retrieval_context:
+                results = VectorStore().search(text, limit=3)
+                snippets = [
+                    str(item.get("text", "")).strip()
+                    for item in results
+                    if str(item.get("text", "")).strip()
+                ]
+                limited = snippets[:2]
+                retrieval_context = "\n\n".join(limited)
+                context.diagnostics.retrieval_context_items = len(limited)
         except Exception as exc:
             context.state["retrieval_context"] = ""
             context.diagnostics.retrieval_used = False
@@ -77,19 +120,13 @@ class RetrievalStage:
             context.diagnostics.push_trace(self.name, started, outcome="fallback")
             return
 
-        snippets = [
-            str(item.get("text", "")).strip()
-            for item in results
-            if str(item.get("text", "")).strip()
-        ]
-        if not snippets:
+        if not retrieval_context:
             context.state["retrieval_context"] = ""
             context.diagnostics.retrieval_used = False
             context.diagnostics.push_trace(self.name, started, outcome="empty")
             return
 
-        limited = snippets[:2]
-        context.state["retrieval_context"] = "\n\n".join(limited)
+        context.state["retrieval_context"] = retrieval_context
         context.diagnostics.retrieval_used = True
-        context.diagnostics.retrieval_context_items = len(limited)
+        context.diagnostics.retrieval_route = route
         context.diagnostics.push_trace(self.name, started, outcome="ok")

--- a/tests/test_214a_daemon_management.py
+++ b/tests/test_214a_daemon_management.py
@@ -185,6 +185,12 @@ def test_daemon_config_cache_change_triggers_soft_reload():
         emotion_detection_enabled=None,
         emotion_response_style_enabled=None,
         cache_implementation="static",
+        execution_mode=None,
+        image_strategy=None,
+        retrieval_mode=None,
+        audio_output_mode=None,
+        assistant_mode=None,
+        economy_mode=None,
     )
 
 

--- a/tests/test_217da_multi_runtime_pipeline_basics.py
+++ b/tests/test_217da_multi_runtime_pipeline_basics.py
@@ -127,6 +127,7 @@ def test_component_snapshot_reflects_policy_modes(monkeypatch) -> None:
     assert by_id["embedding_component"]["enabled"] is True
     assert by_id["tts_component"]["enabled"] is True
     assert by_id["assistant_model"]["enabled"] is True
+    assert "ocr_component" in by_id
     assert by_id["image_input"]["last_error"] is not None
 
 
@@ -188,6 +189,33 @@ def test_ocr_stage_degrades_when_backend_unavailable(monkeypatch) -> None:
     assert context.diagnostics.degradation_reasons
 
 
+def test_ocr_stage_extracts_text_when_backend_available(monkeypatch) -> None:
+    monkeypatch.setattr(OcrOrVisionStage, "_ocr_available", staticmethod(lambda: True))
+    monkeypatch.setattr(
+        OcrOrVisionStage,
+        "_extract_ocr_text",
+        staticmethod(lambda images: "Wykryty tekst z OCR"),
+    )
+    policy = RuntimePolicyResolver().resolve(
+        daemon_status=_daemon_status(params={"image_strategy": "ocr_first"}),
+        has_images=True,
+        has_audio=False,
+    )
+    context = StageContext(
+        request_payload=_Payload(),
+        daemon_status=_daemon_status(params={"image_strategy": "ocr_first"}),
+        text_content="odczytaj tekst",
+        audio_array=None,
+        sample_rate=16000,
+        images=["fake-image"],
+        diagnostics=ExecutionDiagnostics(),
+        state={"policy": policy, "preprocessed_images": ["fake-image"]},
+    )
+    OcrOrVisionStage().run(context)
+    assert context.state["image_execution_path"] == "ocr_first"
+    assert context.state["ocr_text"] == "Wykryty tekst z OCR"
+
+
 def test_assistant_stage_uses_daemon_when_available() -> None:
     policy = RuntimePolicyResolver().resolve(
         daemon_status=_daemon_status(
@@ -240,3 +268,39 @@ def test_retrieval_stage_marks_economy_mode_degradation() -> None:
     RetrievalStage().run(context)
     assert context.diagnostics.economy_mode_activated is True
     assert context.diagnostics.degradation_reasons
+
+
+def test_retrieval_stage_uses_graph_route_for_relational_queries(monkeypatch) -> None:
+    class _FakeGraphRAGService:
+        def local_search(self, query, max_hops=2, llm_service=None, limit=4):
+            async def _run():
+                assert "związek" in query
+                assert max_hops == 2
+                assert limit == 4
+                return "Graph context answer"
+
+            return _run()
+
+    monkeypatch.setattr(
+        "services.multi_runtime.stages.retrieval.GraphRAGService", _FakeGraphRAGService
+    )
+    context = StageContext(
+        request_payload=_Payload(),
+        daemon_status=_daemon_status(params={"retrieval_mode": "always"}),
+        text_content="Jaki jest związek między A i B?",
+        audio_array=None,
+        sample_rate=16000,
+        images=[],
+        diagnostics=ExecutionDiagnostics(),
+        state={
+            "policy": RuntimePolicyResolver().resolve(
+                daemon_status=_daemon_status(params={"retrieval_mode": "always"}),
+                has_images=False,
+                has_audio=False,
+            )
+        },
+    )
+    RetrievalStage().run(context)
+    assert context.diagnostics.retrieval_used is True
+    assert context.diagnostics.retrieval_route == "graph"
+    assert context.state["retrieval_context"] == "Graph context answer"

--- a/tests/test_217da_multi_runtime_pipeline_basics.py
+++ b/tests/test_217da_multi_runtime_pipeline_basics.py
@@ -1,0 +1,87 @@
+from services.multi_runtime.components import build_component_snapshot
+from services.multi_runtime.pipeline import MultiRuntimePipeline, PipelineRequestData
+from services.multi_runtime.policies import RuntimePolicyResolver
+from services.multi_runtime.router import route_inputs
+
+
+def _daemon_status(**overrides):
+    base = {
+        "target_model": "google/gemma-4-E2B-it",
+        "assistant_model": None,
+        "target_loaded": True,
+        "assistant_loaded": False,
+        "supports_image_input": True,
+        "vram": {"backend": "cuda"},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_policy_resolver_selects_vision_priority_for_image_only() -> None:
+    policy = RuntimePolicyResolver().resolve(
+        daemon_status=_daemon_status(), has_images=True, has_audio=False
+    )
+    assert policy.execution_mode == "vision_priority"
+    assert policy.image_strategy == "vlm_only"
+
+
+def test_route_inputs_classifies_audio_as_primary() -> None:
+    route = route_inputs(
+        text_content="co slychac",
+        has_audio=True,
+        image_count=1,
+        image_strategy="vlm_only",
+    )
+    assert route.primary_modality == "audio"
+    assert route.has_images is True
+
+
+def test_component_snapshot_exposes_main_model() -> None:
+    snapshot = build_component_snapshot(_daemon_status())
+    component_ids = {item["component_id"] for item in snapshot}
+    assert "main_model" in component_ids
+    assert "retrieval_component" in component_ids
+
+
+class _FakeEngine:
+    model_id = "fake/model"
+
+    def respond(self, *_args, **_kwargs):
+        return "ok", 0.0
+
+
+class _Payload:
+    task = None
+    question = None
+    system_prompt = None
+    max_new_tokens = 64
+    temperature = None
+    top_p = None
+    do_sample = None
+
+
+def test_pipeline_trace_includes_retrieval_stage() -> None:
+    daemon_status = _daemon_status(
+        params={
+            "enable_thinking": False,
+            "cache_implementation": None,
+            "execution_mode": "balanced",
+            "image_strategy": "vlm_only",
+            "retrieval_mode": "always",
+            "audio_output_mode": "off",
+            "assistant_mode": "off",
+            "economy_mode": "off",
+        }
+    )
+    result = MultiRuntimePipeline(_FakeEngine()).execute(
+        daemon_status=daemon_status,
+        request=PipelineRequestData(
+            request_payload=_Payload(),
+            text_content="test",
+            audio_array=None,
+            sample_rate=16000,
+            images=[],
+        ),
+    )
+    assert "retrieval" in result.diagnostics.trace_names()
+    assert result.diagnostics.retrieval_used is True

--- a/tests/test_217da_multi_runtime_pipeline_basics.py
+++ b/tests/test_217da_multi_runtime_pipeline_basics.py
@@ -1,13 +1,19 @@
+import sys
+import types
+
+from PIL import Image
+
 from services.multi_runtime.components import build_component_snapshot
 from services.multi_runtime.diagnostics import ExecutionDiagnostics
 from services.multi_runtime.pipeline import MultiRuntimePipeline, PipelineRequestData
 from services.multi_runtime.policies import RuntimePolicyResolver
+from services.multi_runtime.retrieval_policy_resolver import RetrievalPolicyResolver
 from services.multi_runtime.router import route_inputs
 from services.multi_runtime.stages.assistant_postprocess import (
     AssistantPostprocessStage,
 )
 from services.multi_runtime.stages.base import StageContext
-from services.multi_runtime.stages.ocr_or_vision import OcrOrVisionStage
+from services.multi_runtime.stages.ocr_or_vision import OcrOrVisionStage, OCRResult
 from services.multi_runtime.stages.retrieval import RetrievalStage
 
 
@@ -193,8 +199,16 @@ def test_ocr_stage_extracts_text_when_backend_available(monkeypatch) -> None:
     monkeypatch.setattr(OcrOrVisionStage, "_ocr_available", staticmethod(lambda: True))
     monkeypatch.setattr(
         OcrOrVisionStage,
-        "_extract_ocr_text",
-        staticmethod(lambda images: "Wykryty tekst z OCR"),
+        "_extract_ocr_result",
+        staticmethod(
+            lambda images, execution_path: OCRResult(
+                backend="pytesseract",
+                available=True,
+                execution_path=execution_path,
+                text="Wykryty tekst z OCR",
+                lines=["Wykryty tekst z OCR"],
+            )
+        ),
     )
     policy = RuntimePolicyResolver().resolve(
         daemon_status=_daemon_status(params={"image_strategy": "ocr_first"}),
@@ -304,3 +318,61 @@ def test_retrieval_stage_uses_graph_route_for_relational_queries(monkeypatch) ->
     assert context.diagnostics.retrieval_used is True
     assert context.diagnostics.retrieval_route == "graph"
     assert context.state["retrieval_context"] == "Graph context answer"
+
+
+def test_retrieval_policy_resolver_prefers_graph_for_relation_queries() -> None:
+    decision = RetrievalPolicyResolver().resolve(
+        text="Jaki jest związek między A i B?",
+        mode="auto",
+        primary_modality="text",
+        economy_mode="off",
+    )
+    assert decision.should_use is True
+    assert decision.route_hint == "graph"
+    assert "graph" in decision.reason or "relationship" in (decision.reason or "")
+
+
+def test_ocr_stage_records_structured_result(monkeypatch) -> None:
+    fake_pytesseract = types.ModuleType("pytesseract")
+    fake_pytesseract.Output = type("Output", (), {"DICT": object()})
+    fake_pytesseract.image_to_string = lambda image: "Witaj świecie"
+    fake_pytesseract.image_to_data = lambda image, output_type=None: {
+        "page_num": [1],
+        "block_num": [1],
+        "par_num": [1],
+        "line_num": [1],
+        "word_num": [1],
+        "left": [12],
+        "top": [18],
+        "width": [42],
+        "height": [16],
+        "conf": ["91"],
+        "text": ["Witaj"],
+    }
+    monkeypatch.setattr(
+        "services.multi_runtime.stages.ocr_or_vision.importlib.util.find_spec",
+        lambda name: object() if name == "pytesseract" else None,
+    )
+    monkeypatch.setitem(sys.modules, "pytesseract", fake_pytesseract)
+
+    policy = RuntimePolicyResolver().resolve(
+        daemon_status=_daemon_status(params={"image_strategy": "ocr_first"}),
+        has_images=True,
+        has_audio=False,
+    )
+    image = Image.new("RGB", (32, 32), color="white")
+    context = StageContext(
+        request_payload=_Payload(),
+        daemon_status=_daemon_status(params={"image_strategy": "ocr_first"}),
+        text_content="odczytaj tekst",
+        audio_array=None,
+        sample_rate=16000,
+        images=[image],
+        diagnostics=ExecutionDiagnostics(),
+        state={"policy": policy, "preprocessed_images": [image]},
+    )
+    OcrOrVisionStage().run(context)
+    ocr_result = context.state["ocr_result"]
+    assert ocr_result.text == "Witaj świecie"
+    assert ocr_result.lines == ["Witaj"]
+    assert ocr_result.tokens[0].text == "Witaj"

--- a/tests/test_217da_multi_runtime_pipeline_basics.py
+++ b/tests/test_217da_multi_runtime_pipeline_basics.py
@@ -1,7 +1,14 @@
 from services.multi_runtime.components import build_component_snapshot
+from services.multi_runtime.diagnostics import ExecutionDiagnostics
 from services.multi_runtime.pipeline import MultiRuntimePipeline, PipelineRequestData
 from services.multi_runtime.policies import RuntimePolicyResolver
 from services.multi_runtime.router import route_inputs
+from services.multi_runtime.stages.assistant_postprocess import (
+    AssistantPostprocessStage,
+)
+from services.multi_runtime.stages.base import StageContext
+from services.multi_runtime.stages.ocr_or_vision import OcrOrVisionStage
+from services.multi_runtime.stages.retrieval import RetrievalStage
 
 
 def _daemon_status(**overrides):
@@ -50,6 +57,11 @@ class _FakeEngine:
         return "ok", 0.0
 
 
+class _FakeDaemon:
+    def respond_with_assistant(self, **_kwargs):
+        return "assistant revised", 0.0
+
+
 class _Payload:
     task = None
     question = None
@@ -60,7 +72,16 @@ class _Payload:
     do_sample = None
 
 
-def test_pipeline_trace_includes_retrieval_stage() -> None:
+def test_pipeline_trace_includes_retrieval_stage(monkeypatch) -> None:
+    class _FakeVectorStore:
+        def search(self, query, limit=3):
+            assert query == "test"
+            assert limit == 3
+            return [{"text": "retrieved chunk", "metadata": {}, "score": 0.1}]
+
+    monkeypatch.setattr(
+        "services.multi_runtime.stages.retrieval.VectorStore", _FakeVectorStore
+    )
     daemon_status = _daemon_status(
         params={
             "enable_thinking": False,
@@ -85,3 +106,137 @@ def test_pipeline_trace_includes_retrieval_stage() -> None:
     )
     assert "retrieval" in result.diagnostics.trace_names()
     assert result.diagnostics.retrieval_used is True
+    assert result.diagnostics.retrieval_context_items == 1
+
+
+def test_component_snapshot_reflects_policy_modes(monkeypatch) -> None:
+    monkeypatch.setenv("TTS_MODEL_PATH", "/tmp/missing-voice.onnx")
+    snapshot = build_component_snapshot(
+        _daemon_status(
+            assistant_model="assistant/model",
+            params={
+                "retrieval_mode": "always",
+                "audio_output_mode": "voice_first",
+                "assistant_mode": "attached",
+                "image_strategy": "ocr_first",
+            },
+        )
+    )
+    by_id = {item["component_id"]: item for item in snapshot}
+    assert by_id["retrieval_component"]["enabled"] is True
+    assert by_id["embedding_component"]["enabled"] is True
+    assert by_id["tts_component"]["enabled"] is True
+    assert by_id["assistant_model"]["enabled"] is True
+    assert by_id["image_input"]["last_error"] is not None
+
+
+def test_retrieval_stage_uses_vector_store_results(monkeypatch) -> None:
+    class _FakeVectorStore:
+        def search(self, query, limit=3):
+            assert query == "jak dziala pamiec?"
+            assert limit == 3
+            return [
+                {"text": "fragment 1", "metadata": {}, "score": 0.1},
+                {"text": "fragment 2", "metadata": {}, "score": 0.2},
+            ]
+
+    monkeypatch.setattr(
+        "services.multi_runtime.stages.retrieval.VectorStore", _FakeVectorStore
+    )
+    context = StageContext(
+        request_payload=_Payload(),
+        daemon_status=_daemon_status(params={"retrieval_mode": "always"}),
+        text_content="jak dziala pamiec?",
+        audio_array=None,
+        sample_rate=16000,
+        images=[],
+        diagnostics=ExecutionDiagnostics(),
+        state={
+            "policy": RuntimePolicyResolver().resolve(
+                daemon_status=_daemon_status(params={"retrieval_mode": "always"}),
+                has_images=False,
+                has_audio=False,
+            )
+        },
+    )
+    RetrievalStage().run(context)
+    assert context.state["retrieval_context"] == "fragment 1\n\nfragment 2"
+    assert context.diagnostics.retrieval_used is True
+    assert context.diagnostics.retrieval_context_items == 2
+
+
+def test_ocr_stage_degrades_when_backend_unavailable(monkeypatch) -> None:
+    monkeypatch.setattr(OcrOrVisionStage, "_ocr_available", staticmethod(lambda: False))
+    policy = RuntimePolicyResolver().resolve(
+        daemon_status=_daemon_status(params={"image_strategy": "ocr_first"}),
+        has_images=True,
+        has_audio=False,
+    )
+    context = StageContext(
+        request_payload=_Payload(),
+        daemon_status=_daemon_status(params={"image_strategy": "ocr_first"}),
+        text_content="odczytaj",
+        audio_array=None,
+        sample_rate=16000,
+        images=["fake-image"],
+        diagnostics=ExecutionDiagnostics(),
+        state={"policy": policy, "preprocessed_images": ["fake-image"]},
+    )
+    OcrOrVisionStage().run(context)
+    assert context.state["image_execution_path"] == "vlm_only"
+    assert context.diagnostics.selected_image_strategy == "vlm_only"
+    assert context.diagnostics.degradation_reasons
+
+
+def test_assistant_stage_uses_daemon_when_available() -> None:
+    policy = RuntimePolicyResolver().resolve(
+        daemon_status=_daemon_status(
+            assistant_model="assistant/model",
+            assistant_loaded=True,
+            params={"assistant_mode": "attached"},
+        ),
+        has_images=False,
+        has_audio=False,
+    )
+    context = StageContext(
+        request_payload=_Payload(),
+        daemon_status=_daemon_status(
+            assistant_model="assistant/model",
+            assistant_loaded=True,
+            params={"assistant_mode": "attached"},
+        ),
+        text_content="hello",
+        audio_array=None,
+        sample_rate=16000,
+        images=[],
+        diagnostics=ExecutionDiagnostics(),
+        state={"policy": policy, "generated_text": "draft"},
+    )
+    AssistantPostprocessStage(_FakeDaemon()).run(context)
+    assert context.state["generated_text"] == "assistant revised"
+    assert context.diagnostics.assistant_used is True
+
+
+def test_retrieval_stage_marks_economy_mode_degradation() -> None:
+    policy = RuntimePolicyResolver().resolve(
+        daemon_status=_daemon_status(
+            params={"retrieval_mode": "auto", "economy_mode": "auto"}
+        ),
+        has_images=False,
+        has_audio=False,
+    )
+    context = StageContext(
+        request_payload=_Payload(),
+        daemon_status=_daemon_status(
+            params={"retrieval_mode": "auto", "economy_mode": "auto"}
+        ),
+        text_content="dlaczego to dziala?",
+        audio_array=None,
+        sample_rate=16000,
+        images=[],
+        diagnostics=ExecutionDiagnostics(),
+        state={"policy": policy},
+    )
+    RetrievalStage().run(context)
+    assert context.diagnostics.economy_mode_activated is True
+    assert context.diagnostics.degradation_reasons

--- a/tests/test_multi_runtime_profile_service.py
+++ b/tests/test_multi_runtime_profile_service.py
@@ -144,13 +144,15 @@ def test_build_profile_from_daemon_params():
     p = build_profile_from_daemon_params(
         target_model="google/gemma-4-E2B-it",
         assistant_model="google/gemma-4-1B-it",
-        max_new_tokens=256,
-        enable_thinking=True,
-        image_token_budget=560,
-        reasoning_summary_enabled=True,
-        emotion_detection_enabled=False,
-        emotion_response_style_enabled=False,
-        cache_implementation="static",
+        daemon_params={
+            "max_new_tokens": 256,
+            "enable_thinking": True,
+            "image_token_budget": 560,
+            "reasoning_summary_enabled": True,
+            "emotion_detection_enabled": False,
+            "emotion_response_style_enabled": False,
+            "cache_implementation": "static",
+        },
     )
     assert p.model_id == "google/gemma-4-E2B-it"
     assert p.assistant_model_id == "google/gemma-4-1B-it"

--- a/venom_core/api/audio_stream.py
+++ b/venom_core/api/audio_stream.py
@@ -114,6 +114,16 @@ def _build_voice_session_record(
         "emotion_confidence": metadata.get("emotion_confidence"),
         "transcription": metadata.get("transcription") or "",
         "response_text": metadata.get("response_text") or "",
+        "execution_trace": metadata.get("execution_trace") or [],
+        "selected_policy": metadata.get("selected_policy"),
+        "selected_image_strategy": metadata.get("selected_image_strategy"),
+        "retrieval_used": metadata.get("retrieval_used"),
+        "retrieval_context_items": metadata.get("retrieval_context_items"),
+        "retrieval_route": metadata.get("retrieval_route"),
+        "assistant_used": metadata.get("assistant_used"),
+        "economy_mode_activated": metadata.get("economy_mode_activated"),
+        "degradation_reasons": metadata.get("degradation_reasons") or [],
+        "component_snapshot": metadata.get("component_snapshot") or [],
     }
 
 
@@ -808,6 +818,16 @@ class AudioStreamHandler:
             "emotion_label": data.get("emotion_label"),
             "emotion_confidence": data.get("emotion_confidence"),
             "emotion_source": data.get("emotion_source"),
+            "execution_trace": data.get("execution_trace") or [],
+            "selected_policy": data.get("selected_policy"),
+            "selected_image_strategy": data.get("selected_image_strategy"),
+            "retrieval_used": bool(data.get("retrieval_used", False)),
+            "retrieval_context_items": data.get("retrieval_context_items"),
+            "retrieval_route": data.get("retrieval_route"),
+            "assistant_used": bool(data.get("assistant_used", False)),
+            "economy_mode_activated": bool(data.get("economy_mode_activated", False)),
+            "degradation_reasons": data.get("degradation_reasons") or [],
+            "component_snapshot": data.get("component_snapshot") or [],
         }
 
     async def _process_native_gemma4_audio_pipeline(
@@ -916,6 +936,20 @@ class AudioStreamHandler:
                 "transcription_length": len(transcription or ""),
                 "response_text": response_text,
                 "response_length": len(response_text or ""),
+                "execution_trace": runtime_result.get("execution_trace") or [],
+                "selected_policy": runtime_result.get("selected_policy"),
+                "selected_image_strategy": runtime_result.get(
+                    "selected_image_strategy"
+                ),
+                "retrieval_used": runtime_result.get("retrieval_used"),
+                "retrieval_context_items": runtime_result.get(
+                    "retrieval_context_items"
+                ),
+                "retrieval_route": runtime_result.get("retrieval_route"),
+                "assistant_used": runtime_result.get("assistant_used"),
+                "economy_mode_activated": runtime_result.get("economy_mode_activated"),
+                "degradation_reasons": runtime_result.get("degradation_reasons") or [],
+                "component_snapshot": runtime_result.get("component_snapshot") or [],
                 **insights,
                 "timings_ms": timings_ms,
                 "runtime": self._build_runtime_metadata(operator_agent),

--- a/venom_core/api/schemas/multi_runtime_profile.py
+++ b/venom_core/api/schemas/multi_runtime_profile.py
@@ -70,6 +70,24 @@ class MultiRuntimeProfile(BaseModel):
     emotion_response_style_enabled: bool = Field(
         False, description="Adapt response style based on detected emotion"
     )
+    execution_mode: Literal["balanced", "vision_priority", "voice_priority"] = Field(
+        "balanced", description="High-level execution mode selector"
+    )
+    image_strategy: Literal["vlm_only", "ocr_first", "hybrid"] = Field(
+        "vlm_only", description="Image processing strategy"
+    )
+    retrieval_mode: Literal["off", "auto", "always"] = Field(
+        "off", description="Retrieval stage activation mode"
+    )
+    audio_output_mode: Literal["off", "text_first", "voice_first"] = Field(
+        "off", description="Audio output behavior mode"
+    )
+    assistant_mode: Literal["off", "attached", "conditional"] = Field(
+        "off", description="Assistant usage mode"
+    )
+    economy_mode: Literal["off", "auto"] = Field(
+        "off", description="Economy/degradation mode"
+    )
 
     # --- Prepared limited fields (apply_mode=unsupported until loader supports them) ---
     precision: str = Field(
@@ -104,6 +122,12 @@ class MultiRuntimeApplyMatrix(BaseModel):
     reasoning_summary_enabled: ApplyMode = "live"
     emotion_detection_enabled: ApplyMode = "live"
     emotion_response_style_enabled: ApplyMode = "live"
+    execution_mode: ApplyMode = "live"
+    image_strategy: ApplyMode = "live"
+    retrieval_mode: ApplyMode = "live"
+    audio_output_mode: ApplyMode = "live"
+    assistant_mode: ApplyMode = "live"
+    economy_mode: ApplyMode = "live"
     precision: ApplyMode = "unsupported"
     quantization_backend: ApplyMode = "unsupported"
     device_target: ApplyMode = "unsupported"
@@ -118,6 +142,20 @@ class MultiRuntimeSupportedOptions(BaseModel):
     precision: list[str] = Field(default_factory=lambda: ["auto"])
     device_target: list[str] = Field(default_factory=lambda: ["auto", "cpu", "cuda"])
     quantization_backend: list[Optional[str]] = Field(default_factory=lambda: [None])
+    execution_mode: list[str] = Field(
+        default_factory=lambda: ["balanced", "vision_priority", "voice_priority"]
+    )
+    image_strategy: list[str] = Field(
+        default_factory=lambda: ["vlm_only", "ocr_first", "hybrid"]
+    )
+    retrieval_mode: list[str] = Field(default_factory=lambda: ["off", "auto", "always"])
+    audio_output_mode: list[str] = Field(
+        default_factory=lambda: ["off", "text_first", "voice_first"]
+    )
+    assistant_mode: list[str] = Field(
+        default_factory=lambda: ["off", "attached", "conditional"]
+    )
+    economy_mode: list[str] = Field(default_factory=lambda: ["off", "auto"])
 
 
 class MultiRuntimeProfileResponse(BaseModel):
@@ -144,6 +182,14 @@ class MultiRuntimeProfileUpdateRequest(BaseModel):
     reasoning_summary_enabled: Optional[bool] = None
     emotion_detection_enabled: Optional[bool] = None
     emotion_response_style_enabled: Optional[bool] = None
+    execution_mode: Optional[
+        Literal["balanced", "vision_priority", "voice_priority"]
+    ] = None
+    image_strategy: Optional[Literal["vlm_only", "ocr_first", "hybrid"]] = None
+    retrieval_mode: Optional[Literal["off", "auto", "always"]] = None
+    audio_output_mode: Optional[Literal["off", "text_first", "voice_first"]] = None
+    assistant_mode: Optional[Literal["off", "attached", "conditional"]] = None
+    economy_mode: Optional[Literal["off", "auto"]] = None
     precision: Optional[str] = None
     quantization_backend: Optional[str] = None
     device_target: Optional[str] = None

--- a/venom_core/services/multi_runtime_profile_service.py
+++ b/venom_core/services/multi_runtime_profile_service.py
@@ -38,6 +38,12 @@ APPLY_MATRIX: dict[str, ApplyMode] = {
     "reasoning_summary_enabled": "live",
     "emotion_detection_enabled": "live",
     "emotion_response_style_enabled": "live",
+    "execution_mode": "live",
+    "image_strategy": "live",
+    "retrieval_mode": "live",
+    "audio_output_mode": "live",
+    "assistant_mode": "live",
+    "economy_mode": "live",
     "precision": "unsupported",
     "quantization_backend": "unsupported",
     "device_target": "unsupported",
@@ -101,6 +107,12 @@ def build_profile_from_daemon_params(
     emotion_detection_enabled: bool,
     emotion_response_style_enabled: bool,
     cache_implementation: Optional[str],
+    execution_mode: str = "balanced",
+    image_strategy: str = "vlm_only",
+    retrieval_mode: str = "off",
+    audio_output_mode: str = "off",
+    assistant_mode: str = "off",
+    economy_mode: str = "off",
 ) -> MultiRuntimeProfile:
     """Build a MultiRuntimeProfile from flat daemon status fields.
 
@@ -117,6 +129,12 @@ def build_profile_from_daemon_params(
         emotion_detection_enabled=emotion_detection_enabled,
         emotion_response_style_enabled=emotion_response_style_enabled,
         cache_implementation=cache_implementation,
+        execution_mode=execution_mode,
+        image_strategy=image_strategy,
+        retrieval_mode=retrieval_mode,
+        audio_output_mode=audio_output_mode,
+        assistant_mode=assistant_mode,
+        economy_mode=economy_mode,
     )
 
 

--- a/venom_core/services/multi_runtime_profile_service.py
+++ b/venom_core/services/multi_runtime_profile_service.py
@@ -100,19 +100,7 @@ def build_profile_from_daemon_params(
     *,
     target_model: str,
     assistant_model: Optional[str],
-    max_new_tokens: int,
-    enable_thinking: bool,
-    image_token_budget: int,
-    reasoning_summary_enabled: bool,
-    emotion_detection_enabled: bool,
-    emotion_response_style_enabled: bool,
-    cache_implementation: Optional[str],
-    execution_mode: str = "balanced",
-    image_strategy: str = "vlm_only",
-    retrieval_mode: str = "off",
-    audio_output_mode: str = "off",
-    assistant_mode: str = "off",
-    economy_mode: str = "off",
+    daemon_params: dict[str, Any],
 ) -> MultiRuntimeProfile:
     """Build a MultiRuntimeProfile from flat daemon status fields.
 
@@ -122,19 +110,25 @@ def build_profile_from_daemon_params(
     return MultiRuntimeProfile(
         model_id=target_model,
         assistant_model_id=assistant_model,
-        max_new_tokens=max_new_tokens,
-        enable_thinking=enable_thinking,
-        image_token_budget=image_token_budget,
-        reasoning_summary_enabled=reasoning_summary_enabled,
-        emotion_detection_enabled=emotion_detection_enabled,
-        emotion_response_style_enabled=emotion_response_style_enabled,
-        cache_implementation=cache_implementation,
-        execution_mode=execution_mode,
-        image_strategy=image_strategy,
-        retrieval_mode=retrieval_mode,
-        audio_output_mode=audio_output_mode,
-        assistant_mode=assistant_mode,
-        economy_mode=economy_mode,
+        max_new_tokens=int(daemon_params.get("max_new_tokens", 128)),
+        enable_thinking=bool(daemon_params.get("enable_thinking", False)),
+        image_token_budget=int(daemon_params.get("image_token_budget", 280)),
+        reasoning_summary_enabled=bool(
+            daemon_params.get("reasoning_summary_enabled", False)
+        ),
+        emotion_detection_enabled=bool(
+            daemon_params.get("emotion_detection_enabled", False)
+        ),
+        emotion_response_style_enabled=bool(
+            daemon_params.get("emotion_response_style_enabled", False)
+        ),
+        cache_implementation=daemon_params.get("cache_implementation"),
+        execution_mode=str(daemon_params.get("execution_mode", "balanced")),
+        image_strategy=str(daemon_params.get("image_strategy", "vlm_only")),
+        retrieval_mode=str(daemon_params.get("retrieval_mode", "off")),
+        audio_output_mode=str(daemon_params.get("audio_output_mode", "off")),
+        assistant_mode=str(daemon_params.get("assistant_mode", "off")),
+        economy_mode=str(daemon_params.get("economy_mode", "off")),
     )
 
 

--- a/web-next/components/cockpit/cockpit-chat-console.tsx
+++ b/web-next/components/cockpit/cockpit-chat-console.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import type { ReactNode, RefObject } from "react";
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
@@ -10,6 +10,11 @@ import { SectionHeading } from "@/components/ui/section-heading";
 import { CockpitPanel3D } from "@/components/cockpit/cockpit-panel-3d";
 import { Maximize2, Minimize2, RefreshCw } from "lucide-react";
 import { useTranslation } from "@/lib/i18n";
+import { useGemma4Daemon } from "@/hooks/use-gemma4-daemon";
+import {
+  RuntimeDiagnosticsPanel,
+  type RuntimeSummaryItem,
+} from "@/components/runtime/runtime-diagnostics-panel";
 
 type ChatPreset = {
   readonly id: string;
@@ -59,6 +64,16 @@ export function CockpitChatConsole({
   onNewChat,
 }: CockpitChatConsoleProps) {
   const t = useTranslation();
+  const daemon = useGemma4Daemon(12_000);
+  const runtimeStatus = daemon.status;
+  const runtimeEmptyStateTitle = daemon.loading
+    ? "Connecting to runtime daemon"
+    : daemon.error
+      ? "Runtime daemon unavailable"
+      : "Runtime diagnostics unavailable";
+  const runtimeEmptyStateDescription = daemon.loading
+    ? "Waiting for multi_runtime status."
+    : daemon.error || "Daemon status is not available yet.";
   useEffect(() => {
     if (!chatFullscreen) return;
     const previousOverflow = document.body.style.overflow;
@@ -67,6 +82,68 @@ export function CockpitChatConsole({
       document.body.style.overflow = previousOverflow;
     };
   }, [chatFullscreen]);
+
+  const runtimeSummary = useMemo<RuntimeSummaryItem[]>(() => {
+    if (!runtimeStatus) return [];
+    return [
+      {
+        label: "Target",
+        value: runtimeStatus.target_model,
+        tone: runtimeStatus.target_loaded ? "success" : "warning",
+        hint: runtimeStatus.mode,
+      },
+      {
+        label: "Assistant",
+        value: runtimeStatus.assistant_model ?? "—",
+        tone: runtimeStatus.assistant_loaded ? "success" : "neutral",
+        hint: runtimeStatus.params.assistant_mode,
+      },
+      {
+        label: "Policy",
+        value: runtimeStatus.params.execution_mode,
+        tone: "neutral",
+        hint: `image ${runtimeStatus.params.image_strategy}`,
+      },
+      {
+        label: "Retrieval",
+        value: runtimeStatus.params.retrieval_mode,
+        tone: runtimeStatus.params.retrieval_mode === "off" ? "neutral" : "success",
+        hint: `audio ${runtimeStatus.params.audio_output_mode}`,
+      },
+      {
+        label: "Economy",
+        value: runtimeStatus.params.economy_mode,
+        tone: runtimeStatus.params.economy_mode === "auto" ? "warning" : "success",
+        hint: `assistant ${runtimeStatus.params.assistant_mode}`,
+      },
+      {
+        label: "Image budget",
+        value: runtimeStatus.params.image_token_budget,
+        tone: "neutral",
+        hint: `thinking ${runtimeStatus.params.enable_thinking ? "on" : "off"}`,
+      },
+    ];
+  }, [runtimeStatus]);
+
+  const runtimeDegradations = useMemo(() => {
+    if (!runtimeStatus) return [];
+    const reasons = new Set<string>();
+    for (const component of runtimeStatus.component_snapshot ?? []) {
+      if (component.enabled && component.available === false) {
+        reasons.add(`${component.component_id}: unavailable`);
+      }
+      if (component.last_error) {
+        reasons.add(component.last_error);
+      }
+    }
+    if (runtimeStatus.pending_reload && runtimeStatus.reload_reason) {
+      reasons.add(runtimeStatus.reload_reason);
+    }
+    if (!runtimeStatus.target_loaded) {
+      reasons.add("target model not loaded");
+    }
+    return Array.from(reasons);
+  }, [runtimeStatus]);
 
   return (
     <div className="space-y-6">
@@ -140,6 +217,15 @@ export function CockpitChatConsole({
           </div>
         </div>
       </CockpitPanel3D>
+      <RuntimeDiagnosticsPanel
+        title="Runtime diagnostics"
+        description="Active daemon snapshot, component health and degradation reasons."
+        summaryItems={runtimeSummary}
+        componentSnapshot={runtimeStatus?.component_snapshot ?? []}
+        degradationReasons={runtimeDegradations}
+        emptyStateTitle={runtimeEmptyStateTitle}
+        emptyStateDescription={runtimeEmptyStateDescription}
+      />
       {!chatFullscreen && showSharedSections && showArtifacts && (
         <div className="mt-4 space-y-3 rounded-2xl box-base px-4 py-4 text-sm text-[color:var(--text-secondary)]">
           <div className="flex flex-wrap items-center justify-between gap-2">

--- a/web-next/components/cockpit/cockpit-chat-console.tsx
+++ b/web-next/components/cockpit/cockpit-chat-console.tsx
@@ -44,6 +44,12 @@ type CockpitChatConsoleProps = Readonly<{
   onNewChat: () => void;
 }>;
 
+function resolveRuntimeEmptyStateTitle(loading: boolean, error: string | null): string {
+  if (loading) return "Connecting to runtime daemon";
+  if (error) return "Runtime daemon unavailable";
+  return "Runtime diagnostics unavailable";
+}
+
 export function CockpitChatConsole({
   chatFullscreen,
   onToggleFullscreen,
@@ -66,11 +72,7 @@ export function CockpitChatConsole({
   const t = useTranslation();
   const daemon = useGemma4Daemon(12_000);
   const runtimeStatus = daemon.status;
-  const runtimeEmptyStateTitle = daemon.loading
-    ? "Connecting to runtime daemon"
-    : daemon.error
-      ? "Runtime daemon unavailable"
-      : "Runtime diagnostics unavailable";
+  const runtimeEmptyStateTitle = resolveRuntimeEmptyStateTitle(daemon.loading, daemon.error);
   const runtimeEmptyStateDescription = daemon.loading
     ? "Waiting for multi_runtime status."
     : daemon.error || "Daemon status is not available yet.";

--- a/web-next/components/gemma4/gemma4-runtime-control.tsx
+++ b/web-next/components/gemma4/gemma4-runtime-control.tsx
@@ -121,6 +121,14 @@ export function Gemma4RuntimeControlInner({
   const [imagePromptInput, setImagePromptInput] = useState("");
   const [imageProbePending, setImageProbePending] = useState(false);
   const [imageProbeResult, setImageProbeResult] = useState<string | null>(null);
+  const [imageProbeDiagnostics, setImageProbeDiagnostics] = useState<{
+    executionTrace: string[];
+    selectedPolicy: string | null;
+    selectedImageStrategy: string | null;
+    retrievalUsed: boolean;
+    assistantUsed: boolean;
+    economyModeActivated: boolean;
+  } | null>(null);
   const [imageProbeError, setImageProbeError] = useState<string | null>(null);
   const imageFileInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -217,6 +225,7 @@ export function Gemma4RuntimeControlInner({
     setImageProbePending(true);
     setImageProbeError(null);
     setImageProbeResult(null);
+    setImageProbeDiagnostics(null);
     try {
       const imageContent = imageDataInput
         ? ({ type: "image", data: imageDataInput } as const)
@@ -238,6 +247,14 @@ export function Gemma4RuntimeControlInner({
         max_new_tokens: status?.params.max_new_tokens ?? 128,
       });
       setImageProbeResult(result.text);
+      setImageProbeDiagnostics({
+        executionTrace: result.execution_trace ?? [],
+        selectedPolicy: result.selected_policy ?? null,
+        selectedImageStrategy: result.selected_image_strategy ?? null,
+        retrievalUsed: Boolean(result.retrieval_used),
+        assistantUsed: Boolean(result.assistant_used),
+        economyModeActivated: Boolean(result.economy_mode_activated),
+      });
     } catch (e) {
       setImageProbeError(e instanceof Error ? e.message : "Image request failed");
     } finally {
@@ -535,6 +552,32 @@ export function Gemma4RuntimeControlInner({
             {imageProbeResult && (
               <p className="text-[11px] text-zinc-300 whitespace-pre-wrap">{imageProbeResult}</p>
             )}
+            {imageProbeDiagnostics && (
+              <div className="rounded-lg border border-white/[0.08] bg-white/[0.02] p-2 text-[10px] text-zinc-400 space-y-1">
+                <p>
+                  <span className="text-zinc-500">selected_policy:</span>{" "}
+                  {imageProbeDiagnostics.selectedPolicy ?? "—"}
+                </p>
+                <p>
+                  <span className="text-zinc-500">image_strategy:</span>{" "}
+                  {imageProbeDiagnostics.selectedImageStrategy ?? "—"}
+                </p>
+                <p>
+                  <span className="text-zinc-500">trace:</span>{" "}
+                  {imageProbeDiagnostics.executionTrace.join(" -> ") || "—"}
+                </p>
+                <p>
+                  <span className="text-zinc-500">retrieval_used:</span>{" "}
+                  {imageProbeDiagnostics.retrievalUsed ? "yes" : "no"}
+                  {" · "}
+                  <span className="text-zinc-500">assistant_used:</span>{" "}
+                  {imageProbeDiagnostics.assistantUsed ? "yes" : "no"}
+                  {" · "}
+                  <span className="text-zinc-500">economy_mode:</span>{" "}
+                  {imageProbeDiagnostics.economyModeActivated ? "on" : "off"}
+                </p>
+              </div>
+            )}
             {imageProbeError && (
               <p className="text-[10px] text-rose-400 break-all">{imageProbeError}</p>
             )}
@@ -596,6 +639,25 @@ export function Gemma4RuntimeControlInner({
 
       {error && (
         <p className="mt-2 text-[10px] text-rose-400 truncate">{error}</p>
+      )}
+
+      {status?.component_snapshot && status.component_snapshot.length > 0 && (
+        <div className="mt-3 rounded-lg border border-white/[0.06] bg-white/[0.02] p-2.5">
+          <p className="text-[10px] uppercase tracking-widest text-zinc-500 mb-2">
+            component snapshot
+          </p>
+          <div className="space-y-1.5">
+            {status.component_snapshot.slice(0, 7).map((component) => (
+              <div
+                key={component.component_id}
+                className="flex items-center justify-between gap-2 text-[10px]"
+              >
+                <span className="text-zinc-300 truncate">{component.component_id}</span>
+                <span className="text-zinc-500 truncate">{component.health}</span>
+              </div>
+            ))}
+          </div>
+        </div>
       )}
     </DaemonCard>
   );

--- a/web-next/components/gemma4/gemma4-runtime-control.tsx
+++ b/web-next/components/gemma4/gemma4-runtime-control.tsx
@@ -156,6 +156,88 @@ async function attachAssistantModel(params: {
   params.setShowDrafterInput(false);
 }
 
+async function applyRuntimeControlDraft(params: {
+  daemon: Gemma4DaemonState;
+  localThinking: boolean | null;
+  localReasoningSummary: boolean | null;
+  localEmotionDetection: boolean | null;
+  localEmotionResponseStyle: boolean | null;
+  localTokens: string;
+  localImageBudget: string;
+  localCache: string | null;
+  resetDraft: () => void;
+}) {
+  const request = buildDaemonConfigRequestFromLocalDraft(params);
+  const result = await params.daemon.applyConfig(request);
+  if (result) {
+    params.resetDraft();
+  }
+}
+
+async function handleRuntimeImageProbe(params: {
+  imageUrlInput: string;
+  imageDataInput: string | null;
+  imagePromptInput: string;
+  imageProbePending: boolean;
+  maxNewTokens: number;
+  setImageProbeResult: (value: string | null) => void;
+  setImageProbeDiagnostics: (
+    value: {
+      executionTrace: string[];
+      selectedPolicy: string | null;
+      selectedImageStrategy: string | null;
+      retrievalUsed: boolean;
+      retrievalContextItems: number;
+      retrievalRoute: string | null;
+      assistantUsed: boolean;
+      economyModeActivated: boolean;
+      degradationReasons: string[];
+    } | null,
+  ) => void;
+  setImageProbeError: (value: string | null) => void;
+  setImageProbePending: (value: boolean) => void;
+}) {
+  const url = params.imageUrlInput.trim();
+  if ((!url && !params.imageDataInput) || params.imageProbePending) return;
+  params.setImageProbePending(true);
+  params.setImageProbeError(null);
+  params.setImageProbeResult(null);
+  params.setImageProbeDiagnostics(null);
+  try {
+    const result = await runImageProbe({
+      imageUrlInput: params.imageUrlInput,
+      imageDataInput: params.imageDataInput,
+      imagePromptInput: params.imagePromptInput,
+      imageProbePending: params.imageProbePending,
+      maxNewTokens: params.maxNewTokens,
+    });
+    params.setImageProbeResult(result.text);
+    params.setImageProbeDiagnostics(result.diagnostics);
+  } catch (e) {
+    params.setImageProbeError(e instanceof Error ? e.message : "Image request failed");
+  } finally {
+    params.setImageProbePending(false);
+  }
+}
+
+async function handleRuntimeImageFileSelection(params: {
+  fileList: FileList | null;
+  setImageProbeError: (value: string | null) => void;
+  setImageDataInput: (value: string | null) => void;
+  setImageFileName: (value: string | null) => void;
+}) {
+  const file = params.fileList?.item(0);
+  if (!file) return;
+  if (!file.type.startsWith("image/")) {
+    params.setImageProbeError("Only image files are supported");
+    return;
+  }
+  params.setImageProbeError(null);
+  const loaded = await readImageFileAsDataUrl(file);
+  params.setImageDataInput(loaded);
+  params.setImageFileName(file.name);
+}
+
 async function readImageFileAsDataUrl(file: File): Promise<string> {
   const reader = new FileReader();
   return new Promise<string>((resolve, reject) => {
@@ -317,8 +399,9 @@ export function Gemma4RuntimeControlInner({
     localImageBudget !== "" ||
     localCache !== null;
 
-  async function handleApply() {
-    const params = buildDaemonConfigRequestFromLocalDraft({
+  const handleApply = () =>
+    applyRuntimeControlDraft({
+      daemon,
       localThinking,
       localReasoningSummary,
       localEmotionDetection,
@@ -326,67 +409,47 @@ export function Gemma4RuntimeControlInner({
       localTokens,
       localImageBudget,
       localCache,
+      resetDraft: () =>
+        resetLocalRuntimeDraft({
+          setLocalThinking,
+          setLocalTokens,
+          setLocalImageBudget,
+          setLocalCache,
+        }),
     });
-    const result = await daemon.applyConfig(params);
-    if (result) {
-      resetLocalRuntimeDraft({
-        setLocalThinking,
-        setLocalTokens,
-        setLocalImageBudget,
-        setLocalCache,
-      });
-    }
-  }
 
-  async function handleAttach() {
-    await attachAssistantModel({
+  const handleAttach = () =>
+    attachAssistantModel({
       daemon,
       drafterInput,
       setDrafterInput,
       setShowDrafterInput,
     });
-  }
 
-  async function handleImageProbe() {
-    if ((!imageUrlInput.trim() && !imageDataInput) || imageProbePending) return;
-    setImageProbePending(true);
-    setImageProbeError(null);
-    setImageProbeResult(null);
-    setImageProbeDiagnostics(null);
-    try {
-      const result = await runImageProbe({
-        imageUrlInput,
-        imageDataInput,
-        imagePromptInput,
-        imageProbePending,
-        maxNewTokens: status?.params.max_new_tokens ?? 128,
-      });
-      setImageProbeResult(result.text);
-      setImageProbeDiagnostics(result.diagnostics);
-    } catch (e) {
-      setImageProbeError(e instanceof Error ? e.message : "Image request failed");
-    } finally {
-      setImageProbePending(false);
-    }
-  }
+  const handleImageProbe = () =>
+    handleRuntimeImageProbe({
+      imageUrlInput,
+      imageDataInput,
+      imagePromptInput,
+      imageProbePending,
+      maxNewTokens: status?.params.max_new_tokens ?? 128,
+      setImageProbeResult,
+      setImageProbeDiagnostics,
+      setImageProbeError,
+      setImageProbePending,
+    });
 
-  async function readImageFile(file: File) {
-    if (!file.type.startsWith("image/")) {
-      setImageProbeError("Only image files are supported");
-      return;
-    }
-    setImageProbeError(null);
-    const loaded = await readImageFileAsDataUrl(file);
-    setImageDataInput(loaded);
-    setImageFileName(file.name);
-    setImageUrlInput("");
-  }
-
-  async function handleImageFileChange(fileList: FileList | null) {
-    const file = fileList?.item(0);
-    if (!file) return;
-    await readImageFile(file);
-  }
+  const handleImageFileChange = (fileList: FileList | null) =>
+    handleRuntimeImageFileSelection({
+      fileList,
+      setImageProbeError,
+      setImageDataInput,
+      setImageFileName,
+    }).then(() => {
+      if (fileList?.item(0)) {
+        setImageUrlInput("");
+      }
+    });
 
   const vram = status?.vram;
   const vramPercent =

--- a/web-next/components/gemma4/gemma4-runtime-control.tsx
+++ b/web-next/components/gemma4/gemma4-runtime-control.tsx
@@ -127,6 +127,7 @@ export function Gemma4RuntimeControlInner({
     selectedImageStrategy: string | null;
     retrievalUsed: boolean;
     retrievalContextItems: number;
+    retrievalRoute: string | null;
     assistantUsed: boolean;
     economyModeActivated: boolean;
     degradationReasons: string[];
@@ -255,6 +256,7 @@ export function Gemma4RuntimeControlInner({
         selectedImageStrategy: result.selected_image_strategy ?? null,
         retrievalUsed: Boolean(result.retrieval_used),
         retrievalContextItems: Number(result.retrieval_context_items ?? 0),
+        retrievalRoute: result.retrieval_route ?? null,
         assistantUsed: Boolean(result.assistant_used),
         economyModeActivated: Boolean(result.economy_mode_activated),
         degradationReasons: Array.isArray(result.degradation_reasons)
@@ -575,6 +577,9 @@ export function Gemma4RuntimeControlInner({
                 <p>
                   <span className="text-zinc-500">retrieval_used:</span>{" "}
                   {imageProbeDiagnostics.retrievalUsed ? "yes" : "no"}
+                  {" · "}
+                  <span className="text-zinc-500">retrieval_route:</span>{" "}
+                  {imageProbeDiagnostics.retrievalRoute ?? "—"}
                   {" · "}
                   <span className="text-zinc-500">retrieval_items:</span>{" "}
                   {imageProbeDiagnostics.retrievalContextItems}

--- a/web-next/components/gemma4/gemma4-runtime-control.tsx
+++ b/web-next/components/gemma4/gemma4-runtime-control.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useRef, useState } from "react";
+import type { RefObject } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { SelectMenu, type SelectMenuOption } from "@/components/ui/select-menu";
@@ -88,6 +89,167 @@ type InnerProps = Readonly<{
 
 export function Gemma4RuntimeControlInner(props: InnerProps) {
   return <Gemma4RuntimeControlPanel {...props} />;
+}
+
+// ---------------------------------------------------------------------------
+// Image probe diagnostics sub-component (extracted to reduce parent complexity)
+// ---------------------------------------------------------------------------
+
+type ImageProbeDiagnostics = {
+  executionTrace: string[];
+  selectedPolicy: string | null;
+  selectedImageStrategy: string | null;
+  retrievalUsed: boolean;
+  retrievalContextItems: number;
+  retrievalRoute: string | null;
+  assistantUsed: boolean;
+  economyModeActivated: boolean;
+  degradationReasons: string[];
+};
+
+type ImageProbeSectionProps = Readonly<{
+  busy: boolean;
+  imageProbePending: boolean;
+  imageUrlInput: string;
+  imageDataInput: string | null;
+  imageFileName: string | null;
+  imagePromptInput: string;
+  imageProbeResult: string | null;
+  imageProbeDiagnostics: ImageProbeDiagnostics | null;
+  imageProbeError: string | null;
+  imageFileInputRef: RefObject<HTMLInputElement | null>;
+  onFileChange: (files: FileList | null) => Promise<void>;
+  onImageUrlChange: (url: string) => void;
+  onImagePromptChange: (prompt: string) => void;
+  onClearImageData: () => void;
+  onProbe: () => void;
+}>;
+
+function ImageProbeSection({
+  busy,
+  imageProbePending,
+  imageUrlInput,
+  imageDataInput,
+  imageFileName,
+  imagePromptInput,
+  imageProbeResult,
+  imageProbeDiagnostics,
+  imageProbeError,
+  imageFileInputRef,
+  onFileChange,
+  onImageUrlChange,
+  onImagePromptChange,
+  onClearImageData,
+  onProbe,
+}: ImageProbeSectionProps) {
+  const t = useTranslation();
+  return (
+    <div className="mb-3 rounded-lg border border-white/[0.06] bg-white/[0.02] p-2.5">
+      <p className="text-[10px] uppercase tracking-widest text-zinc-500">{t("voice.daemon.imageInput")}</p>
+      <div className="mt-2 space-y-2">
+        <button
+          type="button"
+          onDragOver={(event) => { event.preventDefault(); }}
+          onDrop={async (event) => {
+            event.preventDefault();
+            await onFileChange(event.dataTransfer.files);
+            if (event.dataTransfer.files.item(0)) onImageUrlChange("");
+          }}
+          onClick={() => imageFileInputRef.current?.click()}
+          className="w-full rounded-lg border border-dashed border-white/20 bg-white/[0.02] px-3 py-2 text-left text-[11px] text-zinc-400"
+          aria-label={t("voice.daemon.dragDropImage")}
+        >
+          {t("voice.daemon.dragDropImage")}
+        </button>
+        <div className="flex items-center gap-2">
+          <Button
+            size="xs"
+            variant="ghost"
+            onClick={() => imageFileInputRef.current?.click()}
+            disabled={busy || imageProbePending}
+          >
+            {t("voice.daemon.chooseImageFromDisk")}
+          </Button>
+          {imageFileName && (
+            <span className="text-[10px] text-zinc-400 truncate">{imageFileName}</span>
+          )}
+          {imageDataInput && (
+            <Button size="xs" variant="ghost" onClick={onClearImageData} disabled={busy || imageProbePending}>
+              {t("voice.daemon.clearImageFile")}
+            </Button>
+          )}
+          <input
+            ref={imageFileInputRef}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            onChange={async (e) => {
+              await onFileChange(e.currentTarget.files);
+              if (e.currentTarget.files?.item(0)) onImageUrlChange("");
+              e.currentTarget.value = "";
+            }}
+          />
+        </div>
+        <input
+          type="url"
+          value={imageUrlInput}
+          onChange={(e) => onImageUrlChange(e.target.value)}
+          placeholder={imageDataInput ? t("voice.daemon.fileSelectedUrlDisabled") : t("voice.daemon.imageUrlPlaceholder")}
+          disabled={busy || imageProbePending}
+          className="w-full rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-white placeholder:text-zinc-600 focus:outline-none focus:ring-1 focus:ring-emerald-500 disabled:opacity-50"
+          aria-label={t("voice.daemon.imageUrl")}
+        />
+        <input
+          type="text"
+          value={imagePromptInput}
+          onChange={(e) => onImagePromptChange(e.target.value)}
+          placeholder={t("voice.daemon.imagePromptPlaceholder")}
+          disabled={busy || imageProbePending}
+          className="w-full rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-white placeholder:text-zinc-600 focus:outline-none focus:ring-1 focus:ring-emerald-500 disabled:opacity-50"
+          aria-label={t("voice.daemon.imagePrompt")}
+        />
+        <Button
+          size="xs"
+          variant="secondary"
+          onClick={onProbe}
+          disabled={busy || imageProbePending || (!imageUrlInput.trim() && !imageDataInput)}
+        >
+          {imageProbePending ? t("voice.daemon.imageProbeRunning") : t("voice.daemon.runImageProbe")}
+        </Button>
+        {imageProbeResult && (
+          <p className="text-[11px] text-zinc-300 whitespace-pre-wrap">{imageProbeResult}</p>
+        )}
+        {imageProbeDiagnostics && (
+          <div className="rounded-lg border border-white/[0.08] bg-white/[0.02] p-2 text-[10px] text-zinc-400 space-y-1">
+            <p><span className="text-zinc-500">selected_policy:</span> {imageProbeDiagnostics.selectedPolicy ?? "—"}</p>
+            <p><span className="text-zinc-500">image_strategy:</span> {imageProbeDiagnostics.selectedImageStrategy ?? "—"}</p>
+            <p><span className="text-zinc-500">trace:</span> {imageProbeDiagnostics.executionTrace.join(" -> ") || "—"}</p>
+            <p>
+              <span className="text-zinc-500">retrieval_used:</span>{" "}
+              {imageProbeDiagnostics.retrievalUsed ? "yes" : "no"}{" · "}
+              <span className="text-zinc-500">retrieval_route:</span>{" "}
+              {imageProbeDiagnostics.retrievalRoute ?? "—"}{" · "}
+              <span className="text-zinc-500">retrieval_items:</span>{" "}
+              {imageProbeDiagnostics.retrievalContextItems}{" · "}
+              <span className="text-zinc-500">assistant_used:</span>{" "}
+              {imageProbeDiagnostics.assistantUsed ? "yes" : "no"}{" · "}
+              <span className="text-zinc-500">economy_mode:</span>{" "}
+              {imageProbeDiagnostics.economyModeActivated ? "on" : "off"}
+            </p>
+            {imageProbeDiagnostics.degradationReasons.length > 0 && (
+              <p>
+                <span className="text-zinc-500">degradations:</span>{" "}
+                {imageProbeDiagnostics.degradationReasons.join(" | ")}
+              </p>
+            )}
+          </div>
+        )}
+        {imageProbeError && (
+          <p className="text-[10px] text-rose-400 break-all">{imageProbeError}</p>
+        )}
+      </div>
+    </div>
+  );
 }
 
 function vramBarColor(pct: number): string {
@@ -342,17 +504,7 @@ function Gemma4RuntimeControlPanel({
   const [imagePromptInput, setImagePromptInput] = useState("");
   const [imageProbePending, setImageProbePending] = useState(false);
   const [imageProbeResult, setImageProbeResult] = useState<string | null>(null);
-  const [imageProbeDiagnostics, setImageProbeDiagnostics] = useState<{
-    executionTrace: string[];
-    selectedPolicy: string | null;
-    selectedImageStrategy: string | null;
-    retrievalUsed: boolean;
-    retrievalContextItems: number;
-    retrievalRoute: string | null;
-    assistantUsed: boolean;
-    economyModeActivated: boolean;
-    degradationReasons: string[];
-  } | null>(null);
+  const [imageProbeDiagnostics, setImageProbeDiagnostics] = useState<ImageProbeDiagnostics | null>(null);
   const [imageProbeError, setImageProbeError] = useState<string | null>(null);
   const imageFileInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -449,10 +601,6 @@ function Gemma4RuntimeControlPanel({
       setImageProbeError,
       setImageDataInput,
       setImageFileName,
-    }).then(() => {
-      if (fileList?.item(0)) {
-        setImageUrlInput("");
-      }
     });
 
   const vram = status?.vram;
@@ -629,136 +777,23 @@ function Gemma4RuntimeControlPanel({
       />
 
       {status?.supports_image_input && (
-        <div className="mb-3 rounded-lg border border-white/[0.06] bg-white/[0.02] p-2.5">
-          <p className="text-[10px] uppercase tracking-widest text-zinc-500">{t("voice.daemon.imageInput")}</p>
-          <div className="mt-2 space-y-2">
-            <button
-              type="button"
-              onDragOver={(event) => {
-                event.preventDefault();
-              }}
-              onDrop={async (event) => {
-                event.preventDefault();
-                await handleImageFileChange(event.dataTransfer.files);
-              }}
-              onClick={() => imageFileInputRef.current?.click()}
-              className="w-full rounded-lg border border-dashed border-white/20 bg-white/[0.02] px-3 py-2 text-left text-[11px] text-zinc-400"
-              aria-label={t("voice.daemon.dragDropImage")}
-            >
-              {t("voice.daemon.dragDropImage")}
-            </button>
-            <div className="flex items-center gap-2">
-              <Button
-                size="xs"
-                variant="ghost"
-                onClick={() => imageFileInputRef.current?.click()}
-                disabled={busy || imageProbePending}
-              >
-                {t("voice.daemon.chooseImageFromDisk")}
-              </Button>
-              {imageFileName && (
-                <span className="text-[10px] text-zinc-400 truncate">{imageFileName}</span>
-              )}
-              {imageDataInput && (
-                <Button
-                  size="xs"
-                  variant="ghost"
-                  onClick={() => {
-                    setImageDataInput(null);
-                    setImageFileName(null);
-                  }}
-                  disabled={busy || imageProbePending}
-                >
-                  {t("voice.daemon.clearImageFile")}
-                </Button>
-              )}
-              <input
-                ref={imageFileInputRef}
-                type="file"
-                accept="image/*"
-                className="hidden"
-                onChange={async (e) => {
-                  await handleImageFileChange(e.currentTarget.files);
-                  e.currentTarget.value = "";
-                }}
-              />
-            </div>
-            <input
-              type="url"
-              value={imageUrlInput}
-              onChange={(e) => setImageUrlInput(e.target.value)}
-              placeholder={
-                imageDataInput
-                  ? t("voice.daemon.fileSelectedUrlDisabled")
-                  : t("voice.daemon.imageUrlPlaceholder")
-              }
-              disabled={busy || imageProbePending}
-              className="w-full rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-white placeholder:text-zinc-600 focus:outline-none focus:ring-1 focus:ring-emerald-500 disabled:opacity-50"
-              aria-label={t("voice.daemon.imageUrl")}
-            />
-            <input
-              type="text"
-              value={imagePromptInput}
-              onChange={(e) => setImagePromptInput(e.target.value)}
-              placeholder={t("voice.daemon.imagePromptPlaceholder")}
-              disabled={busy || imageProbePending}
-              className="w-full rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-white placeholder:text-zinc-600 focus:outline-none focus:ring-1 focus:ring-emerald-500 disabled:opacity-50"
-              aria-label={t("voice.daemon.imagePrompt")}
-            />
-            <Button
-              size="xs"
-              variant="secondary"
-              onClick={handleImageProbe}
-              disabled={busy || imageProbePending || (!imageUrlInput.trim() && !imageDataInput)}
-            >
-              {imageProbePending ? t("voice.daemon.imageProbeRunning") : t("voice.daemon.runImageProbe")}
-            </Button>
-            {imageProbeResult && (
-              <p className="text-[11px] text-zinc-300 whitespace-pre-wrap">{imageProbeResult}</p>
-            )}
-            {imageProbeDiagnostics && (
-              <div className="rounded-lg border border-white/[0.08] bg-white/[0.02] p-2 text-[10px] text-zinc-400 space-y-1">
-                <p>
-                  <span className="text-zinc-500">selected_policy:</span>{" "}
-                  {imageProbeDiagnostics.selectedPolicy ?? "—"}
-                </p>
-                <p>
-                  <span className="text-zinc-500">image_strategy:</span>{" "}
-                  {imageProbeDiagnostics.selectedImageStrategy ?? "—"}
-                </p>
-                <p>
-                  <span className="text-zinc-500">trace:</span>{" "}
-                  {imageProbeDiagnostics.executionTrace.join(" -> ") || "—"}
-                </p>
-                <p>
-                  <span className="text-zinc-500">retrieval_used:</span>{" "}
-                  {imageProbeDiagnostics.retrievalUsed ? "yes" : "no"}
-                  {" · "}
-                  <span className="text-zinc-500">retrieval_route:</span>{" "}
-                  {imageProbeDiagnostics.retrievalRoute ?? "—"}
-                  {" · "}
-                  <span className="text-zinc-500">retrieval_items:</span>{" "}
-                  {imageProbeDiagnostics.retrievalContextItems}
-                  {" · "}
-                  <span className="text-zinc-500">assistant_used:</span>{" "}
-                  {imageProbeDiagnostics.assistantUsed ? "yes" : "no"}
-                  {" · "}
-                  <span className="text-zinc-500">economy_mode:</span>{" "}
-                  {imageProbeDiagnostics.economyModeActivated ? "on" : "off"}
-                </p>
-                {imageProbeDiagnostics.degradationReasons.length > 0 && (
-                  <p>
-                    <span className="text-zinc-500">degradations:</span>{" "}
-                    {imageProbeDiagnostics.degradationReasons.join(" | ")}
-                  </p>
-                )}
-              </div>
-            )}
-            {imageProbeError && (
-              <p className="text-[10px] text-rose-400 break-all">{imageProbeError}</p>
-            )}
-          </div>
-        </div>
+        <ImageProbeSection
+          busy={busy}
+          imageProbePending={imageProbePending}
+          imageUrlInput={imageUrlInput}
+          imageDataInput={imageDataInput}
+          imageFileName={imageFileName}
+          imagePromptInput={imagePromptInput}
+          imageProbeResult={imageProbeResult}
+          imageProbeDiagnostics={imageProbeDiagnostics}
+          imageProbeError={imageProbeError}
+          imageFileInputRef={imageFileInputRef}
+          onFileChange={handleImageFileChange}
+          onImageUrlChange={setImageUrlInput}
+          onImagePromptChange={setImagePromptInput}
+          onClearImageData={() => { setImageDataInput(null); setImageFileName(null); }}
+          onProbe={handleImageProbe}
+        />
       )}
 
       {/* Actions */}

--- a/web-next/components/gemma4/gemma4-runtime-control.tsx
+++ b/web-next/components/gemma4/gemma4-runtime-control.tsx
@@ -86,6 +86,10 @@ type InnerProps = Readonly<{
   assistantModels?: string[];
 }>;
 
+export function Gemma4RuntimeControlInner(props: InnerProps) {
+  return <Gemma4RuntimeControlPanel {...props} />;
+}
+
 function vramBarColor(pct: number): string {
   if (pct > 90) return "bg-rose-500";
   if (pct > 70) return "bg-amber-400";
@@ -314,7 +318,7 @@ async function runImageProbe(params: {
   };
 }
 
-export function Gemma4RuntimeControlInner({
+function Gemma4RuntimeControlPanel({
   daemon,
   variant,
   runtimeSnapshot = null,

--- a/web-next/components/gemma4/gemma4-runtime-control.tsx
+++ b/web-next/components/gemma4/gemma4-runtime-control.tsx
@@ -143,6 +143,95 @@ function buildDaemonConfigRequestFromLocalDraft(draft: {
   return params;
 }
 
+async function attachAssistantModel(params: {
+  daemon: Gemma4DaemonState;
+  drafterInput: string;
+  setDrafterInput: (value: string) => void;
+  setShowDrafterInput: (value: boolean) => void;
+}) {
+  const id = params.drafterInput.trim();
+  if (!id) return;
+  await params.daemon.attachAssistant(id);
+  params.setDrafterInput("");
+  params.setShowDrafterInput(false);
+}
+
+async function readImageFileAsDataUrl(file: File): Promise<string> {
+  const reader = new FileReader();
+  return new Promise<string>((resolve, reject) => {
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        resolve(reader.result);
+        return;
+      }
+      reject(new Error("Unexpected file reader result type"));
+    };
+    reader.onerror = () => reject(new Error("Failed to read file"));
+    reader.readAsDataURL(file);
+  });
+}
+
+async function runImageProbe(params: {
+  imageUrlInput: string;
+  imageDataInput: string | null;
+  imagePromptInput: string;
+  imageProbePending: boolean;
+  maxNewTokens: number;
+}): Promise<{
+  text: string;
+  diagnostics: {
+    executionTrace: string[];
+    selectedPolicy: string | null;
+    selectedImageStrategy: string | null;
+    retrievalUsed: boolean;
+    retrievalContextItems: number;
+    retrievalRoute: string | null;
+    assistantUsed: boolean;
+    economyModeActivated: boolean;
+    degradationReasons: string[];
+  };
+}> {
+  const url = params.imageUrlInput.trim();
+  if ((!url && !params.imageDataInput) || params.imageProbePending) {
+    throw new Error("Image input is missing");
+  }
+  const imageContent = params.imageDataInput
+    ? ({ type: "image", data: params.imageDataInput } as const)
+    : ({ type: "image", url } as const);
+  const result = await postDaemonRespond(getGemma4ApiBaseUrl(), {
+    messages: [
+      {
+        role: "user",
+        content: [
+          imageContent,
+          {
+            type: "text",
+            text: params.imagePromptInput.trim() || "Describe the image and extract visible text.",
+          },
+        ],
+      },
+    ],
+    task: "question",
+    max_new_tokens: params.maxNewTokens,
+  });
+  return {
+    text: result.text,
+    diagnostics: {
+      executionTrace: result.execution_trace ?? [],
+      selectedPolicy: result.selected_policy ?? null,
+      selectedImageStrategy: result.selected_image_strategy ?? null,
+      retrievalUsed: Boolean(result.retrieval_used),
+      retrievalContextItems: Number(result.retrieval_context_items ?? 0),
+      retrievalRoute: result.retrieval_route ?? null,
+      assistantUsed: Boolean(result.assistant_used),
+      economyModeActivated: Boolean(result.economy_mode_activated),
+      degradationReasons: Array.isArray(result.degradation_reasons)
+        ? result.degradation_reasons
+        : [],
+    },
+  };
+}
+
 export function Gemma4RuntimeControlInner({
   daemon,
   variant,
@@ -250,54 +339,30 @@ export function Gemma4RuntimeControlInner({
   }
 
   async function handleAttach() {
-    const id = drafterInput.trim();
-    if (!id) return;
-    await daemon.attachAssistant(id);
-    setDrafterInput("");
-    setShowDrafterInput(false);
+    await attachAssistantModel({
+      daemon,
+      drafterInput,
+      setDrafterInput,
+      setShowDrafterInput,
+    });
   }
 
   async function handleImageProbe() {
-    const url = imageUrlInput.trim();
-    if ((!url && !imageDataInput) || imageProbePending) return;
+    if ((!imageUrlInput.trim() && !imageDataInput) || imageProbePending) return;
     setImageProbePending(true);
     setImageProbeError(null);
     setImageProbeResult(null);
     setImageProbeDiagnostics(null);
     try {
-      const imageContent = imageDataInput
-        ? ({ type: "image", data: imageDataInput } as const)
-        : ({ type: "image", url } as const);
-      const result = await postDaemonRespond(getGemma4ApiBaseUrl(), {
-        messages: [
-          {
-            role: "user",
-            content: [
-              imageContent,
-              {
-                type: "text",
-                text: imagePromptInput.trim() || "Describe the image and extract visible text.",
-              },
-            ],
-          },
-        ],
-        task: "question",
-        max_new_tokens: status?.params.max_new_tokens ?? 128,
+      const result = await runImageProbe({
+        imageUrlInput,
+        imageDataInput,
+        imagePromptInput,
+        imageProbePending,
+        maxNewTokens: status?.params.max_new_tokens ?? 128,
       });
       setImageProbeResult(result.text);
-      setImageProbeDiagnostics({
-        executionTrace: result.execution_trace ?? [],
-        selectedPolicy: result.selected_policy ?? null,
-        selectedImageStrategy: result.selected_image_strategy ?? null,
-        retrievalUsed: Boolean(result.retrieval_used),
-        retrievalContextItems: Number(result.retrieval_context_items ?? 0),
-        retrievalRoute: result.retrieval_route ?? null,
-        assistantUsed: Boolean(result.assistant_used),
-        economyModeActivated: Boolean(result.economy_mode_activated),
-        degradationReasons: Array.isArray(result.degradation_reasons)
-          ? result.degradation_reasons
-          : [],
-      });
+      setImageProbeDiagnostics(result.diagnostics);
     } catch (e) {
       setImageProbeError(e instanceof Error ? e.message : "Image request failed");
     } finally {
@@ -311,18 +376,7 @@ export function Gemma4RuntimeControlInner({
       return;
     }
     setImageProbeError(null);
-    const reader = new FileReader();
-    const loaded = await new Promise<string>((resolve, reject) => {
-      reader.onload = () => {
-        if (typeof reader.result === "string") {
-          resolve(reader.result);
-          return;
-        }
-        reject(new Error("Unexpected file reader result type"));
-      };
-      reader.onerror = () => reject(new Error("Failed to read file"));
-      reader.readAsDataURL(file);
-    });
+    const loaded = await readImageFileAsDataUrl(file);
     setImageDataInput(loaded);
     setImageFileName(file.name);
     setImageUrlInput("");

--- a/web-next/components/gemma4/gemma4-runtime-control.tsx
+++ b/web-next/components/gemma4/gemma4-runtime-control.tsx
@@ -126,8 +126,10 @@ export function Gemma4RuntimeControlInner({
     selectedPolicy: string | null;
     selectedImageStrategy: string | null;
     retrievalUsed: boolean;
+    retrievalContextItems: number;
     assistantUsed: boolean;
     economyModeActivated: boolean;
+    degradationReasons: string[];
   } | null>(null);
   const [imageProbeError, setImageProbeError] = useState<string | null>(null);
   const imageFileInputRef = useRef<HTMLInputElement | null>(null);
@@ -252,8 +254,12 @@ export function Gemma4RuntimeControlInner({
         selectedPolicy: result.selected_policy ?? null,
         selectedImageStrategy: result.selected_image_strategy ?? null,
         retrievalUsed: Boolean(result.retrieval_used),
+        retrievalContextItems: Number(result.retrieval_context_items ?? 0),
         assistantUsed: Boolean(result.assistant_used),
         economyModeActivated: Boolean(result.economy_mode_activated),
+        degradationReasons: Array.isArray(result.degradation_reasons)
+          ? result.degradation_reasons
+          : [],
       });
     } catch (e) {
       setImageProbeError(e instanceof Error ? e.message : "Image request failed");
@@ -570,12 +576,21 @@ export function Gemma4RuntimeControlInner({
                   <span className="text-zinc-500">retrieval_used:</span>{" "}
                   {imageProbeDiagnostics.retrievalUsed ? "yes" : "no"}
                   {" · "}
+                  <span className="text-zinc-500">retrieval_items:</span>{" "}
+                  {imageProbeDiagnostics.retrievalContextItems}
+                  {" · "}
                   <span className="text-zinc-500">assistant_used:</span>{" "}
                   {imageProbeDiagnostics.assistantUsed ? "yes" : "no"}
                   {" · "}
                   <span className="text-zinc-500">economy_mode:</span>{" "}
                   {imageProbeDiagnostics.economyModeActivated ? "on" : "off"}
                 </p>
+                {imageProbeDiagnostics.degradationReasons.length > 0 && (
+                  <p>
+                    <span className="text-zinc-500">degradations:</span>{" "}
+                    {imageProbeDiagnostics.degradationReasons.join(" | ")}
+                  </p>
+                )}
               </div>
             )}
             {imageProbeError && (

--- a/web-next/components/gemma4/gemma4-runtime-control.tsx
+++ b/web-next/components/gemma4/gemma4-runtime-control.tsx
@@ -97,6 +97,52 @@ function parseTokenInput(raw: string): number | undefined {
   return Number.isNaN(n) || n <= 0 ? undefined : n;
 }
 
+function resetLocalRuntimeDraft(params: {
+  setLocalThinking: (value: boolean | null) => void;
+  setLocalTokens: (value: string) => void;
+  setLocalImageBudget: (value: string) => void;
+  setLocalCache: (value: string | null) => void;
+}) {
+  params.setLocalThinking(null);
+  params.setLocalTokens("");
+  params.setLocalImageBudget("");
+  params.setLocalCache(null);
+}
+
+function buildDaemonConfigRequestFromLocalDraft(draft: {
+  localThinking: boolean | null;
+  localReasoningSummary: boolean | null;
+  localEmotionDetection: boolean | null;
+  localEmotionResponseStyle: boolean | null;
+  localTokens: string;
+  localImageBudget: string;
+  localCache: string | null;
+}): DaemonConfigRequest {
+  const params: DaemonConfigRequest = {};
+  if (draft.localThinking !== null) params.enable_thinking = draft.localThinking;
+  if (draft.localReasoningSummary !== null) {
+    params.reasoning_summary_enabled = draft.localReasoningSummary;
+  }
+  if (draft.localEmotionDetection !== null) {
+    params.emotion_detection_enabled = draft.localEmotionDetection;
+  }
+  if (draft.localEmotionResponseStyle !== null) {
+    params.emotion_response_style_enabled = draft.localEmotionResponseStyle;
+  }
+  if (draft.localTokens !== "") {
+    const n = parseTokenInput(draft.localTokens);
+    if (n !== undefined) params.max_new_tokens = n;
+  }
+  if (draft.localImageBudget !== "") {
+    const n = parseTokenInput(draft.localImageBudget);
+    if (n !== undefined) params.image_token_budget = n;
+  }
+  if (draft.localCache !== null) {
+    params.cache_implementation = draft.localCache === "" ? null : draft.localCache;
+  }
+  return params;
+}
+
 export function Gemma4RuntimeControlInner({
   daemon,
   variant,
@@ -183,34 +229,23 @@ export function Gemma4RuntimeControlInner({
     localCache !== null;
 
   async function handleApply() {
-    const params: DaemonConfigRequest = {};
-    if (localThinking !== null) params.enable_thinking = localThinking;
-    if (localReasoningSummary !== null) {
-      params.reasoning_summary_enabled = localReasoningSummary;
-    }
-    if (localEmotionDetection !== null) {
-      params.emotion_detection_enabled = localEmotionDetection;
-    }
-    if (localEmotionResponseStyle !== null) {
-      params.emotion_response_style_enabled = localEmotionResponseStyle;
-    }
-    if (localTokens !== "") {
-      const n = parseTokenInput(localTokens);
-      if (n !== undefined) params.max_new_tokens = n;
-    }
-    if (localImageBudget !== "") {
-      const n = parseTokenInput(localImageBudget);
-      if (n !== undefined) params.image_token_budget = n;
-    }
-    if (localCache !== null) {
-      params.cache_implementation = localCache === "" ? null : localCache;
-    }
+    const params = buildDaemonConfigRequestFromLocalDraft({
+      localThinking,
+      localReasoningSummary,
+      localEmotionDetection,
+      localEmotionResponseStyle,
+      localTokens,
+      localImageBudget,
+      localCache,
+    });
     const result = await daemon.applyConfig(params);
     if (result) {
-      setLocalThinking(null);
-      setLocalTokens("");
-      setLocalImageBudget("");
-      setLocalCache(null);
+      resetLocalRuntimeDraft({
+        setLocalThinking,
+        setLocalTokens,
+        setLocalImageBudget,
+        setLocalCache,
+      });
     }
   }
 

--- a/web-next/components/gemma4/multi-runtime-profile-panel.tsx
+++ b/web-next/components/gemma4/multi-runtime-profile-panel.tsx
@@ -45,6 +45,41 @@ const CACHE_OPTIONS: SelectMenuOption[] = [
   { value: "offloaded", label: "offloaded" },
 ];
 
+const EXECUTION_MODE_OPTIONS: SelectMenuOption[] = [
+  { value: "balanced", label: "balanced" },
+  { value: "vision_priority", label: "vision_priority" },
+  { value: "voice_priority", label: "voice_priority" },
+];
+
+const IMAGE_STRATEGY_OPTIONS: SelectMenuOption[] = [
+  { value: "vlm_only", label: "vlm_only" },
+  { value: "ocr_first", label: "ocr_first" },
+  { value: "hybrid", label: "hybrid" },
+];
+
+const RETRIEVAL_MODE_OPTIONS: SelectMenuOption[] = [
+  { value: "off", label: "off" },
+  { value: "auto", label: "auto" },
+  { value: "always", label: "always" },
+];
+
+const AUDIO_OUTPUT_MODE_OPTIONS: SelectMenuOption[] = [
+  { value: "off", label: "off" },
+  { value: "text_first", label: "text_first" },
+  { value: "voice_first", label: "voice_first" },
+];
+
+const ASSISTANT_MODE_OPTIONS: SelectMenuOption[] = [
+  { value: "off", label: "off" },
+  { value: "attached", label: "attached" },
+  { value: "conditional", label: "conditional" },
+];
+
+const ECONOMY_MODE_OPTIONS: SelectMenuOption[] = [
+  { value: "off", label: "off" },
+  { value: "auto", label: "auto" },
+];
+
 // ---------------------------------------------------------------------------
 // Main panel (self-contained with hook)
 // ---------------------------------------------------------------------------
@@ -87,6 +122,12 @@ export function MultiRuntimeProfilePanelInner({ state }: InnerProps) {
     boolean | null
   >(null);
   const [localCache, setLocalCache] = useState<string | null>(null);
+  const [localExecutionMode, setLocalExecutionMode] = useState<string | null>(null);
+  const [localImageStrategy, setLocalImageStrategy] = useState<string | null>(null);
+  const [localRetrievalMode, setLocalRetrievalMode] = useState<string | null>(null);
+  const [localAudioOutputMode, setLocalAudioOutputMode] = useState<string | null>(null);
+  const [localAssistantMode, setLocalAssistantMode] = useState<string | null>(null);
+  const [localEconomyMode, setLocalEconomyMode] = useState<string | null>(null);
 
   if (loading && !data) {
     return (
@@ -123,6 +164,28 @@ export function MultiRuntimeProfilePanelInner({ state }: InnerProps) {
       : localImageBudget;
   const effectiveCache =
     localCache === null ? (profile?.cache_implementation ?? "") : localCache;
+  const effectiveExecutionMode =
+    localExecutionMode === null
+      ? (profile?.execution_mode ?? "balanced")
+      : localExecutionMode;
+  const effectiveImageStrategy =
+    localImageStrategy === null
+      ? (profile?.image_strategy ?? "vlm_only")
+      : localImageStrategy;
+  const effectiveRetrievalMode =
+    localRetrievalMode === null
+      ? (profile?.retrieval_mode ?? "off")
+      : localRetrievalMode;
+  const effectiveAudioOutputMode =
+    localAudioOutputMode === null
+      ? (profile?.audio_output_mode ?? "off")
+      : localAudioOutputMode;
+  const effectiveAssistantMode =
+    localAssistantMode === null
+      ? (profile?.assistant_mode ?? "off")
+      : localAssistantMode;
+  const effectiveEconomyMode =
+    localEconomyMode === null ? (profile?.economy_mode ?? "off") : localEconomyMode;
 
   const busy = updatePending;
 
@@ -143,6 +206,23 @@ export function MultiRuntimeProfilePanelInner({ state }: InnerProps) {
   async function handleApplyCacheImpl() {
     await applyUpdate({
       cache_implementation: effectiveCache === "" ? null : effectiveCache,
+    });
+  }
+
+  async function handleApplyPolicy() {
+    await applyUpdate({
+      execution_mode:
+        effectiveExecutionMode as MultiRuntimeProfileUpdateRequest["execution_mode"],
+      image_strategy:
+        effectiveImageStrategy as MultiRuntimeProfileUpdateRequest["image_strategy"],
+      retrieval_mode:
+        effectiveRetrievalMode as MultiRuntimeProfileUpdateRequest["retrieval_mode"],
+      audio_output_mode:
+        effectiveAudioOutputMode as MultiRuntimeProfileUpdateRequest["audio_output_mode"],
+      assistant_mode:
+        effectiveAssistantMode as MultiRuntimeProfileUpdateRequest["assistant_mode"],
+      economy_mode:
+        effectiveEconomyMode as MultiRuntimeProfileUpdateRequest["economy_mode"],
     });
   }
 
@@ -303,6 +383,92 @@ export function MultiRuntimeProfilePanelInner({ state }: InnerProps) {
           disabled={busy || !data?.daemon_reachable}
         >
           {t("runtime.profile.stageCacheReload")}
+        </Button>
+      </section>
+
+      {/* Execution policy (live) */}
+      <section aria-labelledby="profile-policy-section">
+        <div className="flex items-center gap-2 mb-2" id="profile-policy-section">
+          <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            Execution Policy
+          </span>
+          {matrix && <ApplyModeBadge mode={matrix.execution_mode} />}
+        </div>
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-sm">execution_mode</span>
+            <div className="w-48">
+              <SelectMenu
+                value={effectiveExecutionMode}
+                options={EXECUTION_MODE_OPTIONS}
+                onChange={setLocalExecutionMode}
+                disabled={busy}
+              />
+            </div>
+          </div>
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-sm">image_strategy</span>
+            <div className="w-48">
+              <SelectMenu
+                value={effectiveImageStrategy}
+                options={IMAGE_STRATEGY_OPTIONS}
+                onChange={setLocalImageStrategy}
+                disabled={busy}
+              />
+            </div>
+          </div>
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-sm">retrieval_mode</span>
+            <div className="w-48">
+              <SelectMenu
+                value={effectiveRetrievalMode}
+                options={RETRIEVAL_MODE_OPTIONS}
+                onChange={setLocalRetrievalMode}
+                disabled={busy}
+              />
+            </div>
+          </div>
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-sm">audio_output_mode</span>
+            <div className="w-48">
+              <SelectMenu
+                value={effectiveAudioOutputMode}
+                options={AUDIO_OUTPUT_MODE_OPTIONS}
+                onChange={setLocalAudioOutputMode}
+                disabled={busy}
+              />
+            </div>
+          </div>
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-sm">assistant_mode</span>
+            <div className="w-48">
+              <SelectMenu
+                value={effectiveAssistantMode}
+                options={ASSISTANT_MODE_OPTIONS}
+                onChange={setLocalAssistantMode}
+                disabled={busy}
+              />
+            </div>
+          </div>
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-sm">economy_mode</span>
+            <div className="w-48">
+              <SelectMenu
+                value={effectiveEconomyMode}
+                options={ECONOMY_MODE_OPTIONS}
+                onChange={setLocalEconomyMode}
+                disabled={busy}
+              />
+            </div>
+          </div>
+        </div>
+        <Button
+          size="sm"
+          className="mt-3 w-full"
+          onClick={handleApplyPolicy}
+          disabled={busy || !data?.daemon_reachable}
+        >
+          {busy ? t("runtime.profile.applying") : "Apply policy"}
         </Button>
       </section>
 

--- a/web-next/components/runtime/runtime-diagnostics-panel.tsx
+++ b/web-next/components/runtime/runtime-diagnostics-panel.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Panel } from "@/components/ui/panel";
+
+type RuntimeSummaryItem = Readonly<{
+  label: string;
+  value: ReactNode;
+  hint?: string;
+  tone?: "success" | "warning" | "danger" | "neutral";
+}>;
+
+type RuntimeComponentSnapshotItem = Readonly<{
+  component_id?: string | null;
+  component_type?: string | null;
+  enabled?: boolean | null;
+  available?: boolean | null;
+  backend?: string | null;
+  model_id?: string | null;
+  device_target?: string | null;
+  health?: string | null;
+  last_error?: string | null;
+}>;
+
+type RuntimeDiagnosticsPanelProps = Readonly<{
+  title: string;
+  description?: string;
+  summaryItems?: RuntimeSummaryItem[];
+  trace?: string[] | null;
+  componentSnapshot?: RuntimeComponentSnapshotItem[] | null;
+  degradationReasons?: string[] | null;
+  emptyStateTitle?: string;
+  emptyStateDescription?: string;
+  className?: string;
+}>;
+
+function toneClass(tone?: RuntimeSummaryItem["tone"]): string {
+  switch (tone) {
+    case "success":
+      return "border-emerald-400/30 bg-emerald-500/10 text-emerald-100";
+    case "warning":
+      return "border-amber-400/30 bg-amber-500/10 text-amber-100";
+    case "danger":
+      return "border-rose-400/30 bg-rose-500/10 text-rose-100";
+    case "neutral":
+    default:
+      return "border-white/10 bg-white/[0.04] text-zinc-100";
+  }
+}
+
+function healthTone(health?: string | null): "success" | "warning" | "danger" | "neutral" {
+  const normalized = String(health || "").trim().toLowerCase();
+  if (normalized === "ok") return "success";
+  if (normalized === "degraded") return "warning";
+  if (normalized === "disabled") return "neutral";
+  if (normalized === "failed" || normalized === "error") return "danger";
+  return "neutral";
+}
+
+export function RuntimeDiagnosticsPanel({
+  title,
+  description,
+  summaryItems,
+  trace,
+  componentSnapshot,
+  degradationReasons,
+  emptyStateTitle = "Runtime diagnostics unavailable",
+  emptyStateDescription = "No runtime snapshot has been captured yet.",
+  className,
+}: RuntimeDiagnosticsPanelProps) {
+  const hasSummary = Boolean(summaryItems && summaryItems.length > 0);
+  const hasTrace = Boolean(trace && trace.length > 0);
+  const hasComponents = Boolean(componentSnapshot && componentSnapshot.length > 0);
+  const hasDegradations = Boolean(degradationReasons && degradationReasons.length > 0);
+  const hasAny = hasSummary || hasTrace || hasComponents || hasDegradations;
+
+  return (
+    <Panel
+      title={title}
+      description={description}
+      className={className}
+    >
+      {!hasAny ? (
+        <EmptyState
+          title={emptyStateTitle}
+          description={emptyStateDescription}
+        />
+      ) : (
+        <div className="space-y-4 text-sm">
+          {hasSummary && (
+            <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+              {summaryItems?.map((item) => (
+                <div
+                  key={item.label}
+                  className={`rounded-2xl border px-4 py-3 ${toneClass(item.tone)}`}
+                >
+                  <p className="text-[11px] uppercase tracking-[0.25em] text-zinc-400">
+                    {item.label}
+                  </p>
+                  <div className="mt-1.5 text-sm font-semibold text-white">
+                    {item.value}
+                  </div>
+                  {item.hint && (
+                    <p className="mt-1 text-[11px] text-zinc-400">{item.hint}</p>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {hasTrace && (
+            <div className="rounded-2xl box-muted px-4 py-3">
+              <p className="text-caption">Execution trace</p>
+              <p className="mt-1 font-mono text-[11px] text-zinc-300">
+                {trace?.join(" -> ")}
+              </p>
+            </div>
+          )}
+
+          {hasComponents && (
+            <div className="space-y-2">
+              <p className="text-caption">Runtime components</p>
+              <div className="grid gap-2 xl:grid-cols-2">
+                {componentSnapshot?.map((component) => {
+                  const componentHealth = healthTone(component.health);
+                  return (
+                    <div
+                      key={component.component_id || `${component.backend || "component"}-${component.model_id || "unknown"}`}
+                      className="rounded-2xl box-muted px-4 py-3"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="font-semibold text-white">
+                            {component.component_id || "component"}
+                          </p>
+                          <p className="text-[11px] text-zinc-500">
+                            {component.component_type ?? "runtime"}
+                            {component.model_id ? ` · ${component.model_id}` : ""}
+                          </p>
+                        </div>
+                        <Badge tone={componentHealth}>
+                          {component.health || "unknown"}
+                        </Badge>
+                      </div>
+                      <div className="mt-2 grid gap-1 text-[11px] text-zinc-400">
+                        <p>
+                          backend:{" "}
+                          <span className="text-zinc-200">{component.backend ?? "—"}</span>
+                          {" · "}device:{" "}
+                          <span className="text-zinc-200">{component.device_target ?? "—"}</span>
+                        </p>
+                        <p>
+                          enabled:{" "}
+                          <span className="text-zinc-200">
+                            {component.enabled ? "yes" : "no"}
+                          </span>
+                          {" · "}available:{" "}
+                          <span className="text-zinc-200">
+                            {component.available ? "yes" : "no"}
+                          </span>
+                        </p>
+                        {component.last_error && (
+                          <p className="text-amber-200">{component.last_error}</p>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {hasDegradations && (
+            <div className="rounded-2xl border border-amber-400/20 bg-amber-500/10 px-4 py-3">
+              <p className="text-caption text-amber-100">Degradations</p>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {degradationReasons?.map((reason) => (
+                  <Badge key={reason} tone="warning">
+                    {reason}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </Panel>
+  );
+}
+
+export type {
+  RuntimeSummaryItem,
+  RuntimeComponentSnapshotItem,
+  RuntimeDiagnosticsPanelProps,
+};

--- a/web-next/components/runtime/runtime-diagnostics-panel.tsx
+++ b/web-next/components/runtime/runtime-diagnostics-panel.tsx
@@ -82,12 +82,7 @@ export function RuntimeDiagnosticsPanel({
       description={description}
       className={className}
     >
-      {!hasAny ? (
-        <EmptyState
-          title={emptyStateTitle}
-          description={emptyStateDescription}
-        />
-      ) : (
+      {hasAny ? (
         <div className="space-y-4 text-sm">
           {hasSummary && (
             <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
@@ -185,6 +180,11 @@ export function RuntimeDiagnosticsPanel({
             </div>
           )}
         </div>
+      ) : (
+        <EmptyState
+          title={emptyStateTitle}
+          description={emptyStateDescription}
+        />
       )}
     </Panel>
   );

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -2237,7 +2237,11 @@ type VoiceCommandCenterProps = Readonly<{
   isDevMode?: boolean;
 }>;
 
-export function VoiceCommandCenter({
+export function VoiceCommandCenter(props: VoiceCommandCenterProps) {
+  return <VoiceCommandCenterPanel {...props} />;
+}
+
+function VoiceCommandCenterPanel({
   onTranscriptReady,
   voiceModePreset = "standard",
   onStatusUpdate,

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -121,6 +121,21 @@ type VoiceSessionDiagnostics = {
   response_text?: string;
   download_url?: string | null;
   pipeline_id?: string | null;
+  execution_trace?: string[] | null;
+  selected_policy?: string | null;
+  selected_image_strategy?: string | null;
+  retrieval_used?: boolean | null;
+  retrieval_context_items?: number | null;
+  retrieval_route?: string | null;
+  assistant_used?: boolean | null;
+  economy_mode_activated?: boolean | null;
+  degradation_reasons?: string[] | null;
+  component_snapshot?: Array<{
+    component_id?: string | null;
+    health?: string | null;
+    backend?: string | null;
+    available?: boolean | null;
+  }> | null;
   audio_runtime_provider?: string | null;
   audio_runtime_model?: string | null;
   audio_input_status?: string | null;
@@ -2740,6 +2755,49 @@ export function VoiceCommandCenter({
           </div>
 
           <TimingStrip timings={viewState.effectiveAudioStatus?.latest_voice_session?.timings_ms} />
+
+          {viewState.effectiveAudioStatus?.latest_voice_session && (
+            <div className="grid gap-2 sm:grid-cols-2 text-xs">
+              <div className="rounded-2xl box-muted p-3 text-zinc-300">
+                <p className="text-caption">Runtime execution</p>
+                <p className="text-white">
+                  {viewState.effectiveAudioStatus.latest_voice_session.selected_policy ?? "—"}
+                </p>
+                <p className="mt-1 text-[11px] text-zinc-400">
+                  image:{" "}
+                  {viewState.effectiveAudioStatus.latest_voice_session.selected_image_strategy ?? "—"}
+                  {" · "}retrieval:{" "}
+                  {viewState.effectiveAudioStatus.latest_voice_session.retrieval_used ? "on" : "off"}
+                  {" · "}assistant:{" "}
+                  {viewState.effectiveAudioStatus.latest_voice_session.assistant_used ? "on" : "off"}
+                </p>
+                <p className="mt-1 text-[11px] text-zinc-500">
+                  route:{" "}
+                  {viewState.effectiveAudioStatus.latest_voice_session.retrieval_route ?? "—"}
+                  {" · "}economy:{" "}
+                  {viewState.effectiveAudioStatus.latest_voice_session.economy_mode_activated ? "on" : "off"}
+                </p>
+              </div>
+              <div className="rounded-2xl box-muted p-3 text-zinc-300">
+                <p className="text-caption">Pipeline health</p>
+                <p className="text-[11px] text-zinc-400">
+                  trace:{" "}
+                  {(viewState.effectiveAudioStatus.latest_voice_session.execution_trace ?? []).join(" -> ") || "—"}
+                </p>
+                <p className="mt-1 text-[11px] text-zinc-500">
+                  retrieval items:{" "}
+                  {viewState.effectiveAudioStatus.latest_voice_session.retrieval_context_items ?? 0}
+                </p>
+                {Array.isArray(viewState.effectiveAudioStatus.latest_voice_session.degradation_reasons) &&
+                  viewState.effectiveAudioStatus.latest_voice_session.degradation_reasons.length > 0 && (
+                    <p className="mt-1 text-[11px] text-amber-300">
+                      degradations:{" "}
+                      {viewState.effectiveAudioStatus.latest_voice_session.degradation_reasons.join(" | ")}
+                    </p>
+                  )}
+              </div>
+            </div>
+          )}
 
           <p className="text-hint text-xs">{viewState.effectiveStatusMessage ?? t("voice.status.channelReady")}</p>
         </div>

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -2104,6 +2104,24 @@ function useVoiceCommandCenterStatusExpiry(params: {
   }, [debugDryRunRequested, lastAudioSignal, playbackState, processingStatus, recording, setLastAudioSignal]);
 }
 
+function useVoiceStatusUpdateEmitter(params: {
+  onStatusUpdate?: (status: VoiceStatusUpdate | null) => void;
+  debugDryRunRequested: boolean;
+  debugRecording: boolean;
+  audioStatus: AudioStatus | null;
+}) {
+  const { onStatusUpdate, debugDryRunRequested, debugRecording, audioStatus } = params;
+
+  useEffect(() => {
+    if (!onStatusUpdate) return;
+    if (debugDryRunRequested) {
+      onStatusUpdate(buildDebugAudioStatus(debugRecording));
+      return;
+    }
+    onStatusUpdate(audioStatus);
+  }, [audioStatus, debugDryRunRequested, debugRecording, onStatusUpdate]);
+}
+
 type VoiceCommandCenterProps = Readonly<{
   onTranscriptReady?: (text: string) => void;
   voiceModePreset?: VoiceModePreset;
@@ -2200,14 +2218,12 @@ export function VoiceCommandCenter({
     [debugDryRunRequested],
   );
 
-  useEffect(() => {
-    if (!onStatusUpdate) return;
-    if (debugDryRunRequested) {
-      onStatusUpdate(buildDebugAudioStatus(debugMode.recording));
-      return;
-    }
-    onStatusUpdate(audioStatus);
-  }, [audioStatus, debugDryRunRequested, debugMode.recording, onStatusUpdate]);
+  useVoiceStatusUpdateEmitter({
+    onStatusUpdate,
+    debugDryRunRequested,
+    debugRecording: debugMode.recording,
+    audioStatus,
+  });
 
   useVoiceCommandCenterDebugBootstrap({
     debugDryRunRequested,

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -33,6 +33,10 @@ import { usePageVisibility } from "@/components/voice/use-page-visibility";
 import { useOrbActivityWindow } from "@/components/voice/use-orb-activity-window";
 import { useVoiceDebugMode } from "@/components/voice/use-voice-debug-mode";
 import type { VoiceDebugSnapshot } from "@/components/voice/use-voice-debug-mode";
+import {
+  RuntimeDiagnosticsPanel,
+  type RuntimeSummaryItem,
+} from "@/components/runtime/runtime-diagnostics-panel";
 
 export type AudioStatus = {
   enabled: boolean;
@@ -2757,46 +2761,41 @@ export function VoiceCommandCenter({
           <TimingStrip timings={viewState.effectiveAudioStatus?.latest_voice_session?.timings_ms} />
 
           {viewState.effectiveAudioStatus?.latest_voice_session && (
-            <div className="grid gap-2 sm:grid-cols-2 text-xs">
-              <div className="rounded-2xl box-muted p-3 text-zinc-300">
-                <p className="text-caption">Runtime execution</p>
-                <p className="text-white">
-                  {viewState.effectiveAudioStatus.latest_voice_session.selected_policy ?? "—"}
-                </p>
-                <p className="mt-1 text-[11px] text-zinc-400">
-                  image:{" "}
-                  {viewState.effectiveAudioStatus.latest_voice_session.selected_image_strategy ?? "—"}
-                  {" · "}retrieval:{" "}
-                  {viewState.effectiveAudioStatus.latest_voice_session.retrieval_used ? "on" : "off"}
-                  {" · "}assistant:{" "}
-                  {viewState.effectiveAudioStatus.latest_voice_session.assistant_used ? "on" : "off"}
-                </p>
-                <p className="mt-1 text-[11px] text-zinc-500">
-                  route:{" "}
-                  {viewState.effectiveAudioStatus.latest_voice_session.retrieval_route ?? "—"}
-                  {" · "}economy:{" "}
-                  {viewState.effectiveAudioStatus.latest_voice_session.economy_mode_activated ? "on" : "off"}
-                </p>
-              </div>
-              <div className="rounded-2xl box-muted p-3 text-zinc-300">
-                <p className="text-caption">Pipeline health</p>
-                <p className="text-[11px] text-zinc-400">
-                  trace:{" "}
-                  {(viewState.effectiveAudioStatus.latest_voice_session.execution_trace ?? []).join(" -> ") || "—"}
-                </p>
-                <p className="mt-1 text-[11px] text-zinc-500">
-                  retrieval items:{" "}
-                  {viewState.effectiveAudioStatus.latest_voice_session.retrieval_context_items ?? 0}
-                </p>
-                {Array.isArray(viewState.effectiveAudioStatus.latest_voice_session.degradation_reasons) &&
-                  viewState.effectiveAudioStatus.latest_voice_session.degradation_reasons.length > 0 && (
-                    <p className="mt-1 text-[11px] text-amber-300">
-                      degradations:{" "}
-                      {viewState.effectiveAudioStatus.latest_voice_session.degradation_reasons.join(" | ")}
-                    </p>
-                  )}
-              </div>
-            </div>
+            <RuntimeDiagnosticsPanel
+              title="Runtime execution"
+              description="Live voice session diagnostics and component health."
+              summaryItems={
+                [
+                  {
+                    label: "Policy",
+                    value: viewState.effectiveAudioStatus.latest_voice_session.selected_policy ?? "—",
+                    tone: "neutral",
+                  },
+                  {
+                    label: "Image",
+                    value: viewState.effectiveAudioStatus.latest_voice_session.selected_image_strategy ?? "—",
+                    tone: "neutral",
+                    hint: `retrieval ${viewState.effectiveAudioStatus.latest_voice_session.retrieval_used ? "on" : "off"}`,
+                  },
+                  {
+                    label: "Route",
+                    value: viewState.effectiveAudioStatus.latest_voice_session.retrieval_route ?? "—",
+                    tone: "neutral",
+                    hint: `assistant ${viewState.effectiveAudioStatus.latest_voice_session.assistant_used ? "on" : "off"}`,
+                  },
+                  {
+                    label: "Economy",
+                    value: viewState.effectiveAudioStatus.latest_voice_session.economy_mode_activated ? "on" : "off",
+                    tone: viewState.effectiveAudioStatus.latest_voice_session.economy_mode_activated ? "warning" : "success",
+                    hint: `retrieval items ${viewState.effectiveAudioStatus.latest_voice_session.retrieval_context_items ?? 0}`,
+                  },
+                ] as RuntimeSummaryItem[]
+              }
+              trace={viewState.effectiveAudioStatus.latest_voice_session.execution_trace ?? []}
+              componentSnapshot={viewState.effectiveAudioStatus.latest_voice_session.component_snapshot ?? []}
+              degradationReasons={viewState.effectiveAudioStatus.latest_voice_session.degradation_reasons ?? []}
+              className="border-white/10 bg-white/[0.02]"
+            />
           )}
 
           <p className="text-hint text-xs">{viewState.effectiveStatusMessage ?? t("voice.status.channelReady")}</p>

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -2122,6 +2122,108 @@ function useVoiceStatusUpdateEmitter(params: {
   }, [audioStatus, debugDryRunRequested, debugRecording, onStatusUpdate]);
 }
 
+function useVoiceModeSyncEffect(params: {
+  audioEnabled: boolean;
+  connected: boolean;
+  t: ReturnType<typeof useTranslation>;
+  voiceModePreset: VoiceModePreset;
+  lastVoiceModeSentRef: MutableRefObject<string | null>;
+  wsRef: MutableRefObject<WebSocket | null>;
+  setStatusMessage: Dispatch<SetStateAction<string | null>>;
+}) {
+  const {
+    audioEnabled,
+    connected,
+    t,
+    voiceModePreset,
+    lastVoiceModeSentRef,
+    wsRef,
+    setStatusMessage,
+  } = params;
+  useEffect(() => {
+    syncVoiceModeSelection({
+      audioEnabled,
+      connected,
+      t,
+      voiceModePreset,
+      lastVoiceModeSentRef,
+      wsRef,
+      setStatusMessage,
+    });
+  }, [audioEnabled, connected, t, voiceModePreset, lastVoiceModeSentRef, wsRef, setStatusMessage]);
+}
+
+function useVoiceCaptureWarmupEffect(params: {
+  debugDryRunRequested: boolean;
+  audioEnabled: boolean;
+  isVoiceModeEnabled: boolean;
+  mediaStreamRef: MutableRefObject<MediaStream | null>;
+  audioContextRef: MutableRefObject<AudioContext | null>;
+  sourceNodeRef: MutableRefObject<MediaStreamAudioSourceNode | null>;
+  analyserRef: MutableRefObject<AnalyserNode | null>;
+  mediaRecorderRef: MutableRefObject<MediaRecorder | null>;
+  ensurePlaybackContext: () => Promise<AudioContext>;
+  getMediaRecorderMimeType: () => string;
+}) {
+  const {
+    debugDryRunRequested,
+    audioEnabled,
+    isVoiceModeEnabled,
+    mediaStreamRef,
+    audioContextRef,
+    sourceNodeRef,
+    analyserRef,
+    mediaRecorderRef,
+    ensurePlaybackContext,
+    getMediaRecorderMimeType,
+  } = params;
+  useEffect(() => {
+    if (debugDryRunRequested || !audioEnabled || !isVoiceModeEnabled) {
+      return;
+    }
+    if (
+      mediaStreamRef.current &&
+      audioContextRef.current &&
+      sourceNodeRef.current &&
+      analyserRef.current &&
+      mediaRecorderRef.current
+    ) {
+      return;
+    }
+
+    let cancelled = false;
+    createVoiceCaptureEnvironment({
+      activeWindow: getBrowserWindow(),
+      audioContextRef,
+      getMediaRecorderMimeType,
+      mediaStreamRef,
+      sourceNodeRef,
+      analyserRef,
+      mediaRecorderRef,
+      ensurePlaybackContext,
+    }).catch((error) => {
+      if (!cancelled) {
+        console.warn("Voice capture warmup failed", error);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    audioEnabled,
+    analyserRef,
+    audioContextRef,
+    debugDryRunRequested,
+    ensurePlaybackContext,
+    getMediaRecorderMimeType,
+    isVoiceModeEnabled,
+    mediaRecorderRef,
+    mediaStreamRef,
+    sourceNodeRef,
+  ]);
+}
+
 type VoiceCommandCenterProps = Readonly<{
   onTranscriptReady?: (text: string) => void;
   voiceModePreset?: VoiceModePreset;
@@ -2185,17 +2287,15 @@ export function VoiceCommandCenter({
 
   const reducedMotion = useVoiceCommandCenterReducedMotion();
 
-  useEffect(() => {
-    syncVoiceModeSelection({
-      audioEnabled,
-      connected,
-      t,
-      voiceModePreset,
-      lastVoiceModeSentRef,
-      wsRef,
-      setStatusMessage,
-    });
-  }, [audioEnabled, connected, t, voiceModePreset]);
+  useVoiceModeSyncEffect({
+    audioEnabled,
+    connected,
+    t,
+    voiceModePreset,
+    lastVoiceModeSentRef,
+    wsRef,
+    setStatusMessage,
+  });
 
   const refreshAudioStatus = useCallback(
     () =>
@@ -2342,54 +2442,18 @@ export function VoiceCommandCenter({
     [],
   );
 
-  useEffect(() => {
-    if (debugDryRunRequested) {
-      return;
-    }
-    if (!audioEnabled || !isVoiceModeEnabled) {
-      return;
-    }
-    if (
-      mediaStreamRef.current &&
-      audioContextRef.current &&
-      sourceNodeRef.current &&
-      analyserRef.current &&
-      mediaRecorderRef.current
-    ) {
-      return;
-    }
-
-    let cancelled = false;
-    createVoiceCaptureEnvironment({
-      activeWindow: getBrowserWindow(),
-      audioContextRef,
-      getMediaRecorderMimeType,
-      mediaStreamRef,
-      sourceNodeRef,
-      analyserRef,
-      mediaRecorderRef,
-      ensurePlaybackContext,
-    }).catch((error) => {
-      if (!cancelled) {
-        console.warn("Voice capture warmup failed", error);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    audioEnabled,
-    analyserRef,
+  useVoiceCaptureWarmupEffect({
     debugDryRunRequested,
+    audioEnabled,
+    isVoiceModeEnabled,
+    mediaStreamRef,
+    audioContextRef,
+    sourceNodeRef,
+    analyserRef,
+    mediaRecorderRef,
     ensurePlaybackContext,
     getMediaRecorderMimeType,
-    isVoiceModeEnabled,
-    mediaRecorderRef,
-    mediaStreamRef,
-    sourceNodeRef,
-    audioContextRef,
-  ]);
+  });
 
   useEffect(
     () => {

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -2710,12 +2710,10 @@ function VoiceCommandCenterPanel({
 
   const onVoiceModeToggle = useCallback(() => {
     if (debugDryRunActive) return;
-    setIsVoiceModeEnabled((current) => {
-      const next = !current;
-      setStatusMessage(next ? t("voice.controls.voiceChat") : t("voice.controls.textChat"));
-      return next;
-    });
-  }, [debugDryRunActive, setIsVoiceModeEnabled, setStatusMessage, t]);
+    const next = !isVoiceModeEnabled;
+    setIsVoiceModeEnabled(next);
+    setStatusMessage(next ? t("voice.controls.voiceChat") : t("voice.controls.textChat"));
+  }, [debugDryRunActive, isVoiceModeEnabled, setIsVoiceModeEnabled, setStatusMessage, t]);
 
   return (
     <>

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { Dispatch, MutableRefObject, RefObject, SetStateAction } from "react";
+import type {
+  Dispatch,
+  MutableRefObject,
+  PointerEvent as ReactPointerEvent,
+  RefObject,
+  SetStateAction,
+} from "react";
 import { Panel } from "@/components/ui/panel";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -2662,6 +2668,43 @@ export function VoiceCommandCenter({
     setLastAudioSignal,
   });
 
+  const onRecordingPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      if (!recording) {
+        try {
+          event.currentTarget.setPointerCapture(event.pointerId);
+        } catch {
+          // ignore pointer capture failures
+        }
+        startRecording().catch(() => undefined);
+      }
+    },
+    [recording, startRecording],
+  );
+
+  const onRecordingPointerUp = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      stopRecording();
+      try {
+        event.currentTarget.releasePointerCapture(event.pointerId);
+      } catch {
+        // ignore pointer capture failures
+      }
+    },
+    [stopRecording],
+  );
+
+  const onVoiceModeToggle = useCallback(() => {
+    if (debugDryRunActive) return;
+    setIsVoiceModeEnabled((current) => {
+      const next = !current;
+      setStatusMessage(next ? t("voice.controls.voiceChat") : t("voice.controls.textChat"));
+      return next;
+    });
+  }, [debugDryRunActive, setIsVoiceModeEnabled, setStatusMessage, t]);
+
   return (
     <>
       <Panel
@@ -2715,28 +2758,10 @@ export function VoiceCommandCenter({
 
           <Button
             type="button"
-            onPointerDown={(event) => {
-              event.preventDefault();
-              if (!recordingRef.current) {
-                try {
-                  event.currentTarget.setPointerCapture(event.pointerId);
-                } catch {
-                  // ignore pointer capture failures
-                }
-                startRecording().catch(() => undefined);
-              }
-            }}
-            onPointerUp={(event) => {
-              event.preventDefault();
-              stopRecording();
-              try {
-                event.currentTarget.releasePointerCapture(event.pointerId);
-              } catch {
-                // ignore pointer capture failures
-              }
-            }}
-            onPointerCancel={() => stopRecording()}
-            onLostPointerCapture={() => stopRecording()}
+            onPointerDown={onRecordingPointerDown}
+            onPointerUp={onRecordingPointerUp}
+            onPointerCancel={stopRecording}
+            onLostPointerCapture={stopRecording}
             variant="outline"
             size="md"
             className={`w-full justify-center rounded-2xl border px-4 py-6 text-lg font-semibold transition ${viewState.recordingButtonClass}`}
@@ -2750,14 +2775,7 @@ export function VoiceCommandCenter({
               type="button"
               size="xs"
               variant={viewState.effectiveIsVoiceModeEnabled ? "primary" : "outline"}
-              onClick={() => {
-                if (debugDryRunActive) return;
-                setIsVoiceModeEnabled((current) => {
-                  const next = !current;
-                  setStatusMessage(next ? t("voice.controls.voiceChat") : t("voice.controls.textChat"));
-                  return next;
-                });
-              }}
+              onClick={onVoiceModeToggle}
               disabled={!viewState.effectiveAudioEnabled || debugDryRunActive}
             >
               {viewState.effectiveIsVoiceModeEnabled ? t("voice.controls.voice") : t("voice.controls.text")}

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -2241,6 +2241,22 @@ export function VoiceCommandCenter(props: VoiceCommandCenterProps) {
   return <VoiceCommandCenterPanel {...props} />;
 }
 
+function tryCapturePointer(element: HTMLButtonElement, pointerId: number): void {
+  try {
+    element.setPointerCapture(pointerId);
+  } catch {
+    // pointer capture not supported in this environment
+  }
+}
+
+function tryReleasePointer(element: HTMLButtonElement, pointerId: number): void {
+  try {
+    element.releasePointerCapture(pointerId);
+  } catch {
+    // pointer capture not supported in this environment
+  }
+}
+
 function VoiceCommandCenterPanel({
   onTranscriptReady,
   voiceModePreset = "standard",
@@ -2676,11 +2692,7 @@ function VoiceCommandCenterPanel({
     (event: ReactPointerEvent<HTMLButtonElement>) => {
       event.preventDefault();
       if (!recording) {
-        try {
-          event.currentTarget.setPointerCapture(event.pointerId);
-        } catch {
-          // ignore pointer capture failures
-        }
+        tryCapturePointer(event.currentTarget, event.pointerId);
         startRecording().catch(() => undefined);
       }
     },
@@ -2691,11 +2703,7 @@ function VoiceCommandCenterPanel({
     (event: ReactPointerEvent<HTMLButtonElement>) => {
       event.preventDefault();
       stopRecording();
-      try {
-        event.currentTarget.releasePointerCapture(event.pointerId);
-      } catch {
-        // ignore pointer capture failures
-      }
+      tryReleasePointer(event.currentTarget, event.pointerId);
     },
     [stopRecording],
   );

--- a/web-next/lib/gemma4-daemon-api.ts
+++ b/web-next/lib/gemma4-daemon-api.ts
@@ -20,6 +20,24 @@ export type DaemonParamsInfo = {
   emotion_detection_enabled: boolean;
   emotion_response_style_enabled: boolean;
   cache_implementation: string | null;
+  execution_mode: "balanced" | "vision_priority" | "voice_priority";
+  image_strategy: "vlm_only" | "ocr_first" | "hybrid";
+  retrieval_mode: "off" | "auto" | "always";
+  audio_output_mode: "off" | "text_first" | "voice_first";
+  assistant_mode: "off" | "attached" | "conditional";
+  economy_mode: "off" | "auto";
+};
+
+export type RuntimeComponentSnapshotItem = {
+  component_id: string;
+  component_type: string;
+  enabled: boolean;
+  available: boolean;
+  backend: string;
+  model_id: string | null;
+  device_target: string;
+  health: string;
+  last_error: string | null;
 };
 
 export type DaemonStatus = {
@@ -39,6 +57,7 @@ export type DaemonStatus = {
   pending_reload: boolean;
   reload_reason: string | null;
   supports_image_input: boolean;
+  component_snapshot: RuntimeComponentSnapshotItem[];
 };
 
 export type ReloadSignal = "none" | "soft_reload" | "hard_restart";
@@ -51,6 +70,12 @@ export type DaemonConfigRequest = {
   emotion_detection_enabled?: boolean | null;
   emotion_response_style_enabled?: boolean | null;
   cache_implementation?: string | null;
+  execution_mode?: "balanced" | "vision_priority" | "voice_priority" | null;
+  image_strategy?: "vlm_only" | "ocr_first" | "hybrid" | null;
+  retrieval_mode?: "off" | "auto" | "always" | null;
+  audio_output_mode?: "off" | "text_first" | "voice_first" | null;
+  assistant_mode?: "off" | "attached" | "conditional" | null;
+  economy_mode?: "off" | "auto" | null;
 };
 
 export type DaemonConfigResponse = {
@@ -78,6 +103,13 @@ export type DaemonRespondResponse = {
   model: string;
   input_modalities: string[];
   output_modalities: string[];
+  execution_trace: string[];
+  selected_policy: string | null;
+  selected_image_strategy: string | null;
+  retrieval_used: boolean;
+  assistant_used: boolean;
+  economy_mode_activated: boolean;
+  component_snapshot: RuntimeComponentSnapshotItem[];
 };
 
 async function daemonFetch<T>(
@@ -168,6 +200,12 @@ export type MultiRuntimeProfile = {
   reasoning_summary_enabled: boolean;
   emotion_detection_enabled: boolean;
   emotion_response_style_enabled: boolean;
+  execution_mode: "balanced" | "vision_priority" | "voice_priority";
+  image_strategy: "vlm_only" | "ocr_first" | "hybrid";
+  retrieval_mode: "off" | "auto" | "always";
+  audio_output_mode: "off" | "text_first" | "voice_first";
+  assistant_mode: "off" | "attached" | "conditional";
+  economy_mode: "off" | "auto";
   precision: string;
   quantization_backend: string | null;
   device_target: string;
@@ -183,6 +221,12 @@ export type MultiRuntimeApplyMatrix = {
   reasoning_summary_enabled: MultiRuntimeApplyMode;
   emotion_detection_enabled: MultiRuntimeApplyMode;
   emotion_response_style_enabled: MultiRuntimeApplyMode;
+  execution_mode: MultiRuntimeApplyMode;
+  image_strategy: MultiRuntimeApplyMode;
+  retrieval_mode: MultiRuntimeApplyMode;
+  audio_output_mode: MultiRuntimeApplyMode;
+  assistant_mode: MultiRuntimeApplyMode;
+  economy_mode: MultiRuntimeApplyMode;
   precision: MultiRuntimeApplyMode;
   quantization_backend: MultiRuntimeApplyMode;
   device_target: MultiRuntimeApplyMode;
@@ -193,6 +237,12 @@ export type MultiRuntimeSupportedOptions = {
   precision: string[];
   device_target: string[];
   quantization_backend: (string | null)[];
+  execution_mode: string[];
+  image_strategy: string[];
+  retrieval_mode: string[];
+  audio_output_mode: string[];
+  assistant_mode: string[];
+  economy_mode: string[];
 };
 
 export type MultiRuntimeProfileResponse = {
@@ -213,6 +263,12 @@ export type MultiRuntimeProfileUpdateRequest = {
   reasoning_summary_enabled?: boolean | null;
   emotion_detection_enabled?: boolean | null;
   emotion_response_style_enabled?: boolean | null;
+  execution_mode?: "balanced" | "vision_priority" | "voice_priority" | null;
+  image_strategy?: "vlm_only" | "ocr_first" | "hybrid" | null;
+  retrieval_mode?: "off" | "auto" | "always" | null;
+  audio_output_mode?: "off" | "text_first" | "voice_first" | null;
+  assistant_mode?: "off" | "attached" | "conditional" | null;
+  economy_mode?: "off" | "auto" | null;
   precision?: string | null;
   quantization_backend?: string | null;
   device_target?: string | null;

--- a/web-next/lib/gemma4-daemon-api.ts
+++ b/web-next/lib/gemma4-daemon-api.ts
@@ -107,8 +107,10 @@ export type DaemonRespondResponse = {
   selected_policy: string | null;
   selected_image_strategy: string | null;
   retrieval_used: boolean;
+  retrieval_context_items: number;
   assistant_used: boolean;
   economy_mode_activated: boolean;
+  degradation_reasons: string[];
   component_snapshot: RuntimeComponentSnapshotItem[];
 };
 

--- a/web-next/lib/gemma4-daemon-api.ts
+++ b/web-next/lib/gemma4-daemon-api.ts
@@ -108,6 +108,7 @@ export type DaemonRespondResponse = {
   selected_image_strategy: string | null;
   retrieval_used: boolean;
   retrieval_context_items: number;
+  retrieval_route?: string | null;
   assistant_used: boolean;
   economy_mode_activated: boolean;
   degradation_reasons: string[];

--- a/web-next/tests/gemma4-runtime-control.component.test.tsx
+++ b/web-next/tests/gemma4-runtime-control.component.test.tsx
@@ -24,6 +24,12 @@ function makeStatus(overrides: Partial<DaemonStatus> = {}): DaemonStatus {
       emotion_detection_enabled: false,
       emotion_response_style_enabled: false,
       cache_implementation: null,
+      execution_mode: "balanced",
+      image_strategy: "vlm_only",
+      retrieval_mode: "off",
+      audio_output_mode: "off",
+      assistant_mode: "off",
+      economy_mode: "off",
     },
     vram: {
       backend: "cpu",
@@ -41,6 +47,19 @@ function makeStatus(overrides: Partial<DaemonStatus> = {}): DaemonStatus {
     pending_reload: false,
     reload_reason: null,
     supports_image_input: true,
+    component_snapshot: [
+      {
+        component_id: "main_model",
+        component_type: "model",
+        enabled: true,
+        available: true,
+        backend: "cpu",
+        model_id: "google/gemma-4-E2B-it",
+        device_target: "cpu",
+        health: "ok",
+        last_error: null,
+      },
+    ],
     ...overrides,
   };
 }
@@ -283,6 +302,12 @@ describe("Gemma4RuntimeControl — thinking toggle", () => {
           emotion_detection_enabled: false,
           emotion_response_style_enabled: false,
           cache_implementation: null,
+          execution_mode: "balanced",
+          image_strategy: "vlm_only",
+          retrieval_mode: "off",
+          audio_output_mode: "off",
+          assistant_mode: "off",
+          economy_mode: "off",
         },
       }),
     }));

--- a/web-next/tests/multi-runtime-profile.test.ts
+++ b/web-next/tests/multi-runtime-profile.test.ts
@@ -39,6 +39,12 @@ function makeProfile(overrides: Partial<MultiRuntimeProfile> = {}): MultiRuntime
     reasoning_summary_enabled: false,
     emotion_detection_enabled: false,
     emotion_response_style_enabled: false,
+    execution_mode: "balanced",
+    image_strategy: "vlm_only",
+    retrieval_mode: "off",
+    audio_output_mode: "off",
+    assistant_mode: "off",
+    economy_mode: "off",
     precision: "auto",
     quantization_backend: null,
     device_target: "auto",
@@ -57,6 +63,12 @@ function makeMatrix(): MultiRuntimeApplyMatrix {
     reasoning_summary_enabled: "live",
     emotion_detection_enabled: "live",
     emotion_response_style_enabled: "live",
+    execution_mode: "live",
+    image_strategy: "live",
+    retrieval_mode: "live",
+    audio_output_mode: "live",
+    assistant_mode: "live",
+    economy_mode: "live",
     precision: "unsupported",
     quantization_backend: "unsupported",
     device_target: "unsupported",
@@ -75,6 +87,12 @@ function makeProfileResponse(
       precision: ["auto"],
       device_target: ["auto", "cpu", "cuda"],
       quantization_backend: [null],
+      execution_mode: ["balanced", "vision_priority", "voice_priority"],
+      image_strategy: ["vlm_only", "ocr_first", "hybrid"],
+      retrieval_mode: ["off", "auto", "always"],
+      audio_output_mode: ["off", "text_first", "voice_first"],
+      assistant_mode: ["off", "attached", "conditional"],
+      economy_mode: ["off", "auto"],
     },
     daemon_reachable: true,
     ...overrides,
@@ -108,6 +126,12 @@ describe("MultiRuntimeProfile type contract", () => {
       "reasoning_summary_enabled",
       "emotion_detection_enabled",
       "emotion_response_style_enabled",
+      "execution_mode",
+      "image_strategy",
+      "retrieval_mode",
+      "audio_output_mode",
+      "assistant_mode",
+      "economy_mode",
     ];
     for (const field of liveFields) {
       assert.equal(matrix[field], "live", `${field} should be live`);
@@ -162,6 +186,12 @@ describe("MultiRuntimeProfileResponse envelope", () => {
     assert.ok(Array.isArray(opts.precision));
     assert.ok(Array.isArray(opts.device_target));
     assert.ok(Array.isArray(opts.quantization_backend));
+    assert.ok(Array.isArray(opts.execution_mode));
+    assert.ok(Array.isArray(opts.image_strategy));
+    assert.ok(Array.isArray(opts.retrieval_mode));
+    assert.ok(Array.isArray(opts.audio_output_mode));
+    assert.ok(Array.isArray(opts.assistant_mode));
+    assert.ok(Array.isArray(opts.economy_mode));
   });
 });
 

--- a/web-next/tests/runtime-diagnostics-panel.test.tsx
+++ b/web-next/tests/runtime-diagnostics-panel.test.tsx
@@ -1,0 +1,42 @@
+import "./component-test-setup";
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { cleanup, render, screen } from "@testing-library/react";
+import { RuntimeDiagnosticsPanel } from "../components/runtime/runtime-diagnostics-panel";
+
+afterEach(() => cleanup());
+
+describe("RuntimeDiagnosticsPanel", () => {
+  it("renders summary, components and degradations", () => {
+    render(
+      <RuntimeDiagnosticsPanel
+        title="Runtime diagnostics"
+        description="Live snapshot"
+        summaryItems={[
+          { label: "Policy", value: "balanced|vlm_only", tone: "neutral" },
+          { label: "Retrieval", value: "graph", tone: "success" },
+        ]}
+        trace={["input_router", "retrieval", "main_generation"]}
+        componentSnapshot={[
+          {
+            component_id: "main_model",
+            component_type: "model",
+            enabled: true,
+            available: true,
+            backend: "cuda",
+            model_id: "google/gemma-4-E2B-it",
+            device_target: "cuda",
+            health: "ok",
+            last_error: null,
+          },
+        ]}
+        degradationReasons={["retrieval fallback"]}
+      />,
+    );
+
+    assert.ok(screen.getByText("Runtime diagnostics"));
+    assert.ok(screen.getByText("balanced|vlm_only"));
+    assert.ok(screen.getByText("main_model"));
+    assert.ok(screen.getByText("retrieval fallback"));
+  });
+});


### PR DESCRIPTION
## Co się zmieniło

Ten zakres domyka aktywację 217DB dla `multi_runtime` i podnosi pipeline z poziomu scaffoldingu do aktywnej logiki wykonania.

### Backend
- OCR dostaje teraz wynik strukturalny (`OCRResult`) z tekstem, liniami, tokenami i metadanymi zamiast samego surowego stringa.
- Retrieval ma jawny `RetrievalPolicyResolver`, który rozdziela `graph` vs `vector` i uwzględnia tryb economy oraz modalność wejścia.
- `main_generation` składa prompt z OCR context tylko wtedy, gdy OCR faktycznie wnosi treść.
- Diagnostyka pipeline dalej raportuje trace, component snapshot i degradacje, ale teraz opiera się na bardziej świadomych decyzjach runtime.

### UI
- Dodałem wspólny panel `RuntimeDiagnosticsPanel`.
- Panel jest widoczny zarówno w voice, jak i w standardowym chat screen Cockpitu.
- Widok pokazuje status komponentów, trace wykonania i powody degradacji bez wchodzenia do osobnego panelu runtime.

### Helpery 217DB
- Dodałem lekkie skrypty probe do sprawdzania: component snapshot, retrieval mode, image strategy, economy mode i assistant mode.

## Dlaczego

Dotychczasowy scaffold 217DA dawał strukturę, ale decyzje wykonawcze były jeszcze zbyt rozproszone i w dużej części heurystyczne. Ten PR porządkuje odpowiedzialności:
- OCR ma własny artefakt danych,
- retrieval ma własny resolver polityki,
- UI pokazuje te same decyzje w dwóch głównych wejściach użytkownika.

## Wpływ

- Lepsza obserwowalność realnego zachowania runtime.
- Mniej „cichych” degradacji.
- Spójny widok zdrowia runtime w voice i standardowym chatcie.
- Lepsza baza pod kolejne iteracje 217DB bez dokładania ciężkich backendów.

## Walidacja

- `.venv/bin/pytest -q tests/test_217da_multi_runtime_pipeline_basics.py tests/test_214a_daemon_management.py`
- `cd web-next && npm run test:unit -- tests/runtime-diagnostics-panel.test.tsx tests/voice-command-center-debug.component.test.tsx`
- `make test-catalog-check`
- `make test-groups-check`
- `make test-fast-coverage`
