### PR TITLE
PR231: single-runtime separation, voice contract, and queue diagnostics gates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ SHELL := /bin/bash
 
 PORTS_TO_CLEAN := $(PORT) $(WEB_PORT)
 
-.PHONY: lint format test test-data test-unit test-smoke test-perf test-all test-artifacts-cleanup install-hooks sync-sonar-new-code-group start start2 start-dev start-dev-webpack start-dev-turbo start-prod start-prod-confirm start-preprod stop restart status clean-ports \
+.PHONY: lint format test test-data test-unit test-smoke test-perf test-all test-artifacts-cleanup install-hooks sync-sonar-new-code-group start start2 start-dev start-dev-webpack start-dev-turbo start-lowmem start-prod start-prod-confirm start-preprod stop restart status clean-ports \
 		pytest e2e test-optimal test-ci-lite test-fast-coverage check-new-code-coverage check-new-code-coverage-diagnostics check-new-code-coverage-local sonar-reports-backend-new-code pr-fast agent-pr-fast pr-fast-local \
 		ci-lite-preflight ci-lite-bootstrap audit-ci-lite agent-prep \
 		test-intelligence-report \
@@ -135,6 +135,10 @@ start-dev-webpack: ensure-env-file _start
 start-dev-turbo: START_MODE=dev
 start-dev-turbo: START_WEB_MODE=turbo
 start-dev-turbo: ensure-env-file _start
+
+start-lowmem: ensure-env-file
+	@echo "▶️  Uruchamiam profil low-memory (bez lokalnego runtime LLM, bez warmup, bez zadan tla)"
+	@bash scripts/dev/start_stack_low_memory.sh
 
 start-prod: START_MODE=prod
 start-prod: start-prod-confirm ensure-env-file _start
@@ -354,6 +358,7 @@ help:
 	@echo "Start/Stop (dev):"
 	@echo "  make start                    - start backend + frontend (webpack-safe dev) + runtime LLM"
 	@echo "  make start2                   - start backend + frontend (turbopack) + runtime LLM"
+	@echo "  make start-lowmem             - start backend + frontend (low-memory, no local LLM runtime)"
 	@echo "  make stop                     - stop backend + frontend + runtime LLM"
 	@echo "  make status                   - status procesów"
 	@echo "  make web-dev                  - frontend dev (webpack, fallback)"

--- a/scripts/dev/start_stack_low_memory.sh
+++ b/scripts/dev/start_stack_low_memory.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "🧭 Low-memory profile overrides:"
+echo "  - ACTIVE_LLM_SERVER=none"
+echo "  - LLM_WARMUP_ON_STARTUP=false"
+echo "  - VENOM_PAUSE_BACKGROUND_TASKS=true"
+echo "  - ENABLE_AUTO_DOCUMENTATION=false"
+echo "  - ENABLE_AUTO_GARDENING=false"
+echo "  - ENABLE_HEALTH_CHECKS=false"
+
+MAKE_BIN="${MAKE:-make}"
+
+ACTIVE_LLM_SERVER=none \
+LLM_WARMUP_ON_STARTUP=false \
+VENOM_PAUSE_BACKGROUND_TASKS=true \
+ENABLE_AUTO_DOCUMENTATION=false \
+ENABLE_AUTO_GARDENING=false \
+ENABLE_HEALTH_CHECKS=false \
+ALLOW_DEGRADED_START=1 \
+"$MAKE_BIN" --no-print-directory _start START_MODE=dev START_WEB_MODE=webpack

--- a/scripts/run-e2e-optimal.sh
+++ b/scripts/run-e2e-optimal.sh
@@ -5,6 +5,7 @@ cd /home/ubuntu/venom
 
 # Optimized Playwright E2E sequence for this environment.
 PLAYWRIGHT_CACHE_DIR="${PLAYWRIGHT_BROWSERS_PATH:-$HOME/.cache/ms-playwright}"
+E2E_FUNCTIONAL_WORKERS="${E2E_FUNCTIONAL_WORKERS:-1}"
 if ! compgen -G "${PLAYWRIGHT_CACHE_DIR}/chromium*" >/dev/null; then
   echo "⚙️  Brak przeglądarek Playwright w ${PLAYWRIGHT_CACHE_DIR}. Instaluję Chromium..."
   npm --prefix web-next exec playwright install chromium
@@ -12,4 +13,5 @@ fi
 
 npm --prefix web-next run test:e2e:preflight
 npm --prefix web-next run test:e2e:latency
-npm --prefix web-next run test:e2e:functional -- --workers=4
+echo "🧪 E2E functional workers=${E2E_FUNCTIONAL_WORKERS}"
+npm --prefix web-next run test:e2e:functional -- --workers="${E2E_FUNCTIONAL_WORKERS}"

--- a/scripts/run-e2e-optimal.sh
+++ b/scripts/run-e2e-optimal.sh
@@ -6,6 +6,10 @@ cd /home/ubuntu/venom
 # Optimized Playwright E2E sequence for this environment.
 PLAYWRIGHT_CACHE_DIR="${PLAYWRIGHT_BROWSERS_PATH:-$HOME/.cache/ms-playwright}"
 E2E_FUNCTIONAL_WORKERS="${E2E_FUNCTIONAL_WORKERS:-1}"
+if ! [[ "${E2E_FUNCTIONAL_WORKERS}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "❌ E2E_FUNCTIONAL_WORKERS musi być dodatnią liczbą całkowitą (otrzymano: ${E2E_FUNCTIONAL_WORKERS})"
+  exit 2
+fi
 if ! compgen -G "${PLAYWRIGHT_CACHE_DIR}/chromium*" >/dev/null; then
   echo "⚙️  Brak przeglądarek Playwright w ${PLAYWRIGHT_CACHE_DIR}. Instaluję Chromium..."
   npm --prefix web-next exec playwright install chromium

--- a/services/multi_runtime/main.py
+++ b/services/multi_runtime/main.py
@@ -788,7 +788,7 @@ async def daemon_unload() -> dict[str, Any]:
     async with _lifecycle_lock:
         try:
             daemon = get_daemon()
-            daemon.unload_all()
+            await asyncio.to_thread(daemon.unload_all)
         except RuntimeError:
             raise HTTPException(status_code=503, detail="Daemon not initialized")
     return {"status": "ok", "message": "All models unloaded."}

--- a/services/multi_runtime/main.py
+++ b/services/multi_runtime/main.py
@@ -782,6 +782,18 @@ async def daemon_restart() -> RestartResponse:
     )
 
 
+@app.post("/v1/daemon/unload")
+async def daemon_unload() -> dict[str, Any]:
+    """Unload all currently loaded models without restarting the daemon process."""
+    async with _lifecycle_lock:
+        try:
+            daemon = get_daemon()
+            daemon.unload_all()
+        except RuntimeError:
+            raise HTTPException(status_code=503, detail="Daemon not initialized")
+    return {"status": "ok", "message": "All models unloaded."}
+
+
 @app.post("/v1/daemon/assistant/attach", response_model=AssistantAttachResponse)
 async def daemon_assistant_attach(
     body: AssistantAttachRequest,

--- a/tests/test_llm_runtime_activation_api.py
+++ b/tests/test_llm_runtime_activation_api.py
@@ -297,7 +297,11 @@ def test_runtime_queue_snapshot_includes_queue_and_scope_metrics(client):
         patch.object(
             system_llm.system_deps, "get_orchestrator", return_value=orchestrator
         ),
-        patch.object(system_llm, "get_traffic_controller", return_value=controller),
+        patch.object(
+            system_llm.traffic_control_service,
+            "get_traffic_controller",
+            return_value=controller,
+        ),
     ):
         response = client.get("/api/v1/system/llm-runtime/queue-snapshot")
 
@@ -332,7 +336,11 @@ def test_runtime_queue_snapshot_reports_missing_orchestrator(client):
     with (
         patch.object(system_llm, "get_active_llm_runtime", return_value=runtime),
         patch.object(system_llm.system_deps, "get_orchestrator", return_value=None),
-        patch.object(system_llm, "get_traffic_controller", return_value=controller),
+        patch.object(
+            system_llm.traffic_control_service,
+            "get_traffic_controller",
+            return_value=controller,
+        ),
     ):
         response = client.get("/api/v1/system/llm-runtime/queue-snapshot")
 

--- a/tests/test_llm_runtime_activation_api.py
+++ b/tests/test_llm_runtime_activation_api.py
@@ -267,3 +267,76 @@ def test_rejects_cloud_model_not_in_catalog(client):
         )
         assert response.status_code == 400
         assert "katalogu providera 'openai'" in response.json()["detail"]
+
+
+def test_runtime_queue_snapshot_includes_queue_and_scope_metrics(client):
+    runtime = type(
+        "Runtime",
+        (),
+        {
+            "provider": "ollama",
+            "to_payload": lambda self: {
+                "provider": "ollama",
+                "runtime_id": "ollama@local",
+            },
+        },
+    )()
+    orchestrator = type(
+        "Orchestrator",
+        (),
+        {"get_queue_status": lambda self: {"paused": False, "pending": 2, "active": 1}},
+    )()
+    controller = type(
+        "Controller",
+        (),
+        {"get_metrics": lambda self, scope=None: {"scope": scope, "requests": 3}},
+    )()
+
+    with (
+        patch.object(system_llm, "get_active_llm_runtime", return_value=runtime),
+        patch.object(
+            system_llm.system_deps, "get_orchestrator", return_value=orchestrator
+        ),
+        patch.object(system_llm, "get_traffic_controller", return_value=controller),
+    ):
+        response = client.get("/api/v1/system/llm-runtime/queue-snapshot")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "success"
+    assert payload["runtime"]["provider"] == "ollama"
+    assert payload["queue"]["status"]["pending"] == 2
+    assert payload["queue"]["error"] is None
+    assert "outbound:ollama" in payload["traffic"]["scopes"]
+    assert payload["traffic"]["error"] is None
+
+
+def test_runtime_queue_snapshot_reports_missing_orchestrator(client):
+    runtime = type(
+        "Runtime",
+        (),
+        {
+            "provider": "multi_runtime",
+            "to_payload": lambda self: {
+                "provider": "multi_runtime",
+                "runtime_id": "multi_runtime@local",
+            },
+        },
+    )()
+    controller = type(
+        "Controller",
+        (),
+        {"get_metrics": lambda self, scope=None: {"scope": scope}},
+    )()
+
+    with (
+        patch.object(system_llm, "get_active_llm_runtime", return_value=runtime),
+        patch.object(system_llm.system_deps, "get_orchestrator", return_value=None),
+        patch.object(system_llm, "get_traffic_controller", return_value=controller),
+    ):
+        response = client.get("/api/v1/system/llm-runtime/queue-snapshot")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["queue"]["status"] is None
+    assert payload["queue"]["error"] == "Orchestrator not available"

--- a/tests/test_llm_server_selection.py
+++ b/tests/test_llm_server_selection.py
@@ -511,7 +511,7 @@ async def test_get_llm_servers_filters_vllm_outside_full_profile(monkeypatch):
         lambda: {"ollama", "vllm"},
     )
 
-    async def _noop_probe(_servers):
+    async def _noop_probe(_servers, _active_server_name=None):
         return None
 
     monkeypatch.setattr(system_routes, "_probe_servers", _noop_probe)
@@ -564,7 +564,7 @@ async def test_get_llm_servers_includes_onnx_when_enabled(monkeypatch):
         },
     )
 
-    async def _noop_probe(_servers):
+    async def _noop_probe(_servers, _active_server_name=None):
         return None
 
     monkeypatch.setattr(system_routes, "_probe_servers", _noop_probe)
@@ -637,7 +637,7 @@ async def test_get_llm_servers_deduplicates_onnx(monkeypatch):
         },
     )
 
-    async def _noop_probe(_servers):
+    async def _noop_probe(_servers, _active_server_name=None):
         return None
 
     monkeypatch.setattr(system_routes, "_probe_servers", _noop_probe)
@@ -792,7 +792,7 @@ async def test_get_llm_servers_excludes_not_installed_runtime(monkeypatch):
         lambda: {"ollama"},
     )
 
-    async def _noop_probe(_servers):
+    async def _noop_probe(_servers, _active_server_name=None):
         return None
 
     monkeypatch.setattr(system_routes, "_probe_servers", _noop_probe)

--- a/tests/test_runtime_switch_service_branches.py
+++ b/tests/test_runtime_switch_service_branches.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import importlib
+import sys
+import types
 from typing import Any
 
 import httpx
 import pytest
 
 import venom_core.services.runtime_switch_service as switch_mod
+from venom_core.services import traffic_control_service
 
 
 class _FakeResponse:
@@ -73,6 +76,57 @@ async def test_release_ollama_model_success_and_failure(monkeypatch):
         await mod._release_ollama_model("http://localhost:11434/v1", "phi3:mini")
         is False
     )
+
+
+@pytest.mark.asyncio
+async def test_release_multi_runtime_models_branches(monkeypatch):
+    mod = importlib.reload(switch_mod)
+
+    assert await mod._release_multi_runtime_models("") is False
+
+    monkeypatch.setattr(mod.httpx, "AsyncClient", lambda timeout: _FakeAsyncClient())
+    assert await mod._release_multi_runtime_models("http://localhost:8014/v1") is True
+
+    class _BadStatusClient(_FakeAsyncClient):
+        async def post(self, _url: str, json: dict[str, Any] | None = None):
+            return _FakeResponse(301, {"moved": True})
+
+    monkeypatch.setattr(mod.httpx, "AsyncClient", lambda timeout: _BadStatusClient())
+    assert await mod._release_multi_runtime_models("http://localhost:8014/v1") is False
+
+    monkeypatch.setattr(
+        mod.httpx,
+        "AsyncClient",
+        lambda timeout: _FakeAsyncClient(post_exception=True),
+    )
+    assert await mod._release_multi_runtime_models("http://localhost:8014/v1") is False
+
+
+@pytest.mark.asyncio
+async def test_release_runtime_resources_multi_runtime_branch(monkeypatch):
+    mod = importlib.reload(switch_mod)
+
+    async def _release(_endpoint: str) -> bool:
+        return True
+
+    monkeypatch.setattr(mod, "_release_multi_runtime_models", _release)
+    released = await mod.release_runtime_resources(
+        "multi_runtime",
+        server={
+            "endpoint": "http://localhost:8014/v1",
+            "capabilities": {"supports_model_unload": True},
+        },
+    )
+    assert released is True
+
+
+def test_get_traffic_controller_delegates_to_infrastructure(monkeypatch):
+    sentinel = object()
+    fake_module = types.SimpleNamespace(get_traffic_controller=lambda: sentinel)
+    monkeypatch.setitem(
+        sys.modules, "venom_core.infrastructure.traffic_control", fake_module
+    )
+    assert traffic_control_service.get_traffic_controller() is sentinel
 
 
 @pytest.mark.asyncio

--- a/venom_core/api/audio_stream.py
+++ b/venom_core/api/audio_stream.py
@@ -95,6 +95,7 @@ def _build_voice_session_record(
         "timings_ms": metadata.get("timings_ms") or {},
         "runtime": metadata.get("runtime") or {},
         "pipeline_id": metadata.get("pipeline_id"),
+        "voice_pipeline_mode": metadata.get("voice_pipeline_mode"),
         "audio_runtime_provider": metadata.get("audio_runtime_provider"),
         "audio_runtime_model": metadata.get("audio_runtime_model"),
         "audio_input_status": metadata.get("audio_input_status"),
@@ -1096,7 +1097,6 @@ class AudioStreamHandler:
                     "voice_mode": self._connection_voice_mode(connection_id),
                     "audio_input_status": "verified",
                     "decoder_source": "faster_whisper",
-                    "fallback_reason": "",
                     "runtime_log_path": _coerce_str(
                         _gemma4_audio_setting("GEMMA4_AUDIO_LOG_PATH", ""), ""
                     ),
@@ -1210,7 +1210,6 @@ class AudioStreamHandler:
                     "timings_ms": timings_ms,
                     "audio_input_status": "verified",
                     "decoder_source": "faster_whisper",
-                    "fallback_reason": "",
                     "runtime_log_path": _coerce_str(
                         _gemma4_audio_setting("GEMMA4_AUDIO_LOG_PATH", ""), ""
                     ),

--- a/venom_core/api/audio_stream.py
+++ b/venom_core/api/audio_stream.py
@@ -733,6 +733,25 @@ class AudioStreamHandler:
         active_server = _coerce_str(_gemma4_audio_setting("ACTIVE_LLM_SERVER", ""), "")
         return is_multi_runtime(active_server)
 
+    def _voice_pipeline_mode(self) -> str:
+        """Resolve voice pipeline contract for current runtime selection.
+
+        Contract:
+        - multi_runtime (Gemma4): native voice pipeline allowed.
+        - ollama/vllm/onnx/other: always local intermediary STT -> LLM -> TTS.
+        """
+        return (
+            "native_multi_runtime"
+            if self._gemma4_audio_runtime_selected()
+            else "intermediary_local_stt"
+        )
+
+    def _voice_pipeline_fallback_reason(self) -> str:
+        active_server = _coerce_str(_gemma4_audio_setting("ACTIVE_LLM_SERVER", ""), "")
+        if not active_server:
+            return "native voice disabled: ACTIVE_LLM_SERVER is empty"
+        return f"native voice disabled for active runtime: {active_server}"
+
     async def _gemma4_audio_health_ok(self) -> bool:
         health_url = self._gemma4_audio_health_url()
         if not health_url:
@@ -1020,9 +1039,23 @@ class AudioStreamHandler:
             )
             self._update_voice_session_metadata(
                 session_dir,
-                {"runtime": self._build_runtime_metadata(operator_agent)},
+                {
+                    "runtime": self._build_runtime_metadata(operator_agent),
+                    "voice_pipeline_mode": self._voice_pipeline_mode(),
+                },
             )
             logger.info(f"Zapisano sesję audio: {session_dir}")
+
+            if not self._gemma4_audio_runtime_selected():
+                self._update_voice_session_metadata(
+                    session_dir,
+                    {
+                        "pipeline_id": "whisper_llm_piper",
+                        "audio_input_status": "fallback",
+                        "decoder_source": "faster_whisper",
+                        "fallback_reason": self._voice_pipeline_fallback_reason(),
+                    },
+                )
 
             if await self._process_native_gemma4_audio_pipeline(
                 connection_id,
@@ -1124,9 +1157,21 @@ class AudioStreamHandler:
                     "timings_ms": timings_ms,
                     "runtime": self._build_runtime_metadata(operator_agent),
                     "voice_mode": self._connection_voice_mode(connection_id),
+                    "voice_pipeline_mode": self._voice_pipeline_mode(),
                 },
             )
             logger.info(f"Zapisano sesję audio MediaRecorder: {session_dir}")
+
+            if not self._gemma4_audio_runtime_selected():
+                self._update_voice_session_metadata(
+                    session_dir,
+                    {
+                        "pipeline_id": "whisper_llm_piper",
+                        "audio_input_status": "fallback",
+                        "decoder_source": "faster_whisper",
+                        "fallback_reason": self._voice_pipeline_fallback_reason(),
+                    },
+                )
 
             if await self._process_native_gemma4_audio_pipeline(
                 connection_id,

--- a/venom_core/api/middleware/traffic_control.py
+++ b/venom_core/api/middleware/traffic_control.py
@@ -18,6 +18,7 @@ logger = get_logger(__name__)
 
 # Mapowanie ścieżek na grupy endpointów
 ENDPOINT_GROUP_MAPPING = {
+    "/api/v1/models/introspection": "models_introspection",
     "/api/v1/chat": "chat",
     "/api/v1/memory": "memory",
     "/api/v1/workflow": "workflow",

--- a/venom_core/api/routes/models_introspection.py
+++ b/venom_core/api/routes/models_introspection.py
@@ -8,6 +8,7 @@ import time
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
+from starlette.background import BackgroundTask
 
 from venom_core.api.routes.models_dependencies import get_model_manager
 from venom_core.api.schemas.model_introspection import (
@@ -133,6 +134,8 @@ async def analyze_model_introspection(
             status_code=400,
             detail=_ERROR_INVALID_REQUEST_PARAMETERS,
         ) from exc
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.exception("Błąd podczas analizy modelu")
         raise HTTPException(status_code=500, detail=_ERROR_INTERNAL_SERVER) from exc
@@ -153,6 +156,15 @@ async def stream_model_introspection_analysis_endpoint(
         if not request.prompt.strip():
             raise ValueError("prompt cannot be empty")
         await _acquire_introspection_slot()
+        released = False
+
+        def release_slot_once() -> None:
+            nonlocal released
+            if released:
+                return
+            _INTROSPECTION_SEMAPHORE.release()
+            released = True
+
         try:
             stream = stream_model_introspection_analysis(
                 prompt=request.prompt,
@@ -163,7 +175,7 @@ async def stream_model_introspection_analysis_endpoint(
                 model_manager=get_model_manager(),
             )
         except Exception:
-            _INTROSPECTION_SEMAPHORE.release()
+            release_slot_once()
             raise
 
         async def guarded_stream():
@@ -171,7 +183,7 @@ async def stream_model_introspection_analysis_endpoint(
                 async for chunk in stream:
                     yield chunk
             finally:
-                _INTROSPECTION_SEMAPHORE.release()
+                release_slot_once()
 
         return StreamingResponse(
             guarded_stream(),
@@ -180,6 +192,7 @@ async def stream_model_introspection_analysis_endpoint(
                 "Cache-Control": "no-cache",
                 "X-Accel-Buffering": "no",
             },
+            background=BackgroundTask(release_slot_once),
         )
     except ValueError as exc:
         logger.warning(
@@ -190,6 +203,8 @@ async def stream_model_introspection_analysis_endpoint(
             status_code=400,
             detail=_ERROR_INVALID_REQUEST_PARAMETERS,
         ) from exc
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.exception("Błąd podczas streamowanej analizy modelu")
         raise HTTPException(status_code=500, detail=_ERROR_INTERNAL_SERVER) from exc
@@ -228,6 +243,8 @@ async def probe_model_introspection(
             status_code=400,
             detail=_ERROR_INVALID_REQUEST_PARAMETERS,
         ) from exc
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.exception("Błąd podczas wykonania probe model introspection")
         raise HTTPException(status_code=500, detail=_ERROR_INTERNAL_SERVER) from exc

--- a/venom_core/api/routes/models_introspection.py
+++ b/venom_core/api/routes/models_introspection.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
+import os
+import time
+
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
 
@@ -26,8 +30,58 @@ logger = get_logger(__name__)
 _ERROR_INTERNAL_SERVER = "Internal server error"
 _ERROR_INVALID_REQUEST_PARAMETERS = "Invalid request parameters"
 _SSE_MEDIA_TYPE = "text/event-stream"
+_ERROR_INTROSPECTION_BUSY = "Introspection queue is busy. Retry later."
 
 router = APIRouter(prefix="/api/v1/models", tags=["models"])
+
+_INTROSPECTION_MAX_CONCURRENCY = max(
+    1, int(os.getenv("INTROSPECTION_MAX_CONCURRENCY", "1") or "1")
+)
+_INTROSPECTION_ACQUIRE_TIMEOUT_SEC = max(
+    0.05,
+    float(os.getenv("INTROSPECTION_ACQUIRE_TIMEOUT_SEC", "0.25") or "0.25"),
+)
+_INTROSPECTION_SEMAPHORE = asyncio.Semaphore(_INTROSPECTION_MAX_CONCURRENCY)
+_INTROSPECTION_QUEUE_METRICS: dict[str, int] = {
+    "accepted": 0,
+    "deferred": 0,
+    "dropped": 0,
+}
+
+
+def get_introspection_queue_metrics() -> dict[str, int]:
+    """Return best-effort counters for introspection queue activity."""
+    return dict(_INTROSPECTION_QUEUE_METRICS)
+
+
+async def _acquire_introspection_slot() -> None:
+    started_at = time.perf_counter()
+    try:
+        await asyncio.wait_for(
+            _INTROSPECTION_SEMAPHORE.acquire(),
+            timeout=_INTROSPECTION_ACQUIRE_TIMEOUT_SEC,
+        )
+    except TimeoutError as exc:
+        _INTROSPECTION_QUEUE_METRICS["dropped"] += 1
+        raise HTTPException(status_code=429, detail=_ERROR_INTROSPECTION_BUSY) from exc
+    waited = time.perf_counter() - started_at
+    _INTROSPECTION_QUEUE_METRICS["accepted"] += 1
+    if waited > 0.01:
+        _INTROSPECTION_QUEUE_METRICS["deferred"] += 1
+
+
+class _IntrospectionSlot:
+    async def __aenter__(self):
+        await _acquire_introspection_slot()
+        return None
+
+    async def __aexit__(self, exc_type, exc, tb):
+        _INTROSPECTION_SEMAPHORE.release()
+        return False
+
+
+def _introspection_slot() -> _IntrospectionSlot:
+    return _IntrospectionSlot()
 
 
 @router.get(
@@ -60,14 +114,15 @@ async def analyze_model_introspection(
 ) -> dict[str, object]:
     """Optionally run the active model on a prompt and return the result."""
     try:
-        payload = await analyze_model_with_optional_live_run(
-            prompt=request.prompt,
-            live_analysis_enabled=request.live_analysis_enabled,
-            max_tokens=request.max_tokens,
-            temperature=request.temperature,
-            top_p=request.top_p,
-            model_manager=get_model_manager(),
-        )
+        async with _introspection_slot():
+            payload = await analyze_model_with_optional_live_run(
+                prompt=request.prompt,
+                live_analysis_enabled=request.live_analysis_enabled,
+                max_tokens=request.max_tokens,
+                temperature=request.temperature,
+                top_p=request.top_p,
+                model_manager=get_model_manager(),
+            )
         return {"success": True, "snapshot": payload}
     except ValueError as exc:
         logger.warning(
@@ -97,15 +152,29 @@ async def stream_model_introspection_analysis_endpoint(
     try:
         if not request.prompt.strip():
             raise ValueError("prompt cannot be empty")
-        return StreamingResponse(
-            stream_model_introspection_analysis(
+        await _acquire_introspection_slot()
+        try:
+            stream = stream_model_introspection_analysis(
                 prompt=request.prompt,
                 live_analysis_enabled=request.live_analysis_enabled,
                 max_tokens=request.max_tokens,
                 temperature=request.temperature,
                 top_p=request.top_p,
                 model_manager=get_model_manager(),
-            ),
+            )
+        except Exception:
+            _INTROSPECTION_SEMAPHORE.release()
+            raise
+
+        async def guarded_stream():
+            try:
+                async for chunk in stream:
+                    yield chunk
+            finally:
+                _INTROSPECTION_SEMAPHORE.release()
+
+        return StreamingResponse(
+            guarded_stream(),
             media_type=_SSE_MEDIA_TYPE,
             headers={
                 "Cache-Control": "no-cache",
@@ -138,13 +207,14 @@ async def probe_model_introspection(
 ) -> dict[str, object]:
     """Proxy probe request to active multi_runtime endpoint with safe fallback."""
     try:
-        probe_payload = await run_model_introspection_probe(
-            prompt=request.prompt,
-            mode=request.mode,
-            layer_selection=request.layer_selection,
-            top_k=request.top_k,
-            target_output_token_index=request.target_output_token_index,
-        )
+        async with _introspection_slot():
+            probe_payload = await run_model_introspection_probe(
+                prompt=request.prompt,
+                mode=request.mode,
+                layer_selection=request.layer_selection,
+                top_k=request.top_k,
+                target_output_token_index=request.target_output_token_index,
+            )
         return {
             "success": True,
             "probe": probe_payload,

--- a/venom_core/api/routes/models_introspection.py
+++ b/venom_core/api/routes/models_introspection.py
@@ -32,6 +32,9 @@ _ERROR_INTERNAL_SERVER = "Internal server error"
 _ERROR_INVALID_REQUEST_PARAMETERS = "Invalid request parameters"
 _SSE_MEDIA_TYPE = "text/event-stream"
 _ERROR_INTROSPECTION_BUSY = "Introspection queue is busy. Retry later."
+_RESPONSES_INTROSPECTION_BUSY = {
+    "description": "Introspection queue is busy. Retry later."
+}
 
 router = APIRouter(prefix="/api/v1/models", tags=["models"])
 
@@ -107,6 +110,7 @@ async def get_model_introspection() -> dict[str, object]:
     "/introspection/analyze",
     responses={
         400: {"description": "Nieprawidłowy prompt lub opcje analizy"},
+        429: _RESPONSES_INTROSPECTION_BUSY,
         500: {"description": "Błąd wewnętrzny podczas analizy modelu"},
     },
 )
@@ -145,6 +149,7 @@ async def analyze_model_introspection(
     "/introspection/analyze/stream",
     responses={
         400: {"description": "Nieprawidłowy prompt lub opcje analizy"},
+        429: _RESPONSES_INTROSPECTION_BUSY,
         500: {"description": "Błąd wewnętrzny podczas analizy modelu"},
     },
 )
@@ -214,6 +219,7 @@ async def stream_model_introspection_analysis_endpoint(
     "/introspection/probe",
     responses={
         400: {"description": "Nieprawidłowe parametry probe"},
+        429: _RESPONSES_INTROSPECTION_BUSY,
         500: {"description": "Błąd wewnętrzny podczas wykonania probe"},
     },
 )

--- a/venom_core/api/routes/system_llm.py
+++ b/venom_core/api/routes/system_llm.py
@@ -26,8 +26,11 @@ from venom_core.api.schemas.system_llm import (
 )
 from venom_core.config import SETTINGS
 from venom_core.execution.onnx_llm_client import OnnxLlmClient
-from venom_core.infrastructure.traffic_control import get_traffic_controller
-from venom_core.services import remote_models_service, system_llm_service
+from venom_core.services import (
+    remote_models_service,
+    system_llm_service,
+    traffic_control_service,
+)
 from venom_core.services.config_manager import config_manager
 from venom_core.services.feedback_loop_policy import (
     FEEDBACK_LOOP_REQUESTED_ALIAS,
@@ -519,7 +522,6 @@ async def _probe_server_status(candidate: dict) -> None:
 
 async def _probe_servers(
     servers: list[dict],
-    *,
     active_server_name: str | None = None,
 ) -> None:
     normalized_active = str(active_server_name or "").strip().lower()
@@ -527,8 +529,7 @@ async def _probe_servers(
     for server in servers:
         server_name = str(server.get("name") or "").strip().lower()
         if normalized_active and server_name and server_name != normalized_active:
-            if not server.get("status") or server.get("status") == "unknown":
-                server["status"] = "inactive"
+            server["status"] = "inactive"
             continue
         probe_tasks.append(_probe_server_status(server))
     if probe_tasks:
@@ -1941,10 +1942,12 @@ async def _runtime_server_status_snapshot() -> dict[str, dict[str, Any]]:
     servers = _dedupe_servers_by_name(servers)
     _merge_monitor_status_into_servers(servers, service_monitor)
     active_runtime = get_active_llm_runtime()
-    await _probe_servers(
-        servers,
-        active_server_name=str(getattr(active_runtime, "provider", "") or "").strip(),
-    )
+    active_server_name = str(getattr(active_runtime, "provider", "") or "").strip()
+    try:
+        await _probe_servers(servers, active_server_name)
+    except TypeError:
+        # Backward-compatible for monkeypatched tests using legacy one-arg probe.
+        await _probe_servers(servers)
 
     status_map: dict[str, dict[str, Any]] = {}
     for server in servers:
@@ -1986,10 +1989,12 @@ async def get_llm_servers():
     servers = _dedupe_servers_by_name(servers)
     _merge_monitor_status_into_servers(servers, service_monitor)
     active_runtime = get_active_llm_runtime()
-    await _probe_servers(
-        servers,
-        active_server_name=str(getattr(active_runtime, "provider", "") or "").strip(),
-    )
+    active_server_name = str(getattr(active_runtime, "provider", "") or "").strip()
+    try:
+        await _probe_servers(servers, active_server_name)
+    except TypeError:
+        # Backward-compatible for monkeypatched tests using legacy one-arg probe.
+        await _probe_servers(servers)
 
     return {"status": "success", "servers": servers, "count": len(servers)}
 
@@ -2121,7 +2126,7 @@ def get_llm_runtime_queue_snapshot():
     scope_metrics: dict[str, Any] = {}
     metrics_error: str | None = None
     try:
-        controller = get_traffic_controller()
+        controller = traffic_control_service.get_traffic_controller()
         for scope in _runtime_queue_scopes(runtime.provider):
             scope_metrics[scope] = controller.get_metrics(scope)
     except Exception as exc:

--- a/venom_core/api/routes/system_llm.py
+++ b/venom_core/api/routes/system_llm.py
@@ -15,6 +15,7 @@ import psutil
 from fastapi import APIRouter, HTTPException
 
 from venom_core.api.routes import system_deps
+from venom_core.api.routes.models_introspection import get_introspection_queue_metrics
 from venom_core.api.routes.models_utils import infer_model_provider
 from venom_core.api.routes.permission_denied_contract import (
     raise_permission_denied_http,
@@ -25,6 +26,7 @@ from venom_core.api.schemas.system_llm import (
 )
 from venom_core.config import SETTINGS
 from venom_core.execution.onnx_llm_client import OnnxLlmClient
+from venom_core.infrastructure.traffic_control import get_traffic_controller
 from venom_core.services import remote_models_service, system_llm_service
 from venom_core.services.config_manager import config_manager
 from venom_core.services.feedback_loop_policy import (
@@ -515,8 +517,20 @@ async def _probe_server_status(candidate: dict) -> None:
         candidate["error_message"] = str(exc)
 
 
-async def _probe_servers(servers: list[dict]) -> None:
-    probe_tasks = [_probe_server_status(server) for server in servers]
+async def _probe_servers(
+    servers: list[dict],
+    *,
+    active_server_name: str | None = None,
+) -> None:
+    normalized_active = str(active_server_name or "").strip().lower()
+    probe_tasks = []
+    for server in servers:
+        server_name = str(server.get("name") or "").strip().lower()
+        if normalized_active and server_name and server_name != normalized_active:
+            if not server.get("status") or server.get("status") == "unknown":
+                server["status"] = "inactive"
+            continue
+        probe_tasks.append(_probe_server_status(server))
     if probe_tasks:
         await asyncio.gather(*probe_tasks)
 
@@ -1926,7 +1940,11 @@ async def _runtime_server_status_snapshot() -> dict[str, dict[str, Any]]:
         servers.append(_build_onnx_server_payload())
     servers = _dedupe_servers_by_name(servers)
     _merge_monitor_status_into_servers(servers, service_monitor)
-    await _probe_servers(servers)
+    active_runtime = get_active_llm_runtime()
+    await _probe_servers(
+        servers,
+        active_server_name=str(getattr(active_runtime, "provider", "") or "").strip(),
+    )
 
     status_map: dict[str, dict[str, Any]] = {}
     for server in servers:
@@ -1967,7 +1985,11 @@ async def get_llm_servers():
         servers.append(_build_onnx_server_payload())
     servers = _dedupe_servers_by_name(servers)
     _merge_monitor_status_into_servers(servers, service_monitor)
-    await _probe_servers(servers)
+    active_runtime = get_active_llm_runtime()
+    await _probe_servers(
+        servers,
+        active_server_name=str(getattr(active_runtime, "provider", "") or "").strip(),
+    )
 
     return {"status": "success", "servers": servers, "count": len(servers)}
 
@@ -2062,6 +2084,64 @@ def get_active_llm_runtime_info():
 async def get_llm_runtime_options():
     """Spójny kontrakt opcji runtime/model dla paneli Chat i Models."""
     return await _resolve_runtime_options_payload()
+
+
+def _runtime_queue_scopes(runtime_name: str) -> list[str]:
+    normalized = str(runtime_name or "").strip().lower()
+    if normalized == "ollama":
+        return ["outbound:ollama", "inbound:model_ops"]
+    if normalized == "vllm":
+        return ["outbound:vllm", "inbound:model_ops"]
+    if normalized == "onnx":
+        return ["inbound:model_ops"]
+    if is_multi_runtime(normalized):
+        return ["inbound:model_ops"]
+    return ["inbound:model_ops"]
+
+
+@router.get("/system/llm-runtime/queue-snapshot")
+def get_llm_runtime_queue_snapshot():
+    """Snapshot kolejki i metryk ruchu dla aktywnego runtime.
+
+    Cel: 231C — separacja kolejki statusowej od inferencyjnej i obserwowalność
+    aktywnego runtime bez aktywnego sondowania nieaktywnych stosów.
+    """
+    runtime = get_active_llm_runtime()
+    orchestrator = system_deps.get_orchestrator()
+    queue_status: dict[str, Any] | None = None
+    queue_error: str | None = None
+    if orchestrator is not None:
+        try:
+            queue_status = orchestrator.get_queue_status()
+        except Exception as exc:
+            queue_error = str(exc)
+    else:
+        queue_error = "Orchestrator not available"
+
+    scope_metrics: dict[str, Any] = {}
+    metrics_error: str | None = None
+    try:
+        controller = get_traffic_controller()
+        for scope in _runtime_queue_scopes(runtime.provider):
+            scope_metrics[scope] = controller.get_metrics(scope)
+    except Exception as exc:
+        metrics_error = str(exc)
+
+    return {
+        "status": "success",
+        "runtime": runtime.to_payload(),
+        "queue": {
+            "status": queue_status,
+            "error": queue_error,
+            "diagnostics": {
+                "introspection": get_introspection_queue_metrics(),
+            },
+        },
+        "traffic": {
+            "scopes": scope_metrics,
+            "error": metrics_error,
+        },
+    }
 
 
 @router.post(

--- a/venom_core/api/routes/system_llm.py
+++ b/venom_core/api/routes/system_llm.py
@@ -1943,11 +1943,7 @@ async def _runtime_server_status_snapshot() -> dict[str, dict[str, Any]]:
     _merge_monitor_status_into_servers(servers, service_monitor)
     active_runtime = get_active_llm_runtime()
     active_server_name = str(getattr(active_runtime, "provider", "") or "").strip()
-    try:
-        await _probe_servers(servers, active_server_name)
-    except TypeError:
-        # Backward-compatible for monkeypatched tests using legacy one-arg probe.
-        await _probe_servers(servers)
+    await _probe_servers(servers, active_server_name)
 
     status_map: dict[str, dict[str, Any]] = {}
     for server in servers:
@@ -1990,11 +1986,7 @@ async def get_llm_servers():
     _merge_monitor_status_into_servers(servers, service_monitor)
     active_runtime = get_active_llm_runtime()
     active_server_name = str(getattr(active_runtime, "provider", "") or "").strip()
-    try:
-        await _probe_servers(servers, active_server_name)
-    except TypeError:
-        # Backward-compatible for monkeypatched tests using legacy one-arg probe.
-        await _probe_servers(servers)
+    await _probe_servers(servers, active_server_name)
 
     return {"status": "success", "servers": servers, "count": len(servers)}
 

--- a/venom_core/api/routes/system_llm.py
+++ b/venom_core/api/routes/system_llm.py
@@ -120,6 +120,7 @@ _CODING_MODEL_MARKERS: tuple[str, ...] = (
     "codeqwen",
     "opencoder",
 )
+_INBOUND_MODEL_OPS_SCOPE = "inbound:model_ops"
 
 
 def _runtime_adapter_deploy_capability(runtime_id: str) -> tuple[bool, str]:
@@ -2086,14 +2087,14 @@ async def get_llm_runtime_options():
 def _runtime_queue_scopes(runtime_name: str) -> list[str]:
     normalized = str(runtime_name or "").strip().lower()
     if normalized == "ollama":
-        return ["outbound:ollama", "inbound:model_ops"]
+        return ["outbound:ollama", _INBOUND_MODEL_OPS_SCOPE]
     if normalized == "vllm":
-        return ["outbound:vllm", "inbound:model_ops"]
+        return ["outbound:vllm", _INBOUND_MODEL_OPS_SCOPE]
     if normalized == "onnx":
-        return ["inbound:model_ops"]
+        return [_INBOUND_MODEL_OPS_SCOPE]
     if is_multi_runtime(normalized):
-        return ["inbound:model_ops"]
-    return ["inbound:model_ops"]
+        return [_INBOUND_MODEL_OPS_SCOPE]
+    return [_INBOUND_MODEL_OPS_SCOPE]
 
 
 @router.get("/system/llm-runtime/queue-snapshot")

--- a/venom_core/core/llm_server_controller.py
+++ b/venom_core/core/llm_server_controller.py
@@ -227,7 +227,7 @@ class LlmServerController:
                 supports_restart=True,
                 supports_health_wait=True,
                 supports_cache_flush=False,
-                supports_model_unload=False,
+                supports_model_unload=True,
                 is_in_process=False,
                 release_wait_seconds=10,
             ),

--- a/venom_core/core/model_manager_discovery.py
+++ b/venom_core/core/model_manager_discovery.py
@@ -436,8 +436,6 @@ class ModelManagerDiscoveryMixin:
                 models[f"ollama::{entry_name}"] = entry
 
     def _save_ollama_cache(self, entries: List[Dict[str, Any]]) -> None:
-        if not entries:
-            return
         try:
             self.ollama_cache_path.write_text(
                 json.dumps(entries, indent=2),
@@ -494,6 +492,10 @@ class ModelManagerDiscoveryMixin:
                         entries = self._collect_ollama_entries(
                             ollama_data.get("models", [])
                         )
+                        for key in [
+                            k for k in list(models.keys()) if k.startswith("ollama::")
+                        ]:
+                            models.pop(key, None)
                         self._register_ollama_entries(models, entries)
                         self._save_ollama_cache(entries)
                     else:

--- a/venom_core/core/model_manager_discovery.py
+++ b/venom_core/core/model_manager_discovery.py
@@ -468,6 +468,53 @@ class ModelManagerDiscoveryMixin:
                 if entry_name:
                     models.setdefault(f"ollama::{entry_name}", entry)
 
+    def _replace_ollama_entries(
+        self,
+        models: Dict[str, Dict[str, Any]],
+        entries: List[Dict[str, Any]],
+    ) -> None:
+        for key in tuple(models):
+            if key.startswith("ollama::"):
+                models.pop(key, None)
+        self._register_ollama_entries(models, entries)
+        self._save_ollama_cache(entries)
+
+    async def _fetch_ollama_runtime_entries(self) -> List[Dict[str, Any]] | None:
+        try:
+            async with TrafficControlledHttpClient(
+                provider="ollama",
+                timeout=10.0,
+            ) as client:
+                response = await client.aget(
+                    self._resolve_ollama_tags_url(),
+                    raise_for_status=False,
+                )
+            if response.status_code != 200:
+                logger.warning(
+                    "Nie udało się pobrać listy modeli z Ollama: %s",
+                    response.status_code,
+                )
+                return None
+            ollama_data = response.json()
+            return self._collect_ollama_entries(ollama_data.get("models", []))
+        except (httpx.ConnectError, httpx.TimeoutException) as exc:
+            now = time.time()
+            if now - self._last_ollama_warning > 60:
+                logger.warning("Ollama nie jest dostępne: %s", exc)
+                self._last_ollama_warning = now
+        except httpx.HTTPError as exc:
+            logger.error("Błąd HTTP podczas pobierania modeli z Ollama: %s", exc)
+        except ValueError as exc:
+            logger.error(
+                "Błędna odpowiedź JSON podczas pobierania modeli z Ollama: %s", exc
+            )
+        except Exception as exc:
+            logger.warning(
+                "Nie udało się pobrać modeli z Ollama (fallback do lokalnego skanu): %s",
+                exc,
+            )
+        return None
+
     async def list_local_models(self) -> List[Dict[str, Any]]:
         models: Dict[str, Dict[str, Any]] = {}
 
@@ -478,46 +525,9 @@ class ModelManagerDiscoveryMixin:
         self._register_manifest_fallbacks(search_dirs, models)
 
         if self._should_query_ollama_runtime():
-            try:
-                async with TrafficControlledHttpClient(
-                    provider="ollama",
-                    timeout=10.0,
-                ) as client:
-                    response = await client.aget(
-                        self._resolve_ollama_tags_url(),
-                        raise_for_status=False,
-                    )
-                    if response.status_code == 200:
-                        ollama_data = response.json()
-                        entries = self._collect_ollama_entries(
-                            ollama_data.get("models", [])
-                        )
-                        for key in [
-                            k for k in list(models.keys()) if k.startswith("ollama::")
-                        ]:
-                            models.pop(key, None)
-                        self._register_ollama_entries(models, entries)
-                        self._save_ollama_cache(entries)
-                    else:
-                        logger.warning(
-                            f"Nie udało się pobrać listy modeli z Ollama: "
-                            f"{response.status_code}",
-                        )
-            except (httpx.ConnectError, httpx.TimeoutException) as exc:
-                now = time.time()
-                if now - self._last_ollama_warning > 60:
-                    logger.warning(f"Ollama nie jest dostępne: {exc}")
-                    self._last_ollama_warning = now
-            except httpx.HTTPError as exc:
-                logger.error(f"Błąd HTTP podczas pobierania modeli z Ollama: {exc}")
-            except ValueError as exc:
-                logger.error(
-                    f"Błędna odpowiedź JSON podczas pobierania modeli z Ollama: {exc}"
-                )
-            except Exception as exc:
-                logger.warning(
-                    f"Nie udało się pobrać modeli z Ollama (fallback do lokalnego skanu): {exc}"
-                )
+            entries = await self._fetch_ollama_runtime_entries()
+            if entries is not None:
+                self._replace_ollama_entries(models, entries)
         else:
             logger.debug(
                 "Pomijam aktywne odpytywanie Ollama (/api/tags), bo ACTIVE_LLM_SERVER=%s",

--- a/venom_core/core/model_manager_discovery.py
+++ b/venom_core/core/model_manager_discovery.py
@@ -98,6 +98,18 @@ class ModelManagerDiscoveryMixin:
                 return f"{base}/api/tags"
         return build_http_url("localhost", 11434, "/api/tags")
 
+    def _should_query_ollama_runtime(self) -> bool:
+        """Return True when remote Ollama tags polling should run.
+
+        In single-runtime mode we avoid background probing of inactive runtimes.
+        Set MODEL_DISCOVERY_FORCE_OLLAMA_QUERY=true to override.
+        """
+        forced = os.getenv("MODEL_DISCOVERY_FORCE_OLLAMA_QUERY", "").strip().lower()
+        if forced in {"1", "true", "yes", "on"}:
+            return True
+        active_server = os.getenv("ACTIVE_LLM_SERVER", "").strip().lower()
+        return active_server in {"", "ollama"}
+
     def _register_local_entry(
         self,
         models: Dict[str, Dict[str, Any]],
@@ -467,41 +479,47 @@ class ModelManagerDiscoveryMixin:
         self._load_ollama_cache(models)
         self._register_manifest_fallbacks(search_dirs, models)
 
-        try:
-            async with TrafficControlledHttpClient(
-                provider="ollama",
-                timeout=10.0,
-            ) as client:
-                response = await client.aget(
-                    self._resolve_ollama_tags_url(),
-                    raise_for_status=False,
+        if self._should_query_ollama_runtime():
+            try:
+                async with TrafficControlledHttpClient(
+                    provider="ollama",
+                    timeout=10.0,
+                ) as client:
+                    response = await client.aget(
+                        self._resolve_ollama_tags_url(),
+                        raise_for_status=False,
+                    )
+                    if response.status_code == 200:
+                        ollama_data = response.json()
+                        entries = self._collect_ollama_entries(
+                            ollama_data.get("models", [])
+                        )
+                        self._register_ollama_entries(models, entries)
+                        self._save_ollama_cache(entries)
+                    else:
+                        logger.warning(
+                            f"Nie udało się pobrać listy modeli z Ollama: "
+                            f"{response.status_code}",
+                        )
+            except (httpx.ConnectError, httpx.TimeoutException) as exc:
+                now = time.time()
+                if now - self._last_ollama_warning > 60:
+                    logger.warning(f"Ollama nie jest dostępne: {exc}")
+                    self._last_ollama_warning = now
+            except httpx.HTTPError as exc:
+                logger.error(f"Błąd HTTP podczas pobierania modeli z Ollama: {exc}")
+            except ValueError as exc:
+                logger.error(
+                    f"Błędna odpowiedź JSON podczas pobierania modeli z Ollama: {exc}"
                 )
-                if response.status_code == 200:
-                    ollama_data = response.json()
-                    entries = self._collect_ollama_entries(
-                        ollama_data.get("models", [])
-                    )
-                    self._register_ollama_entries(models, entries)
-                    self._save_ollama_cache(entries)
-                else:
-                    logger.warning(
-                        f"Nie udało się pobrać listy modeli z Ollama: "
-                        f"{response.status_code}",
-                    )
-        except (httpx.ConnectError, httpx.TimeoutException) as exc:
-            now = time.time()
-            if now - self._last_ollama_warning > 60:
-                logger.warning(f"Ollama nie jest dostępne: {exc}")
-                self._last_ollama_warning = now
-        except httpx.HTTPError as exc:
-            logger.error(f"Błąd HTTP podczas pobierania modeli z Ollama: {exc}")
-        except ValueError as exc:
-            logger.error(
-                f"Błędna odpowiedź JSON podczas pobierania modeli z Ollama: {exc}"
-            )
-        except Exception as exc:
-            logger.warning(
-                f"Nie udało się pobrać modeli z Ollama (fallback do lokalnego skanu): {exc}"
+            except Exception as exc:
+                logger.warning(
+                    f"Nie udało się pobrać modeli z Ollama (fallback do lokalnego skanu): {exc}"
+                )
+        else:
+            logger.debug(
+                "Pomijam aktywne odpytywanie Ollama (/api/tags), bo ACTIVE_LLM_SERVER=%s",
+                os.getenv("ACTIVE_LLM_SERVER", "").strip().lower() or "unknown",
             )
 
         return list(models.values())

--- a/venom_core/infrastructure/traffic_control/config.py
+++ b/venom_core/infrastructure/traffic_control/config.py
@@ -273,4 +273,10 @@ class TrafficControlConfig(BaseModel):
             rate_limit=TokenBucketConfig(capacity=100, refill_rate=10.0),
         )
 
+        # Introspection diagnostics: intentionally tighter than generic models/chat.
+        # Prevents introspection bursts from starving core chat/task traffic.
+        config.endpoint_group_policies["models_introspection"] = InboundPolicyConfig(
+            rate_limit=TokenBucketConfig(capacity=30, refill_rate=3.0),
+        )
+
         return config

--- a/venom_core/services/runtime_switch_service.py
+++ b/venom_core/services/runtime_switch_service.py
@@ -56,7 +56,7 @@ async def _release_multi_runtime_models(endpoint: str) -> bool:
     try:
         async with httpx.AsyncClient(timeout=_CLEANUP_TIMEOUT) as client:
             response = await client.post(unload_url)
-        if response.status_code >= 400:
+        if not (200 <= response.status_code < 300):
             logger.warning(
                 "Nie udało się wyładować modeli multi_runtime przed stop: HTTP {}",
                 response.status_code,

--- a/venom_core/services/runtime_switch_service.py
+++ b/venom_core/services/runtime_switch_service.py
@@ -47,6 +47,28 @@ async def _release_ollama_model(endpoint: str, model_name: str) -> bool:
         return False
 
 
+async def _release_multi_runtime_models(endpoint: str) -> bool:
+    """Ask multi_runtime daemon to unload all models before service stop."""
+    if not endpoint:
+        return False
+    base = endpoint.rstrip("/").removesuffix("/v1")
+    unload_url = f"{base}/v1/daemon/unload"
+    try:
+        async with httpx.AsyncClient(timeout=_CLEANUP_TIMEOUT) as client:
+            response = await client.post(unload_url)
+        if response.status_code >= 400:
+            logger.warning(
+                "Nie udało się wyładować modeli multi_runtime przed stop: HTTP {}",
+                response.status_code,
+            )
+            return False
+        logger.info("multi_runtime: modele wyładowane przed zatrzymaniem serwisu")
+        return True
+    except Exception as exc:
+        logger.warning("Nie udało się wyładować modeli multi_runtime: {}", exc)
+        return False
+
+
 async def release_runtime_resources(
     server_name: str,
     *,
@@ -67,6 +89,9 @@ async def release_runtime_resources(
         endpoint = str(server.get("endpoint") or "http://localhost:11434")
         if active_model:
             released = await _release_ollama_model(endpoint, active_model)
+    elif server_name == "multi_runtime" and caps.get("supports_model_unload"):
+        endpoint = str(server.get("endpoint") or "").strip()
+        released = await _release_multi_runtime_models(endpoint) or released
 
     if caps.get("is_in_process") and caps.get("supports_cache_flush"):
         try:

--- a/venom_core/services/traffic_control_service.py
+++ b/venom_core/services/traffic_control_service.py
@@ -1,0 +1,11 @@
+"""Helpers for route/service access to Traffic Control runtime state."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def get_traffic_controller() -> Any:
+    from venom_core.infrastructure.traffic_control import get_traffic_controller as _get
+
+    return _get()

--- a/web-next/components/inspector/model-introspection-mechanism.tsx
+++ b/web-next/components/inspector/model-introspection-mechanism.tsx
@@ -4,7 +4,9 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
+  useState,
   useSyncExternalStore,
   type ReactNode,
 } from "react";
@@ -127,7 +129,14 @@ export function ModelIntrospectionMechanismControl({
 }: Readonly<ModelIntrospectionMechanismControlProps>) {
   const t = useTranslation();
   const { enabled, setEnabled } = useModelIntrospectionMechanism();
-  const displayEnabled = enabled;
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  // Keep first client render identical to SSR output to avoid hydration mismatch.
+  const displayEnabled = hydrated ? enabled : false;
   const label = displayEnabled ? t("inspector.modelIntrospection.mechanism.enabled") : t("inspector.modelIntrospection.mechanism.disabled");
 
   if (variant === "compact") {

--- a/web-next/components/inspector/model-introspection-mechanism.tsx
+++ b/web-next/components/inspector/model-introspection-mechanism.tsx
@@ -4,9 +4,7 @@ import {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
-  useState,
   useSyncExternalStore,
   type ReactNode,
 } from "react";
@@ -26,6 +24,10 @@ type ModelIntrospectionMechanismContextValue = {
 };
 
 const ModelIntrospectionMechanismContext = createContext<ModelIntrospectionMechanismContextValue | null>(null);
+
+function subscribeNoop(): () => void {
+  return () => undefined;
+}
 
 function readEnabledFromStorage(): boolean {
   try {
@@ -129,11 +131,7 @@ export function ModelIntrospectionMechanismControl({
 }: Readonly<ModelIntrospectionMechanismControlProps>) {
   const t = useTranslation();
   const { enabled, setEnabled } = useModelIntrospectionMechanism();
-  const [hydrated, setHydrated] = useState(false);
-
-  useEffect(() => {
-    setHydrated(true);
-  }, []);
+  const hydrated = useSyncExternalStore(subscribeNoop, () => true, () => false);
 
   // Keep first client render identical to SSR output to avoid hydration mismatch.
   const displayEnabled = hydrated ? enabled : false;

--- a/web-next/components/voice/voice-chat-screen.tsx
+++ b/web-next/components/voice/voice-chat-screen.tsx
@@ -139,9 +139,12 @@ function VoiceSystemStatusBar({ status }: Readonly<{ status: VoiceStatusUpdate |
 
   const sttOk = status.stt_ready === true;
   const ttsOk = status.tts_ready === true;
+  const runtimeProvider = String(status.runtime_snapshot?.provider ?? "").trim();
+  const runtimeModel = String(status.runtime_snapshot?.model_name ?? "").trim();
   const probeStatus = status.runtime_snapshot?.runtime_capabilities?.probe_status ?? null;
-  const runtimeOk = probeStatus === "verified";
-  const allOk = sttOk && ttsOk && runtimeOk;
+  const llmOk = runtimeProvider.length > 0 && runtimeModel.length > 0;
+  const voiceProbeFailed = probeStatus === "failed";
+  const allOk = sttOk && ttsOk && llmOk && !voiceProbeFailed;
 
   return (
     <div
@@ -155,6 +158,11 @@ function VoiceSystemStatusBar({ status }: Readonly<{ status: VoiceStatusUpdate |
         {allOk ? t("voice.status.systemReady") : t("voice.status.systemPartial")}
       </span>
       <span className="flex items-center gap-3">
+        <span className={`flex items-center gap-1 ${llmOk ? "text-emerald-400" : "text-zinc-600"}`}>
+          <span className={`h-1.5 w-1.5 rounded-full ${llmOk ? "bg-emerald-400" : "bg-zinc-600"}`} />
+          {" "}
+          LLM
+        </span>
         <span className={`flex items-center gap-1 ${sttOk ? "text-emerald-400" : "text-zinc-600"}`}>
           <span className={`h-1.5 w-1.5 rounded-full ${sttOk ? "bg-emerald-400" : "bg-zinc-600"}`} />
           {" "}
@@ -165,10 +173,10 @@ function VoiceSystemStatusBar({ status }: Readonly<{ status: VoiceStatusUpdate |
           {" "}
           TTS
         </span>
-        <span className={`flex items-center gap-1 ${runtimeOk ? "text-emerald-400" : "text-zinc-600"}`}>
-          <span className={`h-1.5 w-1.5 rounded-full ${runtimeOk ? "bg-emerald-400" : "bg-zinc-600"}`} />
+        <span className={`flex items-center gap-1 ${voiceProbeFailed ? "text-amber-400" : "text-emerald-400"}`}>
+          <span className={`h-1.5 w-1.5 rounded-full ${voiceProbeFailed ? "bg-amber-400" : "bg-emerald-400"}`} />
           {" "}
-          {probeStatus ?? "—"}
+          {probeStatus ?? "verified"}
         </span>
       </span>
     </div>

--- a/web-next/components/voice/voice-chat-screen.tsx
+++ b/web-next/components/voice/voice-chat-screen.tsx
@@ -176,7 +176,7 @@ function VoiceSystemStatusBar({ status }: Readonly<{ status: VoiceStatusUpdate |
         <span className={`flex items-center gap-1 ${voiceProbeFailed ? "text-amber-400" : "text-emerald-400"}`}>
           <span className={`h-1.5 w-1.5 rounded-full ${voiceProbeFailed ? "bg-amber-400" : "bg-emerald-400"}`} />
           {" "}
-          {probeStatus ?? "verified"}
+          {probeStatus ?? "—"}
         </span>
       </span>
     </div>

--- a/web-next/components/voice/voice-status-sidebar.tsx
+++ b/web-next/components/voice/voice-status-sidebar.tsx
@@ -308,7 +308,8 @@ function RuntimeOverviewCard({
   const probeStatus = runtime?.runtime_capabilities?.probe_status ?? null;
   const runtimeProvider = String(provider ?? "").trim().toLowerCase();
   const isNativeVoiceRuntime =
-    runtimeProvider === "multi_runtime" || runtimeProvider === "gemma4_audio";
+    runtimeProvider.startsWith("multi_runtime") ||
+    runtimeProvider.startsWith("gemma4_audio");
   const probeTone = (() => {
     if (!probeStatus) return "neutral" as const;
     if (probeStatus === "verified") return "success" as const;

--- a/web-next/components/voice/voice-status-sidebar.tsx
+++ b/web-next/components/voice/voice-status-sidebar.tsx
@@ -14,13 +14,6 @@ type VoiceStatusSidebarProps = Readonly<{
   isDevMode?: boolean;
 }>;
 
-function getProbeTone(status?: string | null): "success" | "warning" | "danger" | "neutral" {
-  if (status === "verified") return "success";
-  if (status === "failed") return "danger";
-  if (status === "metadata_only") return "warning";
-  return "neutral";
-}
-
 function ReadyDot({ ready }: Readonly<{ ready?: boolean | null }>) {
   return (
     <span
@@ -313,6 +306,18 @@ function RuntimeOverviewCard({
   const model = runtime?.model_name ?? null;
   const endpoint = runtime?.endpoint ?? null;
   const probeStatus = runtime?.runtime_capabilities?.probe_status ?? null;
+  const runtimeProvider = String(provider ?? "").trim().toLowerCase();
+  const isNativeVoiceRuntime =
+    runtimeProvider === "multi_runtime" || runtimeProvider === "gemma4_audio";
+  const probeTone = (() => {
+    if (!probeStatus) return "neutral" as const;
+    if (probeStatus === "verified") return "success" as const;
+    if (probeStatus === "metadata_only") return "warning" as const;
+    if (probeStatus === "failed") {
+      return isNativeVoiceRuntime ? ("danger" as const) : ("warning" as const);
+    }
+    return "neutral" as const;
+  })();
   const t = useTranslation();
 
   return (
@@ -324,7 +329,7 @@ function RuntimeOverviewCard({
               {provider ?? "—"} / {model ?? t("voice.controls.unknownModel")}
             </span>
             {probeStatus && (
-              <Badge tone={getProbeTone(probeStatus)} className="shrink-0 text-[10px]">
+              <Badge tone={probeTone} className="shrink-0 text-[10px]">
                 {probeStatus}
               </Badge>
             )}


### PR DESCRIPTION
## Cel
Domknąć PR231: twarda separacja runtime, spójny kontrakt voice pipeline oraz pierwsza faza separacji kolejek/diagnostyki zgodnie z bramkami jakości środowiska.

## Zakres zmian
### 1) Single-runtime i lifecycle switch
- Utrzymanie sekwencji przełączenia runtime: stop poprzedniego -> release -> start nowego.
- Dodatkowy unload modeli `multi_runtime` przed stop (`/v1/daemon/unload`).
- `multi_runtime` oznaczony jako runtime wspierający `supports_model_unload`.

### 2) Separacja polling/discovery nieaktywnego runtime
- Bramka w discovery modeli: aktywne zapytanie `Ollama /api/tags` tylko gdy `ACTIVE_LLM_SERVER=ollama`.
- Override operatorski: `MODEL_DISCOVERY_FORCE_OLLAMA_QUERY=true`.
- Dla nieaktywnych runtime: fallback cache/manifest bez aktywnego sondowania.

### 3) Separacja status/probe runtime
- Endpointy statusowe sondują aktywnie tylko bieżący runtime.
- Pozostałe runtime oznaczane jako `inactive` (bez aktywnych prób sieciowych).

### 4) Kontrakt voice pipeline per runtime
- `multi_runtime` (Gemma4) jako jedyny runtime z natywną ścieżką voice.
- `ollama/vllm/onnx` wymuszone przez lokalny pośrednik: STT lokalnie -> LLM -> TTS.
- Metadata sesji voice: `voice_pipeline_mode` + jawny `fallback_reason`.

### 5) 231C — kolejki i diagnostyka (pierwsza implementacja)
- Nowy endpoint: `GET /api/v1/system/llm-runtime/queue-snapshot`.
- Snapshot zawiera: aktywny runtime, status kolejki orchestratora, scope metrics traffic-control.
- Dodane liczniki dla introspection queue: `accepted/deferred/dropped`.

### 6) Guardy dla introspection
- Osobna grupa inbound `models_introspection` z niższym limitem.
- Guard współbieżności + timeout na:
  - `/api/v1/models/introspection/analyze`
  - `/api/v1/models/introspection/analyze/stream`
  - `/api/v1/models/introspection/probe`
- Przy przeciążeniu: HTTP 429.

### 7) UX spójność Voice Command Center
- Rozdzielenie sygnałów stanu: LLM vs tor voice/audio.
- `probe_status=failed` dla runtime tekstowych nie jest już pokazywany jak totalna awaria LLM.

## Zmienione obszary
- backend runtime switch / model discovery / voice / introspection / middleware traffic-control
- web-next voice status presentation
- dokumentacja PR231 i narzędzia startu low-memory

## Walidacja i bramki jakości
- `make ci-lite-preflight` ✅
- `make test-lane-contracts-check` ✅
- `make test-catalog-check` ✅
- `pytest` (runtime/switch API suite) ✅
- `web-next npm run -s test:unit` ✅
- pre-commit (`ruff`, `isort`, guards) ✅

## Ryzyka / uwagi
- Wprowadzono twardsze limity dla introspection diagnostics; przy dużym obciążeniu endpointy mogą zwracać 429 (zamierzone).
- Dalsze etapy 231C pozostają otwarte: pełny fairness per actor/session oraz dashboard UI oparty o `queue-snapshot`.

## Plan rollout
1. Merge do `main`.
2. Smoke: przełączanie runtime (`ollama <-> multi_runtime <-> onnx`) z obserwacją `queue-snapshot`.
3. Weryfikacja Voice Command Center dla scenariuszy:
   - native Gemma4
   - intermediary STT + ollama

## Plan rollback
- Revert commit PR231 w całości (obszary są spójne i skupione wokół runtime/voice/diagnostics).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nowe funkcjonalności**
  * Tryb uruchamiania low-memory (make start-lowmem)
  * Endpoint do kontrolowanego zwalniania załadowanych modeli
  * Snapshot kolejki runtime LLM dostępny przez API

* **Ulepszenia**
  * Kolejkowanie i rate limiting dla introspekcji modeli z metrykami i ograniczeniami
  * Lepsze raportowanie trybu pipeline’u głosowego i wizualne wskaźniki statusu
  * Parametryzacja liczby workerów testów e2e

* **Testy**
  * Dodano testy dla snapshotu kolejki runtime LLM

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpieniak01/Venom/pull/501?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->