### PR TITLE
[codex] sonar hotfix maintenance

### DIFF
--- a/venom_core/agents/documenter.py
+++ b/venom_core/agents/documenter.py
@@ -262,11 +262,7 @@ class DocumenterAgent:
         keywords = ["def ", "class ", "async def ", '"""', "'''"]
 
         for line in diff.splitlines():
-            if (
-                (line.startswith("+") or line.startswith("-"))
-                and not line.startswith("+++")
-                and not line.startswith("---")
-            ):
+            if line.startswith(("+", "-")) and not line.startswith(("+++", "---")):
                 for keyword in keywords:
                     if keyword in line:
                         logger.debug(

--- a/venom_core/api/routes/audit_stream.py
+++ b/venom_core/api/routes/audit_stream.py
@@ -110,9 +110,7 @@ def _infer_from_source_prefix(source_n: str, source_head: str, action: str) -> s
         return CHANNEL_GOVERNANCE
     if source_n.startswith("core.technical."):
         return _infer_from_technical_source(source_n, action)
-    if source_n.startswith("module.brand_studio") or source_n.startswith(
-        "brand_studio"
-    ):
+    if source_n.startswith(("module.brand_studio", "brand_studio")):
         channel = _channel_from_action(action)
         return channel or CHANNEL_FRONTEND
     if source_n.startswith("core."):

--- a/venom_core/core/intent_manager.py
+++ b/venom_core/core/intent_manager.py
@@ -599,7 +599,7 @@ STATUS_REPORT, INFRA_STATUS, HELP_REQUEST, TIME_REQUEST, UNSUPPORTED_TASK."""
         ):
             candidates = {best_top2[0][0], best_top2[1][0]} & self.TOOL_INTENTS
             if candidates:
-                return sorted(candidates)[0]
+                return min(candidates)
         return best_intent
 
     def _classify_from_lexicon(self, normalized: str, language: str) -> str:

--- a/venom_core/core/model_manager.py
+++ b/venom_core/core/model_manager.py
@@ -6,7 +6,7 @@ import subprocess
 import time
 from pathlib import Path
 from threading import Lock
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Callable, Dict, List, Optional, cast
 
 import psutil
 
@@ -422,7 +422,7 @@ PARAMETER top_k 40
 
     def load_adapter_for_kernel(
         self, version_id: str, kernel_builder
-    ) -> Union[bool, Tuple[Any, Any]]:
+    ) -> bool | tuple[Any, Any]:
         """
         Ładuje adapter LoRA do KernelBuilder (dla integracji z PEFT).
 

--- a/venom_core/perception/watcher.py
+++ b/venom_core/perception/watcher.py
@@ -107,7 +107,7 @@ class VenomFileSystemEventHandler(FileSystemEventHandler):
         return src_path
 
     def _is_supported_file(self, src_path: str) -> bool:
-        return src_path.endswith(".py") or src_path.endswith(".md")
+        return src_path.endswith((".py", ".md"))
 
     def _ensure_event_loop(self) -> Optional[asyncio.AbstractEventLoop]:
         if self._loop is not None:

--- a/venom_core/services/academy/self_learning_service.py
+++ b/venom_core/services/academy/self_learning_service.py
@@ -1010,7 +1010,7 @@ class SelfLearningService:
             return False
         if any(marker in normalized for marker in _BLOCKED_TRAINING_NAME_MARKERS):
             return False
-        if normalized.endswith(".onnx") or normalized.endswith(".gguf"):
+        if normalized.endswith((".onnx", ".gguf")):
             return False
         return "/" in candidate
 

--- a/venom_core/skills/mcp/skill_adapter.py
+++ b/venom_core/skills/mcp/skill_adapter.py
@@ -13,7 +13,7 @@ from venom_core.skills.mcp.proxy_generator import McpToolMetadata
 
 def _map_json_type(type_name: str) -> str:
     lowered = (type_name or "").lower()
-    if lowered.startswith("list") or lowered.startswith("typing.list"):
+    if lowered.startswith(("list", "typing.list")):
         return "array"
     if lowered in {"int", "float", "number"}:
         return "number"

--- a/web-next/components/academy/training-panel.tsx
+++ b/web-next/components/academy/training-panel.tsx
@@ -40,6 +40,10 @@ export type ModelPickerOption = SelectMenuOption & {
   model?: TrainableModelInfo;
 };
 
+function isModelPickerOption(option: SelectMenuOption): option is ModelPickerOption {
+  return "kind" in option;
+}
+
 type TranslateFn = (key: string) => string;
 
 export const MODEL_SECTION_ORDER: ModelSectionKey[] = [
@@ -540,7 +544,7 @@ export function TrainingPanel() {
                 menuClassName="w-[min(980px,96vw)] max-h-[360px] overflow-y-auto rounded-md border border-[color:var(--ui-border-strong)] bg-[color:var(--bg-panel)] p-1 shadow-card backdrop-blur-md"
                 optionClassName="rounded-md px-3 py-2 text-[color:var(--text-primary)] hover:bg-[color:var(--ui-surface-hover)]"
                 renderButton={(option) => {
-                  const selectedOption = option as ModelPickerOption | null;
+                  const selectedOption = option && isModelPickerOption(option) ? option : null;
                   if (!selectedOption || selectedOption.kind !== "model" || !selectedOption.model) {
                     return (
                       <span className="min-w-0 flex-1 truncate text-left text-hint">
@@ -565,7 +569,10 @@ export function TrainingPanel() {
                   );
                 }}
                 renderOption={(option, active) => {
-                  const typedOption = option as ModelPickerOption;
+                  const typedOption = isModelPickerOption(option) ? option : null;
+                  if (!typedOption) {
+                    return null;
+                  }
                   if (typedOption.kind === "section") {
                     return (
                       <div className="w-full cursor-default border-b border-[color:var(--ui-border)] px-1 py-2 text-left">

--- a/web-next/components/cockpit/cockpit-chat-thread.tsx
+++ b/web-next/components/cockpit/cockpit-chat-thread.tsx
@@ -909,7 +909,11 @@ export const ChatComposer = memo(
               <SelectMenu
                 value={chatMode}
                 options={chatModeOptions}
-                onChange={(value) => setChatMode(value as ChatMode)}
+                onChange={(value) => {
+                  if (value === "direct" || value === "normal" || value === "complex") {
+                    setChatMode(value);
+                  }
+                }}
                 ariaLabel={t("cockpit.actions.selectMode")}
                 buttonTestId="chat-mode-select"
                 menuTestId="chat-mode-menu"

--- a/web-next/components/cockpit/cockpit-chat-ui.ts
+++ b/web-next/components/cockpit/cockpit-chat-ui.ts
@@ -349,7 +349,7 @@ export function useCockpitChatUi({
       const schema = config?.generation_schema;
       setModelSchema(schema ?? null);
       if (config?.current_values) {
-        setGenerationParams(config.current_values as GenerationParams);
+        setGenerationParams(config.current_values);
       }
     } catch (err) {
       console.error(t("cockpit.feedback.schemaError"), err);
@@ -369,10 +369,7 @@ export function useCockpitChatUi({
     try {
       await updateModelConfig(activeModelName, {
         runtime: models?.active?.provider,
-        params: (generationParams ?? {}) as Record<
-          string,
-          number | string | boolean | null | undefined
-        >,
+        params: generationParams ?? {},
       });
       pushToast(t("cockpit.feedback.tuningSaved"), "success");
     } catch (err) {

--- a/web-next/components/cockpit/hooks/use-cockpit-logic.ts
+++ b/web-next/components/cockpit/hooks/use-cockpit-logic.ts
@@ -22,9 +22,7 @@ import {
     mergeStreamsIntoHistory,
     parseContextPreviewMeta,
     shouldHydrateCompletedTask,
-    StreamLike,
     toHistoryMessages,
-    HistoryEntryLike,
     HistoryTaskLike,
 } from "./cockpit-history-utils";
 import { useCockpitQueueActions } from "./use-cockpit-queue-actions";
@@ -276,7 +274,7 @@ export function useCockpitLogic({
                     sessionId,
                     hydratedRefs.current,
                     localSessionHistory,
-                    taskStreams as Record<string, StreamLike>,
+                    taskStreams,
                 )
             ) {
                 return;
@@ -406,12 +404,12 @@ export function useCockpitLogic({
             sessionEntryKey,
         });
 
-        mergeStreamsIntoHistory(deduped as HistoryEntryLike[], taskStreams as Record<string, StreamLike>);
+        mergeStreamsIntoHistory(deduped, taskStreams);
 
         deduped = filterHistoryAfterReset(deduped, resetAtRef.current);
         const ordered = orderHistoryEntriesByRequestId(deduped);
 
-        return toHistoryMessages(ordered as HistoryEntryLike[]);
+        return toHistoryMessages(ordered);
 
     }, [localSessionHistory, sessionHistory, taskStreams, sessionEntryKey, data.history, data.tasks, sessionId]);
 

--- a/web-next/components/config/api-map.tsx
+++ b/web-next/components/config/api-map.tsx
@@ -241,7 +241,12 @@ export function ApiMap() {
 
                 {/* Filters Toolbar */}
                 <div className="flex items-center gap-2 overflow-x-auto pb-2 scrollbar-none">
-                    <Select value={filterType} onValueChange={(v: string) => setFilterType(v as "all" | "internal" | "external")}>
+                    <Select
+                        value={filterType}
+                        onValueChange={(v: string) =>
+                            setFilterType(v === "internal" || v === "external" ? v : "all")
+                        }
+                    >
                         <SelectTrigger className="w-[130px] h-8 text-xs bg-theme-overlay-strong border-theme text-theme-secondary">
                             <SelectValue placeholder={t("config.apiMap.filters.type.label")} />
                         </SelectTrigger>

--- a/web-next/components/config/services-panel.tsx
+++ b/web-next/components/config/services-panel.tsx
@@ -142,12 +142,9 @@ export function ServicesPanel() {
 
     const ws = new VenomWebSocket("/ws/events", (payload: unknown) => {
       const event = payload as ServiceEvent;
-      if (event.type === "SERVICE_STATUS_UPDATE" && event.data && event.data.name) {
+      if (event.type === "SERVICE_STATUS_UPDATE" && event.data?.name) {
         setServices((prevServices) =>
-          applyServiceEventUpdate(
-            prevServices,
-            event.data as Partial<ServiceInfo> & { status: string; name?: string }
-          )
+          applyServiceEventUpdate(prevServices, event.data)
         );
       }
     });

--- a/web-next/components/layout/language-switcher.tsx
+++ b/web-next/components/layout/language-switcher.tsx
@@ -75,7 +75,7 @@ export function LanguageSwitcher({ className }: Readonly<{ className?: string }>
     <SelectMenu
       value={language}
       options={options}
-      onChange={(value) => setLanguage(value as LanguageCode)}
+      onChange={setLanguage}
       ariaLabel={t("common.switchLanguage")}
       className={className}
       renderButton={() => (

--- a/web-next/components/models/models-viewer-sections.tsx
+++ b/web-next/components/models/models-viewer-sections.tsx
@@ -164,7 +164,7 @@ export function SearchSection({
                                         { value: "huggingface", label: "HuggingFace" },
                                         { value: "ollama", label: "Ollama" },
                                     ]}
-                                    onChange={(val) => setSearchProvider(val as "huggingface" | "ollama")}
+                                    onChange={(val) => setSearchProvider(val === "ollama" ? "ollama" : "huggingface")}
                                     className="w-full sm:w-[160px]"
                                     buttonClassName="w-full justify-between rounded-full border border-[color:var(--ui-border)] bg-[color:var(--ui-surface)] px-4 py-2 text-xs text-[color:var(--text-primary)] hover:border-[color:var(--ui-border-strong)] hover:bg-[color:var(--ui-surface-hover)]"
                                     renderButton={(opt) => <span className="flex-1 truncate text-left text-[color:var(--text-primary)] uppercase tracking-wider text-[10px]">{opt?.label ?? "Provider"}</span>}

--- a/web-next/components/workflow-control/PropertyPanel.tsx
+++ b/web-next/components/workflow-control/PropertyPanel.tsx
@@ -51,7 +51,6 @@ interface PropertyPanelProps {
 type RuntimeService = string | { name?: string; id?: string; [key: string]: unknown };
 type WorkflowNodeType = "decision" | "intent" | "kernel" | "runtime" | "provider" | "embedding" | "config";
 type SourceType = "local" | "cloud";
-type SourceTypeLike = SourceType | "installed_local" | "installed-local";
 
 type NodeVisualMeta = {
   icon: LucideIcon;
@@ -141,6 +140,10 @@ function resolveAvailableOptions(
       DEFAULT_OPTIONS.embeddingProviders,
     ) as ResolvedAvailableOptions["embeddingProviders"],
   };
+}
+
+function readStringField(value: unknown): string {
+  return typeof value === "string" ? value : "";
 }
 
 const NODE_VISUALS: Record<WorkflowNodeType, NodeVisualMeta> = {
@@ -246,7 +249,7 @@ function isWorkflowNodeType(value: string | undefined): value is WorkflowNodeTyp
   return value === "decision" || value === "intent" || value === "kernel" || value === "runtime" || value === "provider" || value === "embedding" || value === "config";
 }
 
-function normalizeSourceType(value: SourceTypeLike | undefined): SourceType {
+function normalizeSourceType(value: string | undefined): SourceType {
   if (!value) return "local";
   const normalized = value.trim().toLowerCase();
   if (normalized === "cloud") return "cloud";
@@ -376,7 +379,7 @@ function DecisionEditor({
 }>) {
   const strategyOptions = withCurrentOption(
     options.strategies,
-    data.strategy as string | undefined
+    readStringField(data.strategy)
   );
   return (
     <SectionCard
@@ -387,7 +390,7 @@ function DecisionEditor({
     >
       <OptionRail
         label={t("workflowControl.labels.stepAlternatives")}
-        value={(data.strategy as string) ?? ""}
+        value={readStringField(data.strategy)}
         options={strategyOptions}
         onChange={(val) => onUpdate("strategy", val)}
         renderOption={(opt) => translateOption(t, `workflowControl.strategies.${opt}`, opt)}
@@ -396,7 +399,7 @@ function DecisionEditor({
       <Label htmlFor="strategy" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-2.5 block px-0.5">
         {t("workflowControl.labels.stepConfiguration")}
       </Label>
-      <Select value={(data.strategy as string) ?? ""} onValueChange={(val) => onUpdate("strategy", val)}>
+      <Select value={readStringField(data.strategy)} onValueChange={(val) => onUpdate("strategy", val)}>
         <SelectTrigger id="strategy" className={SELECT_TRIGGER_BASE}>
           <SelectValue />
         </SelectTrigger>
@@ -427,9 +430,9 @@ function IntentEditor({
     typeof data.embeddingModel === "string" && data.embeddingModel.trim().length > 0;
   const intentModeOptions = withCurrentOption(
     getCompatibleIntentModes(options, hasEmbedding),
-    data.intentMode as string | undefined
+    readStringField(data.intentMode)
   );
-  const currentIntentMode = data.intentMode as string | undefined;
+  const currentIntentMode = readStringField(data.intentMode);
   const requiresEmbedding = Boolean(
     currentIntentMode && options.intentRequirements[currentIntentMode]?.requires_embedding,
   );
@@ -442,7 +445,7 @@ function IntentEditor({
     >
       <OptionRail
         label={t("workflowControl.labels.stepAlternatives")}
-        value={(data.intentMode as string) ?? ""}
+        value={readStringField(data.intentMode)}
         options={intentModeOptions}
         onChange={(val) => onUpdate("intentMode", val)}
         renderOption={(opt) => translateOption(t, `workflowControl.intentModes.${opt}`, opt)}
@@ -451,7 +454,7 @@ function IntentEditor({
       <Label htmlFor="intentMode" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-2.5 block px-0.5">
         {t("workflowControl.labels.stepConfiguration")}
       </Label>
-      <Select value={(data.intentMode as string) ?? ""} onValueChange={(val) => onUpdate("intentMode", val)}>
+      <Select value={readStringField(data.intentMode)} onValueChange={(val) => onUpdate("intentMode", val)}>
         <SelectTrigger id="intentMode" className={SELECT_TRIGGER_BASE}>
           <SelectValue />
         </SelectTrigger>
@@ -486,7 +489,7 @@ function KernelEditor({
   const compatibleKernels = getCompatibleKernels(options, workflowRuntime);
   const kernelOptions = withCurrentOption(
     compatibleKernels,
-    data.kernel as string | undefined,
+    readStringField(data.kernel) || undefined,
   );
   const hadCompatibilityFilter =
     Boolean(workflowRuntime) && compatibleKernels.length < options.kernels.length;
@@ -499,7 +502,7 @@ function KernelEditor({
     >
       <OptionRail
         label={t("workflowControl.labels.stepAlternatives")}
-        value={(data.kernel as string) ?? ""}
+        value={readStringField(data.kernel)}
         options={kernelOptions}
         onChange={(val) => onUpdate("kernel", val)}
         renderOption={(opt) => translateOption(t, `workflowControl.kernelTypes.${opt}`, opt)}
@@ -508,7 +511,7 @@ function KernelEditor({
       <Label htmlFor="kernel" className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-2.5 block px-0.5">
         {t("workflowControl.labels.stepConfiguration")}
       </Label>
-      <Select value={(data.kernel as string) ?? ""} onValueChange={(val) => onUpdate("kernel", val)}>
+      <Select value={readStringField(data.kernel)} onValueChange={(val) => onUpdate("kernel", val)}>
         <SelectTrigger id="kernel" className={SELECT_TRIGGER_BASE}>
           <SelectValue />
         </SelectTrigger>
@@ -572,12 +575,12 @@ function ProviderEditor({
   onUpdate: (key: string, value: unknown) => void;
   t: (path: string) => string;
 }>) {
-  const provider = (data.provider as { active?: string; sourceType?: SourceTypeLike } | undefined) ?? {};
+  const provider = (data.provider as { active?: string; sourceType?: string } | undefined) ?? {};
   const activeEmbeddingModel =
     typeof data.embeddingModel === "string" ? data.embeddingModel : "";
   const providerBySource = options.providersBySource ?? DEFAULT_OPTIONS.providersBySource;
-  const nodeSourceType = data.sourceType as SourceTypeLike | undefined;
-  const nodeSourceTag = data.sourceTag as SourceTypeLike | undefined;
+  const nodeSourceType = readStringField(data.sourceType);
+  const nodeSourceTag = readStringField(data.sourceTag);
   const inferSource = (value: string | undefined): SourceType => {
     if (value && providerBySource.cloud.includes(value)) return "cloud";
     return "local";
@@ -615,7 +618,7 @@ function ProviderEditor({
         value={sourceType}
         options={["local", "cloud"]}
         onChange={(val) => {
-          const nextSource = normalizeSourceType(val as SourceTypeLike);
+          const nextSource = normalizeSourceType(val);
           const nextProviders = providerBySource[nextSource];
           const nextActive = provider.active && nextProviders.includes(provider.active) ? provider.active : "";
           onUpdate("provider", { active: nextActive, sourceType: nextSource });
@@ -633,7 +636,7 @@ function ProviderEditor({
       <Select
         value={sourceType}
         onValueChange={(val) => {
-          const nextSource = normalizeSourceType(val as SourceTypeLike);
+          const nextSource = normalizeSourceType(val);
           const nextProviders = providerBySource[nextSource];
           const nextActive = provider.active && nextProviders.includes(provider.active) ? provider.active : "";
           onUpdate("provider", { active: nextActive, sourceType: nextSource });
@@ -700,19 +703,19 @@ function EmbeddingEditor({
   const modelsBySource = options.modelsBySource ?? DEFAULT_OPTIONS.modelsBySource;
   const activeProvider =
     typeof data.providerActive === "string" ? data.providerActive : "";
-  const nodeSourceTag = data.sourceTag as SourceTypeLike | undefined;
+  const nodeSourceTag = readStringField(data.sourceTag);
   const inferSource = (value: string | undefined): SourceType => {
     if (value && modelsBySource.cloud.includes(value)) return "cloud";
     return "local";
   };
-  const dataSourceType = data.sourceType as SourceTypeLike | undefined;
+  const dataSourceType = readStringField(data.sourceType);
   let sourceType: SourceType;
   if (dataSourceType) {
     sourceType = normalizeSourceType(dataSourceType);
   } else if (nodeSourceTag) {
     sourceType = normalizeSourceType(nodeSourceTag);
   } else {
-    sourceType = inferSource(data.model as string | undefined);
+    sourceType = inferSource(readStringField(data.model));
   }
   const compatibleEmbeddings = getCompatibleEmbeddings(
     options,
@@ -721,9 +724,9 @@ function EmbeddingEditor({
   );
   const sourceModels = withCurrentOption(
     compatibleEmbeddings,
-    data.model as string | undefined,
+    readStringField(data.model),
   );
-  const safeModel = (data.model as string | undefined) ?? "";
+  const safeModel = readStringField(data.model);
   const hadCompatibilityFilter =
     Boolean(activeProvider) &&
     compatibleEmbeddings.length < (modelsBySource[sourceType] ?? []).length;
@@ -740,9 +743,9 @@ function EmbeddingEditor({
         value={sourceType}
         options={["local", "cloud"]}
         onChange={(val) => {
-          const nextSource = normalizeSourceType(val as SourceTypeLike);
+          const nextSource = normalizeSourceType(val);
           const nextModels = modelsBySource[nextSource];
-          const currentModel = data.model as string | undefined;
+          const currentModel = readStringField(data.model);
           let nextModel = "";
           if (currentModel && nextModels.includes(currentModel)) {
             nextModel = currentModel;
@@ -763,9 +766,9 @@ function EmbeddingEditor({
       <Select
         value={sourceType}
         onValueChange={(val) => {
-          const nextSource = normalizeSourceType(val as SourceTypeLike);
+          const nextSource = normalizeSourceType(val);
           const nextModels = modelsBySource[nextSource];
-          const currentModel = data.model as string | undefined;
+          const currentModel = readStringField(data.model);
           let nextModel = "";
           if (currentModel && nextModels.includes(currentModel)) {
             nextModel = currentModel;

--- a/web-next/hooks/use-api.ts
+++ b/web-next/hooks/use-api.ts
@@ -93,7 +93,6 @@ const OFFLINE_BACKOFF_MS = 15000;
 function ensureEntry<T>(key: string, fetcher: () => Promise<T>, interval: number): PollingEntry<T> {
   const existing = pollingRegistry.get(key);
   if (existing) {
-    // Type assertion safe here because we control the registry
     const typedExisting = existing as PollingEntry<T>;
     typedExisting.fetcher = fetcher;
     if (interval > 0 && interval < typedExisting.interval) {
@@ -360,14 +359,14 @@ export function useServiceStatus(intervalMs = 15000) {
   return usePolling<ServiceStatus[]>(
     "services",
     async () => {
-      const data = await apiFetch<{ services?: ServiceStatus[]; status?: string }>(
+      const data = await apiFetch<ServiceStatus[] | { services?: ServiceStatus[]; status?: string }>(
         "/api/v1/system/services",
       );
       if (Array.isArray(data?.services)) {
         return data.services;
       }
-      if (Array.isArray((data as unknown) as ServiceStatus[])) {
-        return (data as unknown) as ServiceStatus[];
+      if (Array.isArray(data)) {
+        return data;
       }
       return [];
     },

--- a/web-next/hooks/use-benchmark.ts
+++ b/web-next/hooks/use-benchmark.ts
@@ -33,8 +33,8 @@ interface UseBenchmarkReturn {
 export function useBenchmark(): UseBenchmarkReturn {
     const t = useTranslation();
     const translatePreflight = useCallback(
-        (path: string, replacements?: Record<string, unknown>) =>
-            t(path, replacements as Record<string, string | number> | undefined),
+        (path: string, replacements?: Record<string, string | number>) =>
+            t(path, replacements),
         [t],
     );
     const [status, setStatus] = useState<BenchmarkStatus>("idle");

--- a/web-next/hooks/use-coding-benchmark.ts
+++ b/web-next/hooks/use-coding-benchmark.ts
@@ -61,8 +61,8 @@ interface UseCodingBenchmarkReturn {
 export function useCodingBenchmark(): UseCodingBenchmarkReturn {
   const t = useTranslation();
   const translatePreflight = useCallback(
-    (path: string, replacements?: Record<string, unknown>) =>
-      t(path, replacements as Record<string, string | number> | undefined),
+    (path: string, replacements?: Record<string, string | number>) =>
+      t(path, replacements),
     [t],
   );
   const [status, setStatus] = useState<CodingBenchmarkStatus>("idle");

--- a/web-next/hooks/use-task-stream.ts
+++ b/web-next/hooks/use-task-stream.ts
@@ -73,7 +73,11 @@ const defaultState: TaskStreamState = {
   contextUsed: null,
 };
 
-const TERMINAL_STATUSES = new Set<TaskStatus>(["COMPLETED", "FAILED", "LOST"]);
+const TERMINAL_STATUSES = new Set(["COMPLETED", "FAILED", "LOST"]);
+
+function isTerminalStatus(status: string): status is TaskStatus {
+  return TERMINAL_STATUSES.has(status);
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -123,8 +127,8 @@ function normalizeStatus(status: unknown): TaskStatus | null {
     return null;
   }
   const s = String(status).toUpperCase();
-  if (TERMINAL_STATUSES.has(s as TaskStatus)) return s as TaskStatus;
-  if (s === "PENDING" || s === "PROCESSING") return s as TaskStatus;
+  if (isTerminalStatus(s)) return s;
+  if (s === "PENDING" || s === "PROCESSING") return s;
   return null;
 }
 

--- a/web-next/hooks/useWorkflowState.ts
+++ b/web-next/hooks/useWorkflowState.ts
@@ -103,10 +103,10 @@ function readCache<T>(key: string): T | null {
   try {
     const raw = globalThis.window.sessionStorage.getItem(key);
     if (!raw) return null;
-    const parsed = JSON.parse(raw) as { ts?: number; data?: T };
+    const parsed: { ts?: number; data?: T } = JSON.parse(raw);
     if (!parsed || typeof parsed !== "object" || typeof parsed.ts !== "number") return null;
     if (Date.now() - parsed.ts > WORKFLOW_CACHE_TTL_MS) return null;
-    return (parsed.data ?? null) as T | null;
+    return parsed.data ?? null;
   } catch {
     return null;
   }
@@ -138,7 +138,7 @@ export function useWorkflowState() {
       if (!response.ok) {
         throw new Error(await readApiErrorMessage(response, t("workflowControl.error")));
       }
-      const data = (await response.json()) as WorkflowControlOptions;
+      const data: WorkflowControlOptions = await response.json();
       setControlOptions((prev) => {
         if (prev && stableSerialize(prev) === stableSerialize(data)) return prev;
         return data;

--- a/web-next/lib/academy-api.ts
+++ b/web-next/lib/academy-api.ts
@@ -587,9 +587,9 @@ function extractErrorMessage(value: unknown): string | null {
 
 function parseErrorBody(text: string): ParsedErrorBody | null {
   try {
-    const parsed = JSON.parse(text) as unknown;
+    const parsed: ParsedErrorBody = JSON.parse(text);
     if (!parsed || typeof parsed !== "object") return null;
-    return parsed as ParsedErrorBody;
+    return parsed;
   } catch {
     return null;
   }
@@ -624,14 +624,20 @@ function resolveApiErrorMessage(error: ApiError): string {
 
 function parseApiErrorPayload(error: ApiError): ParsedErrorBody | null {
   if (!error.data || typeof error.data !== "object") return null;
-  return error.data as ParsedErrorBody;
+  return error.data;
+}
+
+function isStructuredAcademyErrorDetail(
+  detail: unknown,
+): detail is StructuredAcademyErrorDetail {
+  return Boolean(detail && typeof detail === "object" && !Array.isArray(detail));
 }
 
 function resolveStructuredAcademyErrorMessage(body: ParsedErrorBody): string | null {
-  if (!body.detail || typeof body.detail !== "object" || Array.isArray(body.detail)) {
+  if (!isStructuredAcademyErrorDetail(body.detail)) {
     return null;
   }
-  return formatStructuredAcademyErrorDetail(body.detail as StructuredAcademyErrorDetail);
+  return formatStructuredAcademyErrorDetail(body.detail);
 }
 
 /**

--- a/web-next/lib/i18n/index.tsx
+++ b/web-next/lib/i18n/index.tsx
@@ -72,7 +72,7 @@ function resolvePreferredLanguage(): LanguageCode {
   }
   const browser = globalThis.window.navigator.language?.slice(0, 2).toLowerCase();
   if (browser === "en" || browser === "de") {
-    return browser as LanguageCode;
+    return browser;
   }
   return "pl";
 }


### PR DESCRIPTION
## What changed
- Replaced chained `startswith`/`endswith` checks with tuple-based calls in backend helpers.
- Simplified the intent/model selection logic in `intent_manager` and `model_manager` typing.
- Removed unnecessary type assertions across the `web-next` cockpit, config, workflow, academy, and i18n components/hooks.
- Fixed the remaining lint issues in `use-api`, `use-cockpit-logic`, and `PropertyPanel` that surfaced after the refactor.

## Why
- Sonar was flagging maintainability, typing, and pythonic-style issues across the main branch.
- The changes are mechanical and low-risk, aimed at getting the hotfix cleanly through lint and tests.

## Validation
- `python3 -m compileall` on the touched backend modules
- `.venv/bin/pytest -q tests/test_multi_runtime_profile_service.py`
- `cd web-next && npx eslint` on the touched frontend files
