### PR TITLE
feat(runtime): PR 220A — runtime lifecycle manager, RuntimeCapabilities, central switch orchestrator

### DIFF
--- a/config/pytest-groups/fast.txt
+++ b/config/pytest-groups/fast.txt
@@ -18,6 +18,7 @@ tests/test_217b_api_multi_runtime_profile.py
 tests/test_217b_daemon_profile_endpoints.py
 tests/test_217da_multi_runtime_pipeline_basics.py
 tests/test_217dc_pipeline_completion.py
+tests/test_220a_runtime_lifecycle.py
 tests/test_academy_202c_signing_coverage.py
 tests/test_academy_202d_lora_onnx_deploy.py
 tests/test_academy_adapter_runtime_service.py
@@ -342,6 +343,7 @@ tests/test_runtime_provider_ops.py
 tests/test_runtime_registry_contracts.py
 tests/test_runtime_registry_translation_contracts.py
 tests/test_runtime_service_helpers.py
+tests/test_runtime_switch_service_branches.py
 tests/test_scenario_weaver.py
 tests/test_scheduler.py
 tests/test_scheduler_swarm_flow_streaming.py

--- a/config/pytest-groups/sonar-new-code.txt
+++ b/config/pytest-groups/sonar-new-code.txt
@@ -10,6 +10,7 @@ tests/test_217b_api_multi_runtime_profile.py
 tests/test_217b_daemon_profile_endpoints.py
 tests/test_217da_multi_runtime_pipeline_basics.py
 tests/test_217dc_pipeline_completion.py
+tests/test_220a_runtime_lifecycle.py
 tests/test_academy_202c_signing_coverage.py
 tests/test_academy_202d_lora_onnx_deploy.py
 tests/test_academy_adapter_runtime_service.py

--- a/config/pytest-groups/sonar-new-code.txt
+++ b/config/pytest-groups/sonar-new-code.txt
@@ -229,6 +229,7 @@ tests/test_runtime_policy_regression_contracts.py
 tests/test_runtime_registry_contracts.py
 tests/test_runtime_registry_translation_contracts.py
 tests/test_runtime_service_helpers.py
+tests/test_runtime_switch_service_branches.py
 tests/test_scheduler.py
 tests/test_scheduler_swarm_flow_streaming.py
 tests/test_service_monitor.py

--- a/config/testing/test_catalog.json
+++ b/config/testing/test_catalog.json
@@ -395,6 +395,20 @@
       "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
     },
     {
+      "path": "tests/test_220a_runtime_lifecycle.py",
+      "domain": "runtime",
+      "test_type": "route_contract",
+      "intent": "contract",
+      "primary_lane": "new-code",
+      "allowed_lanes": [
+        "new-code",
+        "ci-lite",
+        "release"
+      ],
+      "legacy_targeted": false,
+      "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
+    },
+    {
       "path": "tests/test_academy_202c_signing_coverage.py",
       "domain": "academy",
       "test_type": "route_contract",
@@ -3248,19 +3262,6 @@
       "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
     },
     {
-      "path": "tests/test_220a_runtime_lifecycle.py",
-      "domain": "runtime",
-      "test_type": "integration",
-      "intent": "regression",
-      "primary_lane": "new-code",
-      "allowed_lanes": [
-        "new-code",
-        "ci-lite"
-      ],
-      "legacy_targeted": false,
-      "rationale": "PR 220A lifecycle regression: switch flow, health-check timeout, drift detection, ONNX cleanup."
-    },
-    {
       "path": "tests/test_llm_server_selection.py",
       "domain": "runtime",
       "test_type": "route_contract",
@@ -5061,6 +5062,20 @@
       ],
       "legacy_targeted": false,
       "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
+    },
+    {
+      "path": "tests/test_runtime_switch_service_branches.py",
+      "domain": "runtime",
+      "test_type": "service_contract",
+      "intent": "contract",
+      "primary_lane": "new-code",
+      "allowed_lanes": [
+        "ci-lite",
+        "new-code",
+        "release"
+      ],
+      "legacy_targeted": false,
+      "rationale": "Nowy test gałęzi runtime switch dla bramki new-code i CI-lite."
     },
     {
       "path": "tests/test_scenario_weaver.py",

--- a/config/testing/test_catalog.json
+++ b/config/testing/test_catalog.json
@@ -3248,6 +3248,19 @@
       "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
     },
     {
+      "path": "tests/test_220a_runtime_lifecycle.py",
+      "domain": "runtime",
+      "test_type": "integration",
+      "intent": "regression",
+      "primary_lane": "new-code",
+      "allowed_lanes": [
+        "new-code",
+        "ci-lite"
+      ],
+      "legacy_targeted": false,
+      "rationale": "PR 220A lifecycle regression: switch flow, health-check timeout, drift detection, ONNX cleanup."
+    },
+    {
       "path": "tests/test_llm_server_selection.py",
       "domain": "runtime",
       "test_type": "route_contract",

--- a/scripts/llm/multi_runtime_service.sh
+++ b/scripts/llm/multi_runtime_service.sh
@@ -178,8 +178,7 @@ start() {
 stop() {
   if [[ "$USE_SYSTEMD" == "true" ]]; then
     echo "Stopping systemd unit ${SYSTEMD_UNIT}"
-    "$SYSTEMCTL_BIN" "${SYSTEMD_SCOPE_ARGS[@]}" stop "$SYSTEMD_UNIT"
-    return 0
+    "$SYSTEMCTL_BIN" "${SYSTEMD_SCOPE_ARGS[@]}" stop "$SYSTEMD_UNIT" || true
   fi
 
   if [[ -f "$PID_FILE" ]]; then
@@ -207,6 +206,8 @@ stop() {
 
   # Cleanup stray processes
   pkill -f "services.multi_runtime" 2>/dev/null || true
+  sleep 1
+  pkill -9 -f "services.multi_runtime" 2>/dev/null || true
 
   echo "Multi-Runtime stopped"
   return 0

--- a/scripts/llm/multi_runtime_service.sh
+++ b/scripts/llm/multi_runtime_service.sh
@@ -57,6 +57,25 @@ except Exception:
     print("unknown")'
 }
 
+_kill_multi_runtime_strays() {
+  local pids pid
+  pids="$(pgrep -f "python -m services.multi_runtime.main" || true)"
+  for pid in $pids; do
+    if [[ "$pid" == "$$" || "$pid" == "$PPID" ]]; then
+      continue
+    fi
+    kill "$pid" 2>/dev/null || true
+  done
+  sleep 1
+  pids="$(pgrep -f "python -m services.multi_runtime.main" || true)"
+  for pid in $pids; do
+    if [[ "$pid" == "$$" || "$pid" == "$PPID" ]]; then
+      continue
+    fi
+    kill -9 "$pid" 2>/dev/null || true
+  done
+}
+
 is_ready() {
   [[ "$(health_status)" == "ok" ]]
 }
@@ -204,10 +223,8 @@ stop() {
     rm -f "$PID_FILE"
   fi
 
-  # Cleanup stray processes
-  pkill -f "services.multi_runtime" 2>/dev/null || true
-  sleep 1
-  pkill -9 -f "services.multi_runtime" 2>/dev/null || true
+  # Cleanup stray daemon processes with explicit PID filtering.
+  _kill_multi_runtime_strays
 
   echo "Multi-Runtime stopped"
   return 0

--- a/scripts/llm/ollama_service.sh
+++ b/scripts/llm/ollama_service.sh
@@ -89,8 +89,7 @@ start() {
 stop() {
   if [[ "$USE_SYSTEMD" == "true" ]]; then
     echo "Zatrzymuję usługę systemd ${SYSTEMD_UNIT}"
-    "$SYSTEMCTL_BIN" "${SYSTEMD_SCOPE_ARGS[@]}" stop "$SYSTEMD_UNIT"
-    return 0
+    "$SYSTEMCTL_BIN" "${SYSTEMD_SCOPE_ARGS[@]}" stop "$SYSTEMD_UNIT" || true
   fi
 
   # Explicitly unload model if Ollama is still running (e.g. managed externally)
@@ -121,6 +120,8 @@ stop() {
 
   # Graceful cleanup zombie processes
   pkill -f "ollama serve" 2>/dev/null || true
+  sleep 1
+  pkill -9 -f "ollama serve" 2>/dev/null || true
 
   echo "Ollama zatrzymana"
   return 0

--- a/scripts/llm/ollama_service.sh
+++ b/scripts/llm/ollama_service.sh
@@ -39,6 +39,25 @@ is_systemd_active() {
     "$SYSTEMCTL_BIN" "${SYSTEMD_SCOPE_ARGS[@]}" is-active --quiet "$SYSTEMD_UNIT"
 }
 
+_kill_ollama_strays() {
+  local pids pid
+  pids="$(pgrep -f "ollama serve" || true)"
+  for pid in $pids; do
+    if [[ "$pid" == "$$" || "$pid" == "$PPID" ]]; then
+      continue
+    fi
+    kill "$pid" 2>/dev/null || true
+  done
+  sleep 1
+  pids="$(pgrep -f "ollama serve" || true)"
+  for pid in $pids; do
+    if [[ "$pid" == "$$" || "$pid" == "$PPID" ]]; then
+      continue
+    fi
+    kill -9 "$pid" 2>/dev/null || true
+  done
+}
+
 start() {
   echo "🧭 Ollama config: base_url=${OLLAMA_BASE_URL}, health_url=${HEALTH_URL}, env_file=${ENV_FILE}"
 
@@ -118,10 +137,8 @@ stop() {
     rm -f "$PID_FILE"
   fi
 
-  # Graceful cleanup zombie processes
-  pkill -f "ollama serve" 2>/dev/null || true
-  sleep 1
-  pkill -9 -f "ollama serve" 2>/dev/null || true
+  # Cleanup stray daemon processes with explicit PID filtering.
+  _kill_ollama_strays
 
   echo "Ollama zatrzymana"
   return 0

--- a/tests/test_220a_runtime_lifecycle.py
+++ b/tests/test_220a_runtime_lifecycle.py
@@ -18,6 +18,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from fastapi import HTTPException
 
 from venom_core.api.routes import system_llm as system_routes
 from venom_core.config import SETTINGS
@@ -422,8 +423,6 @@ async def test_health_check_timeout_prevents_config_write(monkeypatch):
     SETTINGS.ACTIVE_LLM_SERVER = "ollama"
     SETTINGS.LLM_MODEL_NAME = "phi3:mini"
     try:
-        from fastapi import HTTPException
-
         with pytest.raises(HTTPException) as exc_info:
             await system_routes.set_active_llm_server(
                 system_routes.ActiveLlmServerRequest(server_name="multi_runtime")

--- a/tests/test_220a_runtime_lifecycle.py
+++ b/tests/test_220a_runtime_lifecycle.py
@@ -1,0 +1,595 @@
+"""PR 220A regression tests — runtime lifecycle management.
+
+Covers:
+1. ollama → multi_runtime switch releases previous stack and starts new
+2. multi_runtime → ollama switch clears endpoint/cache
+3. Health-check timeout leaves no partial config state
+4. ONNX cleanup is best-effort and doesn't break the switch flow
+5. RuntimeCapabilities contract is consistent with list_servers()
+6. LifecycleSwitchState tracks switch progress correctly
+7. detect_runtime_drift reports issues when config is inconsistent
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from venom_core.api.routes import system_llm as system_routes
+from venom_core.config import SETTINGS
+from venom_core.core.llm_server_controller import (
+    LlmServerController,
+    RuntimeCapabilities,
+)
+from venom_core.services import runtime_switch_service
+from venom_core.services.runtime_switch_service import RuntimeSwitchOrchestrator
+from venom_core.utils.llm_runtime import (
+    LifecycleStep,
+    LifecycleSwitchState,
+    detect_runtime_drift,
+)
+
+OLLAMA_ENDPOINT = "http://localhost:11434"
+MULTI_ENDPOINT = "http://localhost:8014"
+
+
+class _DummyController:
+    def __init__(self, servers):
+        self._servers = servers
+        self.actions: list[tuple[str, str]] = []
+        self.fail_actions: set[tuple[str, str]] = set()
+
+    def has_server(self, name):
+        return any(s["name"] == name for s in self._servers)
+
+    def list_servers(self):
+        return self._servers
+
+    def get_capabilities(self, name):
+        for s in self._servers:
+            if s["name"] == name:
+                caps = s.get("capabilities", {})
+                return RuntimeCapabilities(
+                    **{
+                        "supports_stop": caps.get("supports_stop", False),
+                        "supports_start": caps.get("supports_start", False),
+                        "supports_restart": caps.get("supports_restart", False),
+                        "supports_health_wait": caps.get("supports_health_wait", False),
+                        "supports_cache_flush": caps.get("supports_cache_flush", False),
+                        "supports_model_unload": caps.get(
+                            "supports_model_unload", False
+                        ),
+                        "is_in_process": caps.get("is_in_process", False),
+                        "release_wait_seconds": caps.get("release_wait_seconds", 0),
+                    }
+                )
+        raise ValueError(f"unknown: {name}")
+
+    async def run_action(self, name, action):
+        await asyncio.sleep(0)
+        self.actions.append((name, action))
+        if (name, action) in self.fail_actions:
+            return SimpleNamespace(ok=False, exit_code=1)
+        return SimpleNamespace(ok=True, exit_code=0)
+
+
+class _DummyModelManager:
+    def __init__(self, models):
+        self._models = models
+
+    async def list_local_models(self):
+        await asyncio.sleep(0)
+        return self._models
+
+
+def _make_server(
+    name: str,
+    *,
+    health_url: str = "",
+    endpoint: str = "",
+    supports_stop: bool = True,
+    supports_start: bool = True,
+    supports_health_wait: bool = False,
+    supports_model_unload: bool = False,
+    is_in_process: bool = False,
+    release_wait_seconds: int = 0,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "supports": {"stop": supports_stop, "start": supports_start},
+        "endpoint": endpoint,
+        "health_url": health_url,
+        "capabilities": {
+            "supports_stop": supports_stop,
+            "supports_start": supports_start,
+            "supports_restart": supports_stop,
+            "supports_health_wait": supports_health_wait,
+            "supports_cache_flush": is_in_process,
+            "supports_model_unload": supports_model_unload,
+            "is_in_process": is_in_process,
+            "release_wait_seconds": release_wait_seconds,
+        },
+    }
+
+
+def _snapshot_settings():
+    return {
+        "service_type": SETTINGS.LLM_SERVICE_TYPE,
+        "endpoint": SETTINGS.LLM_LOCAL_ENDPOINT,
+        "model": SETTINGS.LLM_MODEL_NAME,
+        "active": SETTINGS.ACTIVE_LLM_SERVER,
+        "runtime_profile": SETTINGS.VENOM_RUNTIME_PROFILE,
+        "config_hash": getattr(SETTINGS, "LLM_CONFIG_HASH", None),
+        "onnx_enabled": getattr(SETTINGS, "ONNX_LLM_ENABLED", False),
+    }
+
+
+def _restore_settings(snapshot):
+    SETTINGS.LLM_SERVICE_TYPE = snapshot["service_type"]
+    SETTINGS.LLM_LOCAL_ENDPOINT = snapshot["endpoint"]
+    SETTINGS.LLM_MODEL_NAME = snapshot["model"]
+    SETTINGS.ACTIVE_LLM_SERVER = snapshot["active"]
+    SETTINGS.VENOM_RUNTIME_PROFILE = snapshot["runtime_profile"]
+    SETTINGS.ONNX_LLM_ENABLED = snapshot["onnx_enabled"]
+    if snapshot["config_hash"] is not None:
+        SETTINGS.LLM_CONFIG_HASH = snapshot["config_hash"]
+
+
+@pytest.fixture(autouse=True)
+def _no_real_network(monkeypatch):
+    """Prevent real network calls from the orchestrator in all tests."""
+
+    async def _fake_shutdown(_server_name, _health_url):
+        return True
+
+    async def _fake_health(_server_name, _health_url):
+        return True
+
+    monkeypatch.setattr(runtime_switch_service, "probe_until_shutdown", _fake_shutdown)
+    monkeypatch.setattr(runtime_switch_service, "probe_health_ready", _fake_health)
+    monkeypatch.setattr(system_routes, "_await_server_shutdown", _fake_shutdown)
+    monkeypatch.setattr(system_routes, "_await_server_health", _fake_health)
+
+
+# ---------------------------------------------------------------------------
+# 1. RuntimeCapabilities contract
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_capabilities_fields_for_all_servers():
+    """Every server config exposes all RuntimeCapabilities fields."""
+    ctrl = LlmServerController(SETTINGS)
+    for server in ctrl.list_servers():
+        caps = server["capabilities"]
+        for field in [
+            "supports_stop",
+            "supports_start",
+            "supports_restart",
+            "supports_health_wait",
+            "supports_cache_flush",
+            "supports_model_unload",
+            "is_in_process",
+            "release_wait_seconds",
+        ]:
+            assert field in caps, f"{server['name']} missing capability field '{field}'"
+
+
+def test_onnx_capabilities_are_in_process():
+    ctrl = LlmServerController(SETTINGS)
+    caps = ctrl.get_capabilities("onnx")
+    assert caps.is_in_process is True
+    assert caps.supports_stop is False
+    assert caps.supports_cache_flush is True
+    assert caps.supports_model_unload is True
+
+
+def test_ollama_capabilities_support_unload():
+    ctrl = LlmServerController(SETTINGS)
+    caps = ctrl.get_capabilities("ollama")
+    assert caps.supports_model_unload is True
+    assert caps.is_in_process is False
+    assert caps.release_wait_seconds > 0
+
+
+def test_multi_runtime_capabilities():
+    ctrl = LlmServerController(SETTINGS)
+    caps = ctrl.get_capabilities("multi_runtime")
+    assert caps.supports_stop is True
+    assert caps.supports_health_wait is True
+    assert caps.is_in_process is False
+
+
+# ---------------------------------------------------------------------------
+# 2. LifecycleSwitchState tracking
+# ---------------------------------------------------------------------------
+
+
+def test_lifecycle_switch_state_tracks_progress():
+    state = LifecycleSwitchState(from_server="ollama", to_server="multi_runtime")
+    assert not state.is_complete
+    assert not state.is_in_partial_state
+
+    state.mark_done(LifecycleStep.PROCESS_STOPPED)
+    state.mark_done(LifecycleStep.RELEASE_DONE)
+    assert not state.is_complete
+
+    state.mark_done(LifecycleStep.CACHE_INVALIDATED)
+    state.mark_done(LifecycleStep.START_DONE)
+    state.mark_done(LifecycleStep.HEALTH_READY)
+    state.mark_done(LifecycleStep.ENDPOINT_SWITCHED)
+    state.mark_done(LifecycleStep.CONFIG_SAVED)
+    assert state.is_complete
+    assert not state.is_in_partial_state
+
+
+def test_lifecycle_switch_state_failed_step_is_partial():
+    state = LifecycleSwitchState(from_server="ollama", to_server="vllm")
+    state.mark_done(LifecycleStep.PROCESS_STOPPED)
+    state.mark_failed(LifecycleStep.HEALTH_READY, "timeout")
+    assert state.is_in_partial_state
+    assert not state.is_complete
+    assert state.failed_step == LifecycleStep.HEALTH_READY
+
+
+def test_lifecycle_switch_state_payload():
+    state = LifecycleSwitchState(from_server="a", to_server="b")
+    state.mark_done(LifecycleStep.PROCESS_STOPPED)
+    payload = state.to_payload()
+    assert payload["from_server"] == "a"
+    assert payload["to_server"] == "b"
+    assert "process_stopped" in payload["completed_steps"]
+    assert payload["failed_step"] is None
+    assert payload["is_complete"] is False
+
+
+# ---------------------------------------------------------------------------
+# 3. ollama → multi_runtime switch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ollama_to_multi_runtime_stops_ollama_starts_multi(monkeypatch):
+    """Switching from ollama to multi_runtime stops ollama and starts multi_runtime."""
+    servers = [
+        _make_server(
+            "ollama", endpoint=OLLAMA_ENDPOINT, health_url=f"{OLLAMA_ENDPOINT}/api/tags"
+        ),
+        _make_server(
+            "multi_runtime",
+            endpoint=MULTI_ENDPOINT,
+            health_url=f"{MULTI_ENDPOINT}/health",
+        ),
+    ]
+    controller = _DummyController(servers)
+    updates: dict = {}
+    monkeypatch.setattr(system_routes.system_deps, "_llm_controller", controller)
+    monkeypatch.setattr(
+        system_routes.system_deps,
+        "_model_manager",
+        _DummyModelManager([{"name": "gemma2:2b", "provider": "multi_runtime"}]),
+    )
+    monkeypatch.setattr(system_routes.system_deps, "_request_tracer", None)
+    monkeypatch.setattr(
+        system_routes, "_installed_local_servers", lambda: {"ollama", "multi_runtime"}
+    )
+    monkeypatch.setattr(
+        system_routes.config_manager,
+        "get_config",
+        lambda **_: {
+            "LAST_MODEL_GEMMA4_AUDIO": "gemma2:2b",
+        },
+    )
+    monkeypatch.setattr(
+        system_routes.config_manager, "update_config", lambda u: updates.update(u)
+    )
+    monkeypatch.setattr(system_routes, "_release_onnx_runtime_caches", lambda: None)
+
+    original = _snapshot_settings()
+    SETTINGS.LLM_SERVICE_TYPE = "local"
+    SETTINGS.LLM_LOCAL_ENDPOINT = f"{OLLAMA_ENDPOINT}/v1"
+    SETTINGS.LLM_MODEL_NAME = "phi3:mini"
+    SETTINGS.ACTIVE_LLM_SERVER = "ollama"
+    try:
+        response = await system_routes.set_active_llm_server(
+            system_routes.ActiveLlmServerRequest(server_name="multi_runtime")
+        )
+        assert response["status"] == "success"
+        # ollama was stopped, multi_runtime was started
+        assert ("ollama", "stop") in controller.actions
+        assert ("multi_runtime", "start") in controller.actions
+        # lifecycle state confirms all steps done
+        assert "process_stopped" in response["lifecycle_state"]["completed_steps"]
+        assert "health_ready" in response["lifecycle_state"]["completed_steps"]
+        assert "config_saved" in response["lifecycle_state"]["completed_steps"]
+    finally:
+        _restore_settings(original)
+
+
+# ---------------------------------------------------------------------------
+# 4. multi_runtime → ollama switch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_multi_runtime_to_ollama_stops_multi_starts_ollama(monkeypatch):
+    """Switching from multi_runtime to ollama stops multi_runtime and starts ollama."""
+    servers = [
+        _make_server(
+            "ollama", endpoint=OLLAMA_ENDPOINT, health_url=f"{OLLAMA_ENDPOINT}/api/tags"
+        ),
+        _make_server(
+            "multi_runtime",
+            endpoint=MULTI_ENDPOINT,
+            health_url=f"{MULTI_ENDPOINT}/health",
+        ),
+    ]
+    controller = _DummyController(servers)
+    updates: dict = {}
+    monkeypatch.setattr(system_routes.system_deps, "_llm_controller", controller)
+    monkeypatch.setattr(
+        system_routes.system_deps,
+        "_model_manager",
+        _DummyModelManager([{"name": "phi3:mini", "provider": "ollama"}]),
+    )
+    monkeypatch.setattr(system_routes.system_deps, "_request_tracer", None)
+    monkeypatch.setattr(
+        system_routes, "_installed_local_servers", lambda: {"ollama", "multi_runtime"}
+    )
+    monkeypatch.setattr(
+        system_routes.config_manager,
+        "get_config",
+        lambda **_: {
+            "LAST_MODEL_OLLAMA": "phi3:mini",
+        },
+    )
+    monkeypatch.setattr(
+        system_routes.config_manager, "update_config", lambda u: updates.update(u)
+    )
+    monkeypatch.setattr(system_routes, "_release_onnx_runtime_caches", lambda: None)
+
+    original = _snapshot_settings()
+    SETTINGS.LLM_SERVICE_TYPE = "local"
+    SETTINGS.LLM_LOCAL_ENDPOINT = f"{MULTI_ENDPOINT}/v1"
+    SETTINGS.LLM_MODEL_NAME = "gemma2:2b"
+    SETTINGS.ACTIVE_LLM_SERVER = "multi_runtime"
+    try:
+        response = await system_routes.set_active_llm_server(
+            system_routes.ActiveLlmServerRequest(server_name="ollama")
+        )
+        assert response["status"] == "success"
+        assert ("multi_runtime", "stop") in controller.actions
+        assert ("ollama", "start") in controller.actions
+        # endpoint must be updated to ollama
+        assert "ACTIVE_LLM_SERVER" in updates
+        assert updates["ACTIVE_LLM_SERVER"] == "ollama"
+    finally:
+        _restore_settings(original)
+
+
+# ---------------------------------------------------------------------------
+# 5. Health-check timeout → no partial config written
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_health_check_timeout_prevents_config_write(monkeypatch):
+    """If health check times out, config is NOT saved."""
+    servers = [
+        _make_server(
+            "ollama",
+            endpoint=OLLAMA_ENDPOINT,
+            health_url=f"{OLLAMA_ENDPOINT}/api/tags",
+            supports_health_wait=True,
+        ),
+        _make_server(
+            "multi_runtime",
+            endpoint=MULTI_ENDPOINT,
+            health_url=f"{MULTI_ENDPOINT}/health",
+            supports_health_wait=True,
+        ),
+    ]
+    controller = _DummyController(servers)
+    config_written = []
+    monkeypatch.setattr(system_routes.system_deps, "_llm_controller", controller)
+    monkeypatch.setattr(
+        system_routes.system_deps,
+        "_model_manager",
+        _DummyModelManager([{"name": "phi3:mini", "provider": "ollama"}]),
+    )
+    monkeypatch.setattr(system_routes.system_deps, "_request_tracer", None)
+    monkeypatch.setattr(
+        system_routes, "_installed_local_servers", lambda: {"ollama", "multi_runtime"}
+    )
+    monkeypatch.setattr(
+        system_routes.config_manager,
+        "update_config",
+        lambda u: config_written.append(u),
+    )
+    monkeypatch.setattr(system_routes, "_release_onnx_runtime_caches", lambda: None)
+
+    # Override health probe to simulate timeout (returns False = not ready)
+    async def _health_timeout(_server_name, _health_url):
+        return False
+
+    monkeypatch.setattr(runtime_switch_service, "probe_health_ready", _health_timeout)
+
+    original = _snapshot_settings()
+    SETTINGS.LLM_SERVICE_TYPE = "local"
+    SETTINGS.ACTIVE_LLM_SERVER = "ollama"
+    SETTINGS.LLM_MODEL_NAME = "phi3:mini"
+    try:
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await system_routes.set_active_llm_server(
+                system_routes.ActiveLlmServerRequest(server_name="multi_runtime")
+            )
+        assert exc_info.value.status_code == 503
+        # Config must NOT have been written — health failed before config save.
+        assert config_written == [], (
+            "Config must not be written when health check fails"
+        )
+    finally:
+        _restore_settings(original)
+
+
+# ---------------------------------------------------------------------------
+# 6. ONNX cleanup is best-effort — failure doesn't break switch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_onnx_cleanup_failure_does_not_break_switch(monkeypatch):
+    """If ONNX cache flush raises, the switch continues successfully."""
+    servers = [
+        _make_server(
+            "ollama", endpoint=OLLAMA_ENDPOINT, health_url=f"{OLLAMA_ENDPOINT}/api/tags"
+        ),
+    ]
+    controller = _DummyController(servers)
+    monkeypatch.setattr(system_routes.system_deps, "_llm_controller", controller)
+    monkeypatch.setattr(
+        system_routes.system_deps,
+        "_model_manager",
+        _DummyModelManager([{"name": "phi3:mini", "provider": "ollama"}]),
+    )
+    monkeypatch.setattr(system_routes.system_deps, "_request_tracer", None)
+    monkeypatch.setattr(system_routes, "_installed_local_servers", lambda: {"ollama"})
+    monkeypatch.setattr(
+        system_routes.config_manager,
+        "get_config",
+        lambda **_: {
+            "LAST_MODEL_OLLAMA": "phi3:mini",
+        },
+    )
+    monkeypatch.setattr(system_routes.config_manager, "update_config", lambda _: None)
+
+    def _onnx_flush_raises():
+        raise RuntimeError("ONNX not available")
+
+    monkeypatch.setattr(
+        system_routes, "_release_onnx_runtime_caches", _onnx_flush_raises
+    )
+
+    original = _snapshot_settings()
+    SETTINGS.LLM_SERVICE_TYPE = "local"
+    SETTINGS.ACTIVE_LLM_SERVER = "onnx"
+    SETTINGS.LLM_MODEL_NAME = "phi3:mini"
+    try:
+        response = await system_routes.set_active_llm_server(
+            system_routes.ActiveLlmServerRequest(server_name="ollama")
+        )
+        assert response["status"] == "success"
+    finally:
+        _restore_settings(original)
+
+
+# ---------------------------------------------------------------------------
+# 7. Drift detection
+# ---------------------------------------------------------------------------
+
+
+def _fake_settings(**kwargs):
+    defaults = {
+        "ACTIVE_LLM_SERVER": "",
+        "LLM_LOCAL_ENDPOINT": "",
+        "LLM_MODEL_NAME": "",
+        "LLM_SERVICE_TYPE": "local",
+        "AI_MODE": "LOCAL",
+        "VLLM_ENDPOINT": "http://localhost:8001/v1",
+        "GEMMA4_AUDIO_ENDPOINT": "http://localhost:8014/v1",
+        "GEMMA4_AUDIO_HOST": "localhost",
+        "GEMMA4_AUDIO_PORT": 8014,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def test_detect_runtime_drift_no_drift():
+    """No drift when ACTIVE_LLM_SERVER matches endpoint provider."""
+    settings = _fake_settings(
+        ACTIVE_LLM_SERVER="ollama",
+        LLM_LOCAL_ENDPOINT="http://localhost:11434/v1",
+        LLM_MODEL_NAME="phi3:mini",
+    )
+    result = detect_runtime_drift(settings)
+    assert result["drift_detected"] is False
+    assert result["issues"] == []
+
+
+def test_detect_runtime_drift_detects_endpoint_mismatch():
+    """Drift detected when ACTIVE_LLM_SERVER=ollama but endpoint points to vllm."""
+    settings = _fake_settings(
+        ACTIVE_LLM_SERVER="ollama",
+        LLM_LOCAL_ENDPOINT="http://localhost:8001/v1",
+        LLM_MODEL_NAME="phi3:mini",
+    )
+    result = detect_runtime_drift(settings)
+    assert result["drift_detected"] is True
+    assert len(result["issues"]) > 0
+    assert "ollama" in result["issues"][0]
+
+
+def test_detect_runtime_drift_multi_runtime_no_drift():
+    """multi_runtime endpoint doesn't cause false drift."""
+    settings = _fake_settings(
+        ACTIVE_LLM_SERVER="multi_runtime",
+        LLM_LOCAL_ENDPOINT="http://localhost:8014/v1",
+        LLM_MODEL_NAME="gemma2:2b",
+    )
+    result = detect_runtime_drift(settings)
+    assert result["drift_detected"] is False
+
+
+# ---------------------------------------------------------------------------
+# 8. Orchestrator — pre-stop Ollama unload is called
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_calls_ollama_pre_stop_unload():
+    """RuntimeSwitchOrchestrator calls release_runtime_resources before stopping Ollama."""
+    ollama_server = _make_server(
+        "ollama",
+        endpoint=OLLAMA_ENDPOINT,
+        health_url=f"{OLLAMA_ENDPOINT}/api/tags",
+        supports_model_unload=True,
+    )
+    multi_server = _make_server("multi_runtime", endpoint=MULTI_ENDPOINT)
+
+    controller = _DummyController([ollama_server, multi_server])
+    release_calls: list[tuple] = []
+
+    async def _mock_release_resources(server_name, *, server, active_model=""):
+        release_calls.append((server_name, active_model))
+        return True
+
+    orchestrator = RuntimeSwitchOrchestrator(controller)
+    with patch.object(
+        runtime_switch_service,
+        "release_runtime_resources",
+        side_effect=_mock_release_resources,
+    ):
+        (
+            state,
+            stop_results,
+            shutdown_results,
+            start_result,
+            target,
+        ) = await orchestrator.execute_lifecycle_switch(
+            servers=[ollama_server, multi_server],
+            target_server_name="multi_runtime",
+            from_server_name="ollama",
+            active_model="phi3:mini",
+            onnx_flush_fn=lambda: None,
+        )
+
+    assert ("ollama", "phi3:mini") in release_calls
+    assert ("ollama", "stop") in controller.actions
+    assert ("multi_runtime", "start") in controller.actions
+    assert state.is_complete is False  # CONFIG_SAVED not marked (caller's job)
+    assert LifecycleStep.HEALTH_READY in state.completed_steps

--- a/tests/test_220a_runtime_lifecycle.py
+++ b/tests/test_220a_runtime_lifecycle.py
@@ -530,7 +530,7 @@ def test_detect_runtime_drift_detects_endpoint_mismatch():
     result = detect_runtime_drift(settings)
     assert result["drift_detected"] is True
     assert len(result["issues"]) > 0
-    assert "ollama" in result["issues"][0]
+    assert "conflicts with endpoint provider" in result["issues"][0]
 
 
 def test_detect_runtime_drift_multi_runtime_no_drift():
@@ -539,6 +539,28 @@ def test_detect_runtime_drift_multi_runtime_no_drift():
         ACTIVE_LLM_SERVER="multi_runtime",
         LLM_LOCAL_ENDPOINT="http://localhost:8014/v1",
         LLM_MODEL_NAME="gemma2:2b",
+    )
+    result = detect_runtime_drift(settings)
+    assert result["drift_detected"] is False
+
+
+def test_detect_runtime_drift_non_local_uses_service_type_as_inferred():
+    settings = _fake_settings(
+        LLM_SERVICE_TYPE="openai",
+        ACTIVE_LLM_SERVER="",
+        LLM_LOCAL_ENDPOINT="",
+        LLM_MODEL_NAME="gpt-4o-mini",
+    )
+    result = detect_runtime_drift(settings)
+    assert result["drift_detected"] is False
+    assert result["inferred_provider"] == "openai"
+
+
+def test_detect_runtime_drift_empty_endpoint_does_not_raise_false_positive():
+    settings = _fake_settings(
+        ACTIVE_LLM_SERVER="ollama",
+        LLM_LOCAL_ENDPOINT="",
+        LLM_MODEL_NAME="phi3:mini",
     )
     result = detect_runtime_drift(settings)
     assert result["drift_detected"] is False

--- a/tests/test_llm_server_selection.py
+++ b/tests/test_llm_server_selection.py
@@ -8,6 +8,7 @@ import pytest
 from tests.helpers.url_fixtures import LOCALHOST_11434_V1
 from venom_core.api.routes import system_llm as system_routes
 from venom_core.config import SETTINGS
+from venom_core.services import runtime_switch_service
 
 
 class _FakeResponse:
@@ -95,6 +96,8 @@ def _skip_real_shutdown_wait(monkeypatch):
         return True
 
     monkeypatch.setattr(system_routes, "_await_server_shutdown", _fake_shutdown)
+    # Also patch the orchestrator's probe function to prevent real network calls.
+    monkeypatch.setattr(runtime_switch_service, "probe_until_shutdown", _fake_shutdown)
 
 
 @pytest.mark.asyncio
@@ -316,6 +319,7 @@ async def test_set_active_llm_server_waits_for_previous_runtime_shutdown_before_
         return True
 
     monkeypatch.setattr(system_routes, "_await_server_shutdown", _fake_shutdown)
+    monkeypatch.setattr(runtime_switch_service, "probe_until_shutdown", _fake_shutdown)
 
     original = _snapshot_settings()
     SETTINGS.LLM_SERVICE_TYPE = "local"

--- a/tests/test_onnx_llm_client.py
+++ b/tests/test_onnx_llm_client.py
@@ -196,6 +196,28 @@ def test_status_payload_contains_resolved_path_and_runtime_fields(
     assert payload["ready"] is True
     assert "active_execution_provider" in payload
     assert "runtime_device_type" in payload
+    assert "available_execution_providers" in payload
+    assert "requested_provider_available" in payload
+
+
+def test_ensure_ready_fails_when_requested_provider_unavailable(tmp_path, monkeypatch):
+    model_dir = _prepare_model_dir(tmp_path)
+    client = OnnxLlmClient(settings=_settings(ONNX_LLM_MODEL_PATH=str(model_dir)))
+    monkeypatch.setattr(
+        "venom_core.execution.onnx_llm_client.is_onnx_genai_available", lambda: True
+    )
+    monkeypatch.setattr(
+        "venom_core.execution.onnx_llm_client.OnnxLlmClient._is_provider_available",
+        classmethod(lambda cls, provider: False),
+    )
+    monkeypatch.setattr(
+        "venom_core.execution.onnx_llm_client.OnnxLlmClient._available_execution_providers",
+        staticmethod(lambda: ["CPUExecutionProvider"]),
+    )
+    with pytest.raises(
+        RuntimeError, match="requested execution provider is unavailable"
+    ):
+        client.ensure_ready()
 
 
 @pytest.mark.parametrize(
@@ -324,6 +346,10 @@ def test_ensure_runtime_builds_model_once_and_caches(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "venom_core.execution.onnx_llm_client.is_onnx_genai_available", lambda: True
     )
+    monkeypatch.setattr(
+        "venom_core.execution.onnx_llm_client.OnnxLlmClient._is_provider_available",
+        classmethod(lambda cls, provider: True),
+    )
     monkeypatch.setitem(sys.modules, "onnxruntime_genai", fake_og)
     client._ensure_runtime()
     first_model = client._model
@@ -343,6 +369,10 @@ def test_stream_generate_and_generate_return_text(tmp_path, monkeypatch):
     fake_og = _fake_og_module()
     monkeypatch.setattr(
         "venom_core.execution.onnx_llm_client.is_onnx_genai_available", lambda: True
+    )
+    monkeypatch.setattr(
+        "venom_core.execution.onnx_llm_client.OnnxLlmClient._is_provider_available",
+        classmethod(lambda cls, provider: True),
     )
     monkeypatch.setitem(sys.modules, "onnxruntime_genai", fake_og)
     parts = list(

--- a/tests/test_runtime_switch_service_branches.py
+++ b/tests/test_runtime_switch_service_branches.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import httpx
+import pytest
+
+import venom_core.services.runtime_switch_service as switch_mod
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: dict[str, Any] | None = None):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+
+    def json(self):
+        return self._payload
+
+
+class _FakeAsyncClient:
+    def __init__(
+        self,
+        *,
+        get_items: list[Any] | None = None,
+        post_exception: bool = False,
+    ):
+        self._get_items = list(get_items or [])
+        self._post_exception = post_exception
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, _url: str):
+        if not self._get_items:
+            return _FakeResponse(500, {"status": "error"})
+        item = self._get_items.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    async def post(self, _url: str, json: dict[str, Any] | None = None):
+        if self._post_exception:
+            raise RuntimeError("post failed")
+        return _FakeResponse(200, {"ok": True, "echo": json or {}})
+
+
+@pytest.mark.asyncio
+async def test_release_ollama_model_handles_empty_input():
+    mod = importlib.reload(switch_mod)
+    assert await mod._release_ollama_model("", "phi3:mini") is False
+    assert await mod._release_ollama_model("http://localhost:11434", "") is False
+
+
+@pytest.mark.asyncio
+async def test_release_ollama_model_success_and_failure(monkeypatch):
+    mod = importlib.reload(switch_mod)
+    monkeypatch.setattr(mod.httpx, "AsyncClient", lambda timeout: _FakeAsyncClient())
+    assert (
+        await mod._release_ollama_model("http://localhost:11434/v1", "phi3:mini")
+        is True
+    )
+
+    monkeypatch.setattr(
+        mod.httpx,
+        "AsyncClient",
+        lambda timeout: _FakeAsyncClient(post_exception=True),
+    )
+    assert (
+        await mod._release_ollama_model("http://localhost:11434/v1", "phi3:mini")
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_probe_health_ready_and_shutdown_branches(monkeypatch):
+    mod = importlib.reload(switch_mod)
+
+    async def _no_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(mod.asyncio, "sleep", _no_sleep)
+    monkeypatch.setattr(mod, "_HEALTH_MAX_ATTEMPTS", 2)
+
+    monkeypatch.setattr(
+        mod.httpx,
+        "AsyncClient",
+        lambda timeout: _FakeAsyncClient(
+            get_items=[_FakeResponse(200, {"status": "ok"})]
+        ),
+    )
+    assert (
+        await mod.probe_health_ready("multi_runtime", "http://localhost:8014/health")
+        is True
+    )
+
+    monkeypatch.setattr(
+        mod.httpx,
+        "AsyncClient",
+        lambda timeout: _FakeAsyncClient(
+            get_items=[httpx.ConnectError("down"), httpx.ConnectError("down")]
+        ),
+    )
+    assert (
+        await mod.probe_health_ready("multi_runtime", "http://localhost:8014/health")
+        is False
+    )
+
+    monkeypatch.setattr(
+        mod.httpx,
+        "AsyncClient",
+        lambda timeout: _FakeAsyncClient(
+            get_items=[_FakeResponse(503, {"status": "down"})]
+        ),
+    )
+    assert (
+        await mod.probe_until_shutdown("ollama", "http://localhost:11434/api/tags")
+        is True
+    )
+
+    monkeypatch.setattr(
+        mod.httpx,
+        "AsyncClient",
+        lambda timeout: _FakeAsyncClient(
+            get_items=[
+                _FakeResponse(200, {"status": "ok"}),
+                _FakeResponse(200, {"status": "ok"}),
+            ]
+        ),
+    )
+    assert (
+        await mod.probe_until_shutdown("multi_runtime", "http://localhost:8014/health")
+        is False
+    )
+
+
+@pytest.mark.asyncio
+async def test_probe_until_shutdown_returns_true_on_exception(monkeypatch):
+    mod = importlib.reload(switch_mod)
+
+    async def _no_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(mod.asyncio, "sleep", _no_sleep)
+    monkeypatch.setattr(mod, "_HEALTH_MAX_ATTEMPTS", 1)
+    monkeypatch.setattr(
+        mod.httpx,
+        "AsyncClient",
+        lambda timeout: _FakeAsyncClient(get_items=[httpx.ConnectError("boom")]),
+    )
+    assert (
+        await mod.probe_until_shutdown("ollama", "http://localhost:11434/api/tags")
+        is True
+    )

--- a/venom_core/api/routes/system_llm.py
+++ b/venom_core/api/routes/system_llm.py
@@ -38,8 +38,11 @@ from venom_core.services.feedback_loop_policy import (
     resolve_feedback_loop_model,
 )
 from venom_core.services.gemma4_audio_models import gemma4_audio_available_models
+from venom_core.services.runtime_switch_service import RuntimeSwitchOrchestrator
 from venom_core.utils.llm_runtime import (
+    LifecycleStep,
     compute_llm_config_hash,
+    detect_runtime_drift,
     get_active_llm_runtime,
     infer_local_provider,
 )
@@ -249,7 +252,7 @@ def _assert_stop_results_clean(stop_results: dict[str, dict[str, Any]]) -> None:
     ]
     if failures:
         logger.warning(
-            "Nie udało się zatrzymać poprzednich serwerów LLM: %s",
+            "Nie udało się zatrzymać poprzednich serwerów LLM: {}",
             ", ".join(sorted(failures)),
         )
 
@@ -271,52 +274,16 @@ def _release_onnx_runtime_caches() -> None:
 
 
 async def _await_server_health(_server_name: str, health_url: str) -> bool:
-    logger.info("Oczekiwanie na gotowość serwera LLM.")
-    async with httpx.AsyncClient(timeout=2.0) as client:
-        for attempt in range(60):
-            try:
-                resp = await client.get(health_url)
-                is_ready = _is_health_response_ready(
-                    server_name=_server_name,
-                    response=resp,
-                )
-                if is_ready is True:
-                    logger.info("Serwer LLM gotowy po %.1fs", attempt * 0.5)
-                    return True
-            except Exception:
-                pass
-            await asyncio.sleep(0.5)
-    logger.error("Serwer LLM nie odpowiedział prawidłowo po 30s")
-    return False
+    from venom_core.services.runtime_switch_service import probe_health_ready
+
+    return await probe_health_ready(_server_name, health_url)
 
 
 async def _await_server_shutdown(server_name: str, health_url: str) -> bool:
     """Wait until a stopped server no longer reports healthy."""
-    logger.info("Oczekiwanie na zwolnienie serwera LLM: %s", server_name)
-    async with httpx.AsyncClient(timeout=2.0) as client:
-        for attempt in range(60):
-            try:
-                resp = await client.get(health_url)
-                if not _is_health_response_ready(
-                    server_name=server_name,
-                    response=resp,
-                ):
-                    logger.info(
-                        "Serwer LLM %s zwolnił zasoby po %.1fs",
-                        server_name,
-                        attempt * 0.5,
-                    )
-                    return True
-            except Exception:
-                logger.info(
-                    "Serwer LLM %s jest niedostępny po %.1fs",
-                    server_name,
-                    attempt * 0.5,
-                )
-                return True
-            await asyncio.sleep(0.5)
-    logger.error("Serwer LLM %s nadal odpowiada po 30s", server_name)
-    return False
+    from venom_core.services.runtime_switch_service import probe_until_shutdown
+
+    return await probe_until_shutdown(server_name, health_url)
 
 
 def _extract_health_status(response: httpx.Response) -> str | None:
@@ -1031,7 +998,7 @@ async def _load_trainable_model_catalog(
             local_models=local_models,
         )
     except Exception as exc:
-        logger.warning("Failed to load trainable model catalog: %s", exc)
+        logger.warning("Failed to load trainable model catalog: {}", exc)
         return []
 
     normalized: list[dict[str, Any]] = []
@@ -1127,7 +1094,7 @@ def _build_adapter_catalog(
     try:
         adapters_raw = academy_models.list_adapters(model_manager)
     except Exception as exc:
-        logger.warning("Failed to load adapter catalog for runtime options: %s", exc)
+        logger.warning("Failed to load adapter catalog for runtime options: {}", exc)
         return {
             "all_adapters": [],
             "by_runtime": {},
@@ -2050,7 +2017,12 @@ def get_active_llm_server():
 def get_active_llm_runtime_info():
     """Alias z pełnym payloadem aktywnego runtime LLM."""
     runtime = get_active_llm_runtime()
-    return {"status": "success", "runtime": runtime.to_payload()}
+    drift = detect_runtime_drift()
+    return {
+        "status": "success",
+        "runtime": runtime.to_payload(),
+        "drift": drift,
+    }
 
 
 @router.get(
@@ -2508,15 +2480,15 @@ async def set_active_llm_server(request: ActiveLlmServerRequest):
     )
     llm_controller = _get_llm_controller_or_503()
     servers = llm_controller.list_servers()
-    stop_results = await _stop_other_servers(llm_controller, servers, server_name)
-    _assert_stop_results_clean(stop_results)
-    shutdown_results = await _collect_shutdown_results_for_switch(
-        servers=servers,
-        target_server_name=server_name,
-    )
-    if server_name != "onnx":
-        _release_onnx_runtime_caches()
+
+    # ONNX: in-process runtime, no daemon start/stop needed — dedicated path.
     if server_name == "onnx":
+        stop_results = await _stop_other_servers(llm_controller, servers, server_name)
+        _assert_stop_results_clean(stop_results)
+        shutdown_results = await _collect_shutdown_results_for_switch(
+            servers=servers,
+            target_server_name=server_name,
+        )
         response = _activate_onnx_server_switch(stop_results=stop_results)
         response["shutdown_results"] = shutdown_results
         return response
@@ -2526,6 +2498,7 @@ async def set_active_llm_server(request: ActiveLlmServerRequest):
     if not llm_controller.has_server(server_name):
         raise HTTPException(status_code=404, detail="Nieznany serwer LLM")
 
+    from_server = str(getattr(SETTINGS, "ACTIVE_LLM_SERVER", "") or "").strip().lower()
     _trace_switch(
         request_tracer,
         request.trace_id,
@@ -2533,13 +2506,25 @@ async def set_active_llm_server(request: ActiveLlmServerRequest):
         f"server={server_name}",
     )
 
-    target = _find_target_server(server_name, servers)
-    start_result = await _start_server_and_check_health(
-        llm_controller=llm_controller,
-        server_name=server_name,
-        target=target,
+    # Delegate full lifecycle (stop → release → flush → start → health) to orchestrator.
+    # Config/endpoint are saved ONLY after orchestrator returns with confirmed health.
+    active_model = str(getattr(SETTINGS, "LLM_MODEL_NAME", "") or "").strip()
+    orchestrator = RuntimeSwitchOrchestrator(llm_controller)
+    (
+        switch_state,
+        stop_results,
+        shutdown_results,
+        start_result,
+        target,
+    ) = await orchestrator.execute_lifecycle_switch(
+        servers=servers,
+        target_server_name=server_name,
+        from_server_name=from_server or "unknown",
+        active_model=active_model,
+        onnx_flush_fn=_release_onnx_runtime_caches,
     )
 
+    # All lifecycle steps confirmed — safe to persist config and model now.
     endpoint = _resolve_local_endpoint(server_name, target)
     _persist_local_runtime_endpoint(server_name, endpoint)
 
@@ -2570,6 +2555,7 @@ async def set_active_llm_server(request: ActiveLlmServerRequest):
     config_hash = _persist_selected_model_settings(
         server_name, selected_model, endpoint
     )
+    switch_state.mark_done(LifecycleStep.CONFIG_SAVED)
 
     runtime = get_active_llm_runtime()
     _trace_switch(
@@ -2590,4 +2576,5 @@ async def set_active_llm_server(request: ActiveLlmServerRequest):
         "start_result": start_result,
         "stop_results": stop_results,
         "shutdown_results": shutdown_results,
+        "lifecycle_state": switch_state.to_payload(),
     }

--- a/venom_core/api/routes/system_llm.py
+++ b/venom_core/api/routes/system_llm.py
@@ -38,7 +38,11 @@ from venom_core.services.feedback_loop_policy import (
     resolve_feedback_loop_model,
 )
 from venom_core.services.gemma4_audio_models import gemma4_audio_available_models
-from venom_core.services.runtime_switch_service import RuntimeSwitchOrchestrator
+from venom_core.services.runtime_switch_service import (
+    RuntimeSwitchOrchestrator,
+    probe_health_ready,
+    probe_until_shutdown,
+)
 from venom_core.utils.llm_runtime import (
     LifecycleStep,
     compute_llm_config_hash,
@@ -274,15 +278,11 @@ def _release_onnx_runtime_caches() -> None:
 
 
 async def _await_server_health(_server_name: str, health_url: str) -> bool:
-    from venom_core.services.runtime_switch_service import probe_health_ready
-
     return await probe_health_ready(_server_name, health_url)
 
 
 async def _await_server_shutdown(server_name: str, health_url: str) -> bool:
     """Wait until a stopped server no longer reports healthy."""
-    from venom_core.services.runtime_switch_service import probe_until_shutdown
-
     return await probe_until_shutdown(server_name, health_url)
 
 
@@ -2481,19 +2481,10 @@ async def set_active_llm_server(request: ActiveLlmServerRequest):
     llm_controller = _get_llm_controller_or_503()
     servers = llm_controller.list_servers()
 
-    # ONNX: in-process runtime, no daemon start/stop needed — dedicated path.
-    if server_name == "onnx":
-        stop_results = await _stop_other_servers(llm_controller, servers, server_name)
-        _assert_stop_results_clean(stop_results)
-        shutdown_results = await _collect_shutdown_results_for_switch(
-            servers=servers,
-            target_server_name=server_name,
-        )
-        response = _activate_onnx_server_switch(stop_results=stop_results)
-        response["shutdown_results"] = shutdown_results
-        return response
-
-    _, model_manager, request_tracer = _validate_switch_dependencies()
+    request_tracer = system_deps.get_request_tracer()
+    model_manager = None
+    if server_name != "onnx":
+        _, model_manager, request_tracer = _validate_switch_dependencies()
 
     if not llm_controller.has_server(server_name):
         raise HTTPException(status_code=404, detail="Nieznany serwer LLM")
@@ -2524,10 +2515,19 @@ async def set_active_llm_server(request: ActiveLlmServerRequest):
         onnx_flush_fn=_release_onnx_runtime_caches,
     )
 
+    if server_name == "onnx":
+        switch_state.mark_done(LifecycleStep.ENDPOINT_SWITCHED)
+        switch_state.mark_done(LifecycleStep.CONFIG_SAVED)
+        response = _activate_onnx_server_switch(stop_results=stop_results)
+        response["shutdown_results"] = shutdown_results
+        response["lifecycle_state"] = switch_state.to_payload()
+        return response
+
     # All lifecycle steps confirmed — safe to persist config and model now.
     endpoint = _resolve_local_endpoint(server_name, target)
     _persist_local_runtime_endpoint(server_name, endpoint)
 
+    assert model_manager is not None
     config = config_manager.get_config(mask_secrets=False)
     models = await model_manager.list_local_models()
     (

--- a/venom_core/core/llm_server_controller.py
+++ b/venom_core/core/llm_server_controller.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional
 
@@ -12,6 +12,36 @@ from venom_core.utils.logger import get_logger
 from venom_core.utils.url_policy import build_http_url
 
 logger = get_logger(__name__)
+
+
+@dataclass
+class RuntimeCapabilities:
+    """Formalny kontrakt lifecycle dla jednego runtime stack.
+
+    Opisuje które operacje lifecycle są dostępne i jak runtime zachowuje się
+    podczas switch flow: stop → release → flush_cache → start → await_ready.
+    """
+
+    supports_stop: bool
+    supports_start: bool
+    supports_restart: bool
+    supports_health_wait: bool
+    supports_cache_flush: bool
+    supports_model_unload: bool
+    is_in_process: bool
+    release_wait_seconds: int = 0
+
+    def as_dict(self) -> dict:
+        return {
+            "supports_stop": self.supports_stop,
+            "supports_start": self.supports_start,
+            "supports_restart": self.supports_restart,
+            "supports_health_wait": self.supports_health_wait,
+            "supports_cache_flush": self.supports_cache_flush,
+            "supports_model_unload": self.supports_model_unload,
+            "is_in_process": self.is_in_process,
+            "release_wait_seconds": self.release_wait_seconds,
+        }
 
 
 @dataclass
@@ -25,6 +55,17 @@ class LlmServerConfig:
     provider: str
     commands: Dict[str, str]
     health_url: Optional[str] = None
+    capabilities: RuntimeCapabilities = field(
+        default_factory=lambda: RuntimeCapabilities(
+            supports_stop=False,
+            supports_start=False,
+            supports_restart=False,
+            supports_health_wait=False,
+            supports_cache_flush=False,
+            supports_model_unload=False,
+            is_in_process=False,
+        )
+    )
 
 
 @dataclass
@@ -87,6 +128,16 @@ class LlmServerController:
                 "stop": vllm_stop_cmd,
                 "restart": vllm_restart_cmd,
             },
+            capabilities=RuntimeCapabilities(
+                supports_stop=True,
+                supports_start=True,
+                supports_restart=True,
+                supports_health_wait=True,
+                supports_cache_flush=False,
+                supports_model_unload=False,
+                is_in_process=False,
+                release_wait_seconds=10,
+            ),
         )
 
         # Komendy dla Ollama (puste = brak akcji)
@@ -115,6 +166,16 @@ class LlmServerController:
                 "stop": ollama_stop_cmd,
                 "restart": ollama_restart_cmd,
             },
+            capabilities=RuntimeCapabilities(
+                supports_stop=True,
+                supports_start=True,
+                supports_restart=True,
+                supports_health_wait=True,
+                supports_cache_flush=False,
+                supports_model_unload=True,
+                is_in_process=False,
+                release_wait_seconds=5,
+            ),
         )
 
         # Multi-runtime (Gemma 4 multimodal — audio, image, text)
@@ -145,6 +206,16 @@ class LlmServerController:
                 "stop": multi_runtime_stop_cmd,
                 "restart": multi_runtime_restart_cmd,
             },
+            capabilities=RuntimeCapabilities(
+                supports_stop=True,
+                supports_start=True,
+                supports_restart=True,
+                supports_health_wait=True,
+                supports_cache_flush=False,
+                supports_model_unload=False,
+                is_in_process=False,
+                release_wait_seconds=10,
+            ),
         )
 
         # ONNX Runtime działa in-process, ale utrzymujemy spójny wpis serwera
@@ -161,6 +232,16 @@ class LlmServerController:
                 "stop": "",
                 "restart": "",
             },
+            capabilities=RuntimeCapabilities(
+                supports_stop=False,
+                supports_start=False,
+                supports_restart=False,
+                supports_health_wait=False,
+                supports_cache_flush=True,
+                supports_model_unload=True,
+                is_in_process=True,
+                release_wait_seconds=0,
+            ),
         )
 
         return servers
@@ -183,6 +264,7 @@ class LlmServerController:
                         action: bool(command)
                         for action, command in server.commands.items()
                     },
+                    "capabilities": server.capabilities.as_dict(),
                 }
             )
         return servers
@@ -190,6 +272,12 @@ class LlmServerController:
     def has_server(self, server_name: str) -> bool:
         """Sprawdza czy mamy konfigurację serwera."""
         return server_name in self._servers
+
+    def get_capabilities(self, server_name: str) -> RuntimeCapabilities:
+        """Zwraca kontrakt lifecycle dla danego runtime."""
+        if server_name not in self._servers:
+            raise ValueError(f"Nieznany serwer LLM: {server_name}")
+        return self._servers[server_name].capabilities
 
     async def check_systemd_available(
         self, service_name: str = "ollama.service"

--- a/venom_core/core/model_registry_runtime.py
+++ b/venom_core/core/model_registry_runtime.py
@@ -24,7 +24,7 @@ async def activate_model(registry: Any, model_name: str, runtime: str) -> bool:
 
     meta = registry.manifest.get(model_name)
     if not meta:
-        logger.error("Brak metadanych modelu %s po aktywacji", model_name)
+        logger.error("Brak metadanych modelu {} po aktywacji", model_name)
         return False
 
     try:
@@ -168,4 +168,4 @@ async def restart_runtime_after_activation(runtime: str, settings: Any) -> None:
                     result.stderr,
                 )
     except Exception as exc:
-        logger.warning("Nie udało się wykonać restartu %s: %s", runtime, exc)
+        logger.warning("Nie udało się wykonać restartu {}: {}", runtime, exc)

--- a/venom_core/execution/onnx_llm_client.py
+++ b/venom_core/execution/onnx_llm_client.py
@@ -98,13 +98,37 @@ class OnnxLlmClient:
     def can_serve(self) -> bool:
         return self.is_enabled() and is_onnx_genai_available() and self.has_model_path()
 
+    @staticmethod
+    def _available_execution_providers() -> list[str]:
+        try:
+            import onnxruntime as ort  # type: ignore[import-untyped]
+
+            return [str(item) for item in ort.get_available_providers()]
+        except Exception:
+            return []
+
+    @classmethod
+    def _is_provider_available(cls, provider: str) -> bool:
+        normalized = cls._normalize_execution_provider(provider)
+        aliases = {alias.lower() for alias in cls._provider_aliases(normalized)}
+        for available in cls._available_execution_providers():
+            if str(available).lower() in aliases:
+                return True
+        return False
+
     def status_payload(self) -> dict[str, Any]:
         resolved_path = self._resolve_runtime_model_path()
+        available_providers = self._available_execution_providers()
+        requested_provider_available = self._is_provider_available(
+            self._config.execution_provider
+        )
         return {
             **asdict(self._config),
             "genai_installed": is_onnx_genai_available(),
             "model_path_exists": self.has_model_path(),
             "resolved_model_path": str(resolved_path) if resolved_path else None,
+            "available_execution_providers": available_providers,
+            "requested_provider_available": requested_provider_available,
             "active_execution_provider": self._active_execution_provider,
             "runtime_device_type": self._runtime_device_type,
             "ready": self.can_serve(),
@@ -210,6 +234,19 @@ class OnnxLlmClient:
         if resolved_path is None:
             raise RuntimeError(
                 f"ONNX LLM model path does not exist: {self._config.model_path}"
+            )
+        requested_provider = self._normalize_execution_provider(
+            self._config.execution_provider
+        )
+        if requested_provider != "cpu" and not self._is_provider_available(
+            requested_provider
+        ):
+            available = ", ".join(self._available_execution_providers()) or "none"
+            raise RuntimeError(
+                "ONNX requested execution provider is unavailable "
+                f"(requested={requested_provider}, available={available}). "
+                "Install and activate GPU runtime (onnxruntime-gpu) or set "
+                "ONNX_LLM_EXECUTION_PROVIDER=cpu."
             )
         self._resolved_model_path = str(resolved_path)
 

--- a/venom_core/services/onnx_runtime_cleanup.py
+++ b/venom_core/services/onnx_runtime_cleanup.py
@@ -19,7 +19,7 @@ def _safe_call(module_name: str, function_name: str, **kwargs: Any) -> bool:
         func(**kwargs)
         return True
     except Exception:
-        logger.warning(
+        logger.exception(
             "Failed to run ONNX cleanup hook: {}.{}",
             module_name,
             function_name,

--- a/venom_core/services/onnx_runtime_cleanup.py
+++ b/venom_core/services/onnx_runtime_cleanup.py
@@ -20,10 +20,9 @@ def _safe_call(module_name: str, function_name: str, **kwargs: Any) -> bool:
         return True
     except Exception:
         logger.warning(
-            "Failed to run ONNX cleanup hook: %s.%s",
+            "Failed to run ONNX cleanup hook: {}.{}",
             module_name,
             function_name,
-            exc_info=True,
         )
         return False
 

--- a/venom_core/services/runtime_switch_service.py
+++ b/venom_core/services/runtime_switch_service.py
@@ -1,0 +1,362 @@
+"""Centralny orkiestrator przełączania runtime LLM.
+
+Faza 2 PR 220A: wydziela logikę lifecycle switch z routera do serwisu.
+Sekwencja: stop → release_wait → cache_flush → start → health_check.
+Config/endpoint zapisywane są przez wywołującego TYLKO po pomyślnym return.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Optional
+
+import httpx
+from fastapi import HTTPException
+
+from venom_core.utils.llm_runtime import LifecycleStep, LifecycleSwitchState
+from venom_core.utils.logger import get_logger
+from venom_core.utils.runtime_names import is_multi_runtime
+
+logger = get_logger(__name__)
+
+_HEALTH_POLL_INTERVAL = 0.5
+_HEALTH_MAX_ATTEMPTS = 60
+_CLEANUP_TIMEOUT = 5.0
+
+
+async def _release_ollama_model(endpoint: str, model_name: str) -> bool:
+    """Ask Ollama to evict the model from VRAM before stopping the daemon.
+
+    Uses keep_alive=0 so Ollama releases GPU/RAM immediately. Best-effort.
+    """
+    if not model_name or not endpoint:
+        return False
+    base = endpoint.rstrip("/").removesuffix("/v1")
+    unload_url = f"{base}/api/generate"
+    try:
+        async with httpx.AsyncClient(timeout=_CLEANUP_TIMEOUT) as client:
+            await client.post(
+                unload_url,
+                json={"model": model_name, "keep_alive": 0},
+            )
+        logger.info("Ollama model {} evicted from VRAM (keep_alive=0)", model_name)
+        return True
+    except Exception as exc:
+        logger.warning("Nie udało się zwolnić modelu Ollama z VRAM: {}", exc)
+        return False
+
+
+async def release_runtime_resources(
+    server_name: str,
+    *,
+    server: dict[str, Any],
+    active_model: str = "",
+) -> bool:
+    """Best-effort pre-stop cleanup for a specific runtime stack.
+
+    Called before stopping the server process to release GPU/RAM early.
+    Never raises — failures are logged and ignored.
+
+    Returns True if any cleanup hook ran successfully.
+    """
+    caps = server.get("capabilities", {})
+    released = False
+
+    if server_name == "ollama" and caps.get("supports_model_unload"):
+        endpoint = str(server.get("endpoint") or "http://localhost:11434")
+        if active_model:
+            released = await _release_ollama_model(endpoint, active_model)
+
+    if caps.get("is_in_process") and caps.get("supports_cache_flush"):
+        try:
+            from venom_core.services.onnx_runtime_cleanup import (  # noqa: PLC0415
+                release_onnx_runtime_best_effort,
+            )
+
+            released = release_onnx_runtime_best_effort(wait=False) or released
+        except Exception as exc:
+            logger.warning("Nie udało się zwolnić runtime ONNX: {}", exc)
+
+    return released
+
+
+def _extract_health_status(response: httpx.Response) -> str | None:
+    try:
+        payload = response.json()
+    except Exception:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    raw = payload.get("status")
+    if raw is None:
+        return None
+    return str(raw).strip().lower() or None
+
+
+def _is_health_response_ready(*, server_name: str, response: httpx.Response) -> bool:
+    if not (200 <= response.status_code < 300):
+        return False
+    if not is_multi_runtime(server_name):
+        return True
+    status = _extract_health_status(response)
+    return status in {"ok", "ready", "running"}
+
+
+async def probe_health_ready(server_name: str, health_url: str) -> bool:
+    """Return True when server reports healthy within 30 seconds."""
+    logger.info("Oczekiwanie na gotowość serwera LLM: {}", server_name)
+    async with httpx.AsyncClient(timeout=2.0) as client:
+        for attempt in range(_HEALTH_MAX_ATTEMPTS):
+            try:
+                resp = await client.get(health_url)
+                if _is_health_response_ready(server_name=server_name, response=resp):
+                    logger.info(
+                        "Serwer LLM {} gotowy po {:.1f}s",
+                        server_name,
+                        attempt * _HEALTH_POLL_INTERVAL,
+                    )
+                    return True
+            except Exception:
+                pass
+            await asyncio.sleep(_HEALTH_POLL_INTERVAL)
+    logger.error("Serwer LLM {} nie odpowiedział prawidłowo po 30s", server_name)
+    return False
+
+
+async def probe_until_shutdown(server_name: str, health_url: str) -> bool:
+    """Return True when server stops responding within 30 seconds."""
+    logger.info("Oczekiwanie na zwolnienie serwera LLM: {}", server_name)
+    async with httpx.AsyncClient(timeout=2.0) as client:
+        for attempt in range(_HEALTH_MAX_ATTEMPTS):
+            try:
+                resp = await client.get(health_url)
+                if not _is_health_response_ready(
+                    server_name=server_name, response=resp
+                ):
+                    logger.info(
+                        "Serwer LLM {} zwolnił zasoby po {:.1f}s",
+                        server_name,
+                        attempt * _HEALTH_POLL_INTERVAL,
+                    )
+                    return True
+            except Exception:
+                logger.info(
+                    "Serwer LLM {} jest niedostępny po {:.1f}s",
+                    server_name,
+                    attempt * _HEALTH_POLL_INTERVAL,
+                )
+                return True
+            await asyncio.sleep(_HEALTH_POLL_INTERVAL)
+    logger.error("Serwer LLM {} nadal odpowiada po 30s", server_name)
+    return False
+
+
+class RuntimeSwitchOrchestrator:
+    """Orchestrates the full lifecycle switch between LLM runtimes.
+
+    Sequence: stop_others → await_release → flush_caches → start_target → verify_health.
+
+    Tracks progress via LifecycleSwitchState.
+    Raises HTTPException on critical failures.
+    Config/endpoint MUST be saved by the caller only after this returns successfully.
+    """
+
+    def __init__(self, llm_controller: Any) -> None:
+        self._controller = llm_controller
+
+    async def execute_lifecycle_switch(
+        self,
+        *,
+        servers: list[dict[str, Any]],
+        target_server_name: str,
+        from_server_name: str = "unknown",
+        active_model: str = "",
+        onnx_flush_fn: Optional[Any] = None,
+    ) -> tuple[
+        LifecycleSwitchState,
+        dict[str, Any],
+        dict[str, Any],
+        Optional[dict[str, Any]],
+        dict[str, Any],
+    ]:
+        """Execute the lifecycle switch.
+
+        Returns (state, stop_results, shutdown_results, start_result, target_server_dict).
+        Raises HTTPException if a critical lifecycle step fails.
+        Config/endpoint MUST be saved by the caller only after this returns successfully.
+
+        active_model: current model name, used for pre-stop unload hooks (e.g. Ollama).
+        onnx_flush_fn: optional callable invoked to release ONNX in-process caches when
+        switching away from ONNX. Injected by the caller so it can be patched in tests.
+        """
+        state = LifecycleSwitchState(
+            from_server=from_server_name,
+            to_server=target_server_name,
+        )
+
+        stop_results = await self._stop_other_servers(
+            servers, target_server_name, state, active_model=active_model
+        )
+        shutdown_results = await self._await_release(servers, target_server_name, state)
+        self._flush_caches_if_leaving_onnx(target_server_name, state, onnx_flush_fn)
+
+        target = self._find_target(target_server_name, servers)
+        start_result = await self._start_and_verify_health(
+            target_server_name, target, state
+        )
+
+        return state, stop_results, shutdown_results, start_result, target
+
+    async def _stop_other_servers(
+        self,
+        servers: list[dict[str, Any]],
+        target_name: str,
+        state: LifecycleSwitchState,
+        *,
+        active_model: str = "",
+    ) -> dict[str, Any]:
+        stop_results: dict[str, Any] = {}
+        for server in servers:
+            name = str(server.get("name") or "").strip()
+            if not name or name == target_name:
+                continue
+            if not server.get("supports", {}).get("stop"):
+                continue
+
+            # Pre-stop cleanup: release model from VRAM/RAM before sending stop command.
+            await release_runtime_resources(
+                name, server=server, active_model=active_model
+            )
+
+            try:
+                result = await self._controller.run_action(name, "stop")
+                stop_results[name] = {"ok": result.ok, "exit_code": result.exit_code}
+            except Exception as exc:
+                stop_results[name] = {"ok": False, "error": str(exc)}
+
+        failures = [n for n, r in stop_results.items() if not r.get("ok")]
+        if failures:
+            logger.warning(
+                "Nie udało się zatrzymać poprzednich serwerów LLM: {}",
+                ", ".join(sorted(failures)),
+            )
+
+        state.mark_done(LifecycleStep.PROCESS_STOPPED)
+        return stop_results
+
+    async def _await_release(
+        self,
+        servers: list[dict[str, Any]],
+        target_name: str,
+        state: LifecycleSwitchState,
+    ) -> dict[str, Any]:
+        """Await shutdown probes + per-capabilities release_wait.
+
+        Returns shutdown_results dict mapping server_name → {"ok": bool, "health_url": str}.
+        """
+        shutdown_results: dict[str, Any] = {}
+        for server in servers:
+            name = str(server.get("name") or "").strip()
+            if not name or name == target_name:
+                continue
+            if not server.get("supports", {}).get("stop"):
+                continue
+
+            health_url = str(server.get("health_url") or "").strip()
+            if health_url:
+                shutdown_ok = await probe_until_shutdown(name, health_url)
+                shutdown_results[name] = {"ok": shutdown_ok, "health_url": health_url}
+                if not shutdown_ok:
+                    state.mark_failed(
+                        LifecycleStep.RELEASE_DONE,
+                        f"{name} nie zwolnił zasobów po zatrzymaniu",
+                    )
+                    raise HTTPException(
+                        status_code=503,
+                        detail=f"Serwer LLM '{name}' nie zwolnił zasobów po zatrzymaniu.",
+                    )
+
+            caps_dict = server.get("capabilities", {})
+            release_wait = int(caps_dict.get("release_wait_seconds", 0))
+            if release_wait > 0:
+                logger.info(
+                    "Oczekiwanie {}s na zwolnienie zasobów przez {}",
+                    release_wait,
+                    name,
+                )
+                await asyncio.sleep(release_wait)
+
+        state.mark_done(LifecycleStep.RELEASE_DONE)
+        return shutdown_results
+
+    def _flush_caches_if_leaving_onnx(
+        self,
+        target_name: str,
+        state: LifecycleSwitchState,
+        onnx_flush_fn: Optional[Any] = None,
+    ) -> None:
+        if target_name == "onnx":
+            return
+        if onnx_flush_fn is not None:
+            try:
+                onnx_flush_fn()
+            except Exception:
+                logger.warning("Nie udało się zwolnić cache ONNX runtime.")
+        else:
+            try:
+                from venom_core.services.onnx_runtime_cleanup import (
+                    release_onnx_runtime_best_effort,
+                )
+
+                release_onnx_runtime_best_effort(wait=False)
+            except Exception:
+                logger.warning("Nie udało się zwolnić runtime ONNX.")
+        state.mark_done(LifecycleStep.CACHE_INVALIDATED)
+
+    def _find_target(
+        self,
+        target_name: str,
+        servers: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        for server in servers:
+            if server.get("name") == target_name:
+                return server
+        raise HTTPException(
+            status_code=404,
+            detail=f"Serwer LLM '{target_name}' nie znaleziony w konfiguracji.",
+        )
+
+    async def _start_and_verify_health(
+        self,
+        target_name: str,
+        target: dict[str, Any],
+        state: LifecycleSwitchState,
+    ) -> Optional[dict[str, Any]]:
+        start_result: Optional[dict[str, Any]] = None
+
+        if target.get("supports", {}).get("start"):
+            try:
+                result = await self._controller.run_action(target_name, "start")
+                start_result = {"ok": result.ok, "exit_code": result.exit_code}
+            except Exception as exc:
+                start_result = {"ok": False, "error": str(exc)}
+
+        state.mark_done(LifecycleStep.START_DONE)
+
+        caps_dict = target.get("capabilities", {})
+        if caps_dict.get("supports_health_wait"):
+            health_url = str(target.get("health_url") or "").strip()
+            if health_url:
+                is_ready = await probe_health_ready(target_name, health_url)
+                if not is_ready:
+                    state.mark_failed(
+                        LifecycleStep.HEALTH_READY,
+                        "Health check timeout - serwer nie odpowiada",
+                    )
+                    raise HTTPException(
+                        status_code=503,
+                        detail="Health check timeout — serwer LLM nie odpowiada po 30s.",
+                    )
+
+        state.mark_done(LifecycleStep.HEALTH_READY)
+        return start_result

--- a/venom_core/services/runtime_switch_service.py
+++ b/venom_core/services/runtime_switch_service.py
@@ -13,6 +13,7 @@ from typing import Any, Optional
 import httpx
 from fastapi import HTTPException
 
+from venom_core.services.onnx_runtime_cleanup import release_onnx_runtime_best_effort
 from venom_core.utils.llm_runtime import LifecycleStep, LifecycleSwitchState
 from venom_core.utils.logger import get_logger
 from venom_core.utils.runtime_names import is_multi_runtime
@@ -69,10 +70,6 @@ async def release_runtime_resources(
 
     if caps.get("is_in_process") and caps.get("supports_cache_flush"):
         try:
-            from venom_core.services.onnx_runtime_cleanup import (  # noqa: PLC0415
-                release_onnx_runtime_best_effort,
-            )
-
             released = release_onnx_runtime_best_effort(wait=False) or released
         except Exception as exc:
             logger.warning("Nie udało się zwolnić runtime ONNX: {}", exc)
@@ -304,10 +301,6 @@ class RuntimeSwitchOrchestrator:
                 logger.warning("Nie udało się zwolnić cache ONNX runtime.")
         else:
             try:
-                from venom_core.services.onnx_runtime_cleanup import (
-                    release_onnx_runtime_best_effort,
-                )
-
                 release_onnx_runtime_best_effort(wait=False)
             except Exception:
                 logger.warning("Nie udało się zwolnić runtime ONNX.")

--- a/venom_core/utils/llm_runtime.py
+++ b/venom_core/utils/llm_runtime.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import hashlib
-from dataclasses import dataclass
-from typing import Optional, Tuple
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Optional, Tuple
 from urllib.parse import urlparse, urlunparse
 
 import httpx
@@ -12,6 +13,64 @@ import httpx
 from venom_core.config import SETTINGS
 from venom_core.utils.runtime_names import MULTI_RUNTIME_ID, is_multi_runtime
 from venom_core.utils.url_policy import apply_http_policy_to_url, build_http_url
+
+
+class LifecycleStep(str, Enum):
+    """Kroki lifecycle switch runtime — używane do śledzenia postępu przełączenia."""
+
+    PROCESS_STOPPED = "process_stopped"
+    RELEASE_DONE = "release_done"
+    CACHE_INVALIDATED = "cache_invalidated"
+    START_DONE = "start_done"
+    HEALTH_READY = "health_ready"
+    ENDPOINT_SWITCHED = "endpoint_switched"
+    CONFIG_SAVED = "config_saved"
+
+
+@dataclass
+class LifecycleSwitchState:
+    """Opisuje stan przełączenia runtime w danym momencie switch flow.
+
+    Umożliwia diagnostykę i detekcję driftu: które kroki zostały wykonane,
+    a które nie. W razie niepowodzenia pozwala określić, w którym miejscu
+    switch się zatrzymał.
+    """
+
+    from_server: str
+    to_server: str
+    completed_steps: List[LifecycleStep] = field(default_factory=list)
+    failed_step: Optional[LifecycleStep] = None
+    error_message: Optional[str] = None
+
+    def mark_done(self, step: LifecycleStep) -> None:
+        if step not in self.completed_steps:
+            self.completed_steps.append(step)
+
+    def mark_failed(self, step: LifecycleStep, error: str) -> None:
+        self.failed_step = step
+        self.error_message = error
+
+    @property
+    def is_complete(self) -> bool:
+        return (
+            self.failed_step is None
+            and LifecycleStep.CONFIG_SAVED in self.completed_steps
+        )
+
+    @property
+    def is_in_partial_state(self) -> bool:
+        return self.failed_step is not None and len(self.completed_steps) > 0
+
+    def to_payload(self) -> dict:
+        return {
+            "from_server": self.from_server,
+            "to_server": self.to_server,
+            "completed_steps": [s.value for s in self.completed_steps],
+            "failed_step": self.failed_step.value if self.failed_step else None,
+            "error_message": self.error_message,
+            "is_complete": self.is_complete,
+            "is_in_partial_state": self.is_in_partial_state,
+        }
 
 
 @dataclass
@@ -281,3 +340,67 @@ async def warmup_local_runtime(
         return response.status_code < 400
     except Exception:
         return False
+
+
+# ---------------------------------------------------------------------------
+# Drift detection (Faza 4 PR 220A)
+# ---------------------------------------------------------------------------
+
+
+def detect_runtime_drift(settings=None) -> dict:
+    """Detect inconsistency between ACTIVE_LLM_SERVER, endpoint, and model.
+
+    Drift occurs when the config keys disagree with each other or with what
+    get_active_llm_runtime() resolves — e.g. ACTIVE_LLM_SERVER says "ollama"
+    but LLM_LOCAL_ENDPOINT points at a vLLM port, or the model name belongs
+    to a different provider than the active server.
+
+    Returns a dict with:
+      - "drift_detected": bool
+      - "active_server": the ACTIVE_LLM_SERVER value
+      - "inferred_provider": what infer_local_provider() resolves from endpoint
+      - "model_name": current LLM_MODEL_NAME
+      - "endpoint": current LLM_LOCAL_ENDPOINT
+      - "issues": list of human-readable inconsistency descriptions
+    """
+    settings = settings or SETTINGS
+    active_server = (getattr(settings, "ACTIVE_LLM_SERVER", "") or "").strip().lower()
+    endpoint = (getattr(settings, "LLM_LOCAL_ENDPOINT", "") or "").strip()
+    model_name = (getattr(settings, "LLM_MODEL_NAME", "") or "").strip()
+    service_type = (getattr(settings, "LLM_SERVICE_TYPE", "local") or "local").lower()
+
+    issues: List[str] = []
+
+    if service_type == "local" and active_server and endpoint:
+        inferred = infer_local_provider(endpoint)
+        if inferred != active_server and active_server not in {"onnx"}:
+            if not (active_server == "ollama" and inferred == "local"):
+                issues.append(
+                    f"ACTIVE_LLM_SERVER='{active_server}' but endpoint "
+                    f"'{endpoint}' maps to provider='{inferred}'"
+                )
+    else:
+        inferred = infer_local_provider(endpoint) if endpoint else ""
+
+    runtime = get_active_llm_runtime(settings)
+    if runtime.provider and active_server and service_type == "local":
+        if (
+            runtime.provider != active_server
+            and not is_multi_runtime(active_server)
+            and not is_multi_runtime(runtime.provider)
+        ):
+            if active_server != "onnx" or runtime.provider != "onnx":
+                if runtime.provider not in {"local"} and active_server not in {"local"}:
+                    issues.append(
+                        f"Resolved runtime provider='{runtime.provider}' differs "
+                        f"from ACTIVE_LLM_SERVER='{active_server}'"
+                    )
+
+    return {
+        "drift_detected": len(issues) > 0,
+        "active_server": active_server,
+        "inferred_provider": inferred if service_type == "local" else service_type,
+        "model_name": model_name,
+        "endpoint": endpoint,
+        "issues": issues,
+    }

--- a/venom_core/utils/llm_runtime.py
+++ b/venom_core/utils/llm_runtime.py
@@ -369,32 +369,28 @@ def detect_runtime_drift(settings=None) -> dict:
     model_name = (getattr(settings, "LLM_MODEL_NAME", "") or "").strip()
     service_type = (getattr(settings, "LLM_SERVICE_TYPE", "local") or "local").lower()
 
+    inferred = _build_inferred_provider(
+        service_type=service_type,
+        endpoint=endpoint,
+    )
     issues: List[str] = []
-
-    if service_type == "local" and active_server and endpoint:
-        inferred = infer_local_provider(endpoint)
-        if inferred != active_server and active_server not in {"onnx"}:
-            if not (active_server == "ollama" and inferred == "local"):
-                issues.append(
-                    f"ACTIVE_LLM_SERVER='{active_server}' but endpoint "
-                    f"'{endpoint}' maps to provider='{inferred}'"
-                )
-    else:
-        inferred = infer_local_provider(endpoint) if endpoint else ""
+    endpoint_issue = _collect_endpoint_provider_issue(
+        service_type=service_type,
+        active_server=active_server,
+        endpoint=endpoint,
+        inferred_provider=inferred,
+    )
+    if endpoint_issue:
+        issues.append(endpoint_issue)
 
     runtime = get_active_llm_runtime(settings)
-    if runtime.provider and active_server and service_type == "local":
-        if (
-            runtime.provider != active_server
-            and not is_multi_runtime(active_server)
-            and not is_multi_runtime(runtime.provider)
-        ):
-            if active_server != "onnx" or runtime.provider != "onnx":
-                if runtime.provider not in {"local"} and active_server not in {"local"}:
-                    issues.append(
-                        f"Resolved runtime provider='{runtime.provider}' differs "
-                        f"from ACTIVE_LLM_SERVER='{active_server}'"
-                    )
+    runtime_issue = _collect_runtime_provider_issue(
+        service_type=service_type,
+        active_server=active_server,
+        runtime_provider=(runtime.provider or "").strip().lower(),
+    )
+    if runtime_issue:
+        issues.append(runtime_issue)
 
     return {
         "drift_detected": len(issues) > 0,
@@ -404,3 +400,69 @@ def detect_runtime_drift(settings=None) -> dict:
         "endpoint": endpoint,
         "issues": issues,
     }
+
+
+def _build_inferred_provider(*, service_type: str, endpoint: str) -> str:
+    if service_type != "local":
+        return service_type
+    return infer_local_provider(endpoint) if endpoint else ""
+
+
+def _collect_endpoint_provider_issue(
+    *,
+    service_type: str,
+    active_server: str,
+    endpoint: str,
+    inferred_provider: str,
+) -> str | None:
+    if service_type != "local":
+        return None
+    if not active_server or not endpoint:
+        return None
+    if active_server == "onnx":
+        return None
+    if inferred_provider == active_server:
+        return None
+    if active_server == "ollama" and inferred_provider == "local":
+        return None
+    if is_multi_runtime(active_server) and is_multi_runtime(inferred_provider):
+        return None
+    return (
+        f"Configured active server '{active_server}' conflicts with endpoint "
+        f"provider '{inferred_provider}' for '{endpoint}'."
+    )
+
+
+def _should_skip_provider_mismatch(
+    *, active_server: str, runtime_provider: str
+) -> bool:
+    if not active_server or not runtime_provider:
+        return True
+    if runtime_provider == active_server:
+        return True
+    if active_server == "local" or runtime_provider == "local":
+        return True
+    if active_server == "onnx" and runtime_provider == "onnx":
+        return True
+    if is_multi_runtime(active_server) or is_multi_runtime(runtime_provider):
+        return True
+    return False
+
+
+def _collect_runtime_provider_issue(
+    *,
+    service_type: str,
+    active_server: str,
+    runtime_provider: str,
+) -> str | None:
+    if service_type != "local":
+        return None
+    if _should_skip_provider_mismatch(
+        active_server=active_server,
+        runtime_provider=runtime_provider,
+    ):
+        return None
+    return (
+        f"Resolved runtime provider '{runtime_provider}' differs from configured "
+        f"ACTIVE_LLM_SERVER '{active_server}'."
+    )


### PR DESCRIPTION
## Summary

- **Faza 1**: `RuntimeCapabilities` dataclass added to `LlmServerController` — formal per-server lifecycle contract (stop/start/restart/health_wait/cache_flush/model_unload/is_in_process/release_wait_seconds) with per-server defaults for ollama/vllm/multi_runtime/onnx
- **Faza 2**: `RuntimeSwitchOrchestrator` service in `runtime_switch_service.py` centralizes the full switch sequence: stop → await_release → flush_caches → start → health_check; config/endpoint saved **only** after `HEALTH_READY` confirmed (previously config was written even on health timeout)
- **Faza 3**: Pre-stop Ollama VRAM unload via `keep_alive=0` before daemon stop; ONNX best-effort in-process cleanup hooks; injected `onnx_flush_fn` for testability
- **Faza 4**: `LifecycleStep` + `LifecycleSwitchState` track switch progress; `detect_runtime_drift()` exposed in `GET /system/llm/info` response; loguru `%s` → `{}` bugs fixed across 4 files
- **Faza 5**: 15 regression tests in `tests/test_220a_runtime_lifecycle.py` covering switch flow, health-timeout prevents config write, ONNX cleanup failure resilience, drift detection scenarios, orchestrator pre-stop unload

## Test plan

- [ ] `make agent-pr-fast` passes (135 tests, all green)
- [ ] `tests/test_220a_runtime_lifecycle.py` — 15 tests: RuntimeCapabilities contract, LifecycleSwitchState tracking, ollama↔multi_runtime switch, health timeout blocks config save, drift detection
- [ ] `tests/test_llm_server_selection.py` — existing suite stays green with updated autouse fixture patching `runtime_switch_service.probe_until_shutdown`
- [ ] Manual: `GET /system/llm/info` now includes `drift` field in response
- [ ] Manual: switching runtimes returns `lifecycle_state` with completed steps in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)