### PR TITLE
PR232: Ollama introspection lite (contract + backend + UI + gates)

### DIFF
--- a/compose/compose.minimal.yml
+++ b/compose/compose.minimal.yml
@@ -5,7 +5,7 @@ name: venom-minimal
 # Services are published on host interfaces to allow testing from another machine in LAN.
 services:
   ollama:
-    image: ${OLLAMA_IMAGE:-ollama/ollama:0.16.1}
+    image: ${OLLAMA_IMAGE:-ollama/ollama:0.24.0}
     container_name: venom-ollama-minimal
     ports:
       - "11434:11434"

--- a/compose/compose.release.yml
+++ b/compose/compose.release.yml
@@ -6,7 +6,7 @@ name: venom-release
 # - intended for trusted/private networks only
 services:
   ollama:
-    image: ${OLLAMA_IMAGE:-ollama/ollama:0.16.1}
+    image: ${OLLAMA_IMAGE:-ollama/ollama:0.24.0}
     container_name: venom-ollama-release
     ports:
       - "11434:11434"

--- a/config/pytest-groups/ci-lite.txt
+++ b/config/pytest-groups/ci-lite.txt
@@ -50,6 +50,7 @@ tests/test_policy_gate_integration.py
 tests/test_preprod_ops_regression.py
 tests/test_preprod_readiness_check.py
 tests/test_providers_service.py
+tests/test_runtime_controller_api.py
 tests/test_runtime_conversion_contracts.py
 tests/test_runtime_policy_regression_contracts.py
 tests/test_service_monitor_contracts.py

--- a/config/pytest-groups/fast.txt
+++ b/config/pytest-groups/fast.txt
@@ -41,6 +41,7 @@ tests/test_academy_self_learning_routes.py
 tests/test_academy_self_learning_service.py
 tests/test_academy_training_service.py
 tests/test_adapter_audit_service.py
+tests/test_adapter_runtime_service.py
 tests/test_admin_audit.py
 tests/test_agent_improvements.py
 tests/test_agents.py

--- a/config/pytest-groups/sonar-new-code.txt
+++ b/config/pytest-groups/sonar-new-code.txt
@@ -33,6 +33,7 @@ tests/test_academy_self_learning_routes.py
 tests/test_academy_self_learning_service.py
 tests/test_academy_training_service.py
 tests/test_adapter_audit_service.py
+tests/test_adapter_runtime_service.py
 tests/test_admin_audit.py
 tests/test_agents_ghost_runtime_store.py
 tests/test_agents_release_integration_contracts.py

--- a/config/testing/test_catalog.json
+++ b/config/testing/test_catalog.json
@@ -480,6 +480,20 @@
       "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
     },
     {
+      "path": "tests/test_adapter_runtime_service.py",
+      "domain": "academy",
+      "test_type": "service_contract",
+      "intent": "contract",
+      "primary_lane": "new-code",
+      "allowed_lanes": [
+        "new-code",
+        "ci-lite",
+        "release"
+      ],
+      "legacy_targeted": false,
+      "rationale": "Direct module-name fallback entrypoint for changed-lines coverage gate."
+    },
+    {
       "path": "tests/test_academy_api.py",
       "domain": "academy",
       "test_type": "route_contract",
@@ -5135,12 +5149,13 @@
       "domain": "runtime",
       "test_type": "route_contract",
       "intent": "contract",
-      "primary_lane": "release",
+      "primary_lane": "ci-lite",
       "allowed_lanes": [
+        "ci-lite",
         "release"
       ],
       "legacy_targeted": false,
-      "rationale": "Default release-lane regression coverage."
+      "rationale": "CI-lite coverage for changed-scope runtime controller API checks."
     },
     {
       "path": "tests/test_runtime_controller_roi.py",

--- a/docs/DEPLOYMENT_NEXT.md
+++ b/docs/DEPLOYMENT_NEXT.md
@@ -56,7 +56,7 @@ Interpretation rules:
    | `NEXT_PUBLIC_WS_BASE` | WebSocket endpoint for `/ws/events`. | `ws://localhost:8000/ws/events` |
    | `API_PROXY_TARGET` | Proxy target in `next.config.ts` (SSR). | `http://localhost:8000` |
    | `NEXT_DISABLE_TURBOPACK` | Set automatically by Makefile in dev mode. | `1` |
-   | `OLLAMA_IMAGE` | Ollama container image tag used by compose profiles. | `ollama/ollama:0.16.1` |
+   | `OLLAMA_IMAGE` | Ollama container image tag used by compose profiles. | `ollama/ollama:0.24.0` |
    | `VENOM_RUNTIME_PROFILE` | Runtime profile (`light`, `llm_off`, `full`) for single-package deployment flow (`llm_off` = no local LLM runtime, external APIs still possible after key setup). | `light` |
    | `OLLAMA_HOST` | Bind address for Ollama inside container. | `0.0.0.0` |
    | `VENOM_OLLAMA_PROFILE` | Venom single-user tuning profile (`balanced-12-24gb`, `low-vram-8-12gb`, `max-context-24gb-plus`). | `balanced-12-24gb` |

--- a/docs/DOCKER_RELEASE_GUIDE.md
+++ b/docs/DOCKER_RELEASE_GUIDE.md
@@ -91,7 +91,7 @@ cd Venom
 # optional overrides:
 # export BACKEND_IMAGE=ghcr.io/mpieniak01/venom-backend:v1.8.0
 # export FRONTEND_IMAGE=ghcr.io/mpieniak01/venom-frontend:v1.8.0
-# export OLLAMA_IMAGE=ollama/ollama:0.16.1
+# export OLLAMA_IMAGE=ollama/ollama:0.24.0
 # export OLLAMA_MODEL=gemma3:1b
 # export OLLAMA_NO_CLOUD=1
 # export VENOM_ENABLE_GPU=auto

--- a/docs/MODEL_MANAGEMENT.md
+++ b/docs/MODEL_MANAGEMENT.md
@@ -21,7 +21,7 @@ Profile behavior notes:
 ## Ollama Runtime Baseline (v1.5 / task 152)
 
 Current Venom baseline for local runtime:
-1. **Target Ollama line**: `0.16.x` (stable).
+1. **Target Ollama line**: `0.24.x` (stable).
 2. **Default single-user profile**: `balanced-12-24gb`.
 3. **Configuration source of truth**: backend env/config (no frontend hardcodes).
 

--- a/docs/PL/DEPLOYMENT_NEXT.md
+++ b/docs/PL/DEPLOYMENT_NEXT.md
@@ -56,7 +56,7 @@ Zasady interpretacji:
    | `NEXT_PUBLIC_WS_BASE` | Endpoint WebSocket dla `/ws/events`. | `ws://localhost:8000/ws/events` |
    | `API_PROXY_TARGET` | Cel proxy w `next.config.ts` (SSR). | `http://localhost:8000` |
    | `NEXT_DISABLE_TURBOPACK` | W trybie dev ustawiane automatycznie przez Makefile. | `1` |
-   | `OLLAMA_IMAGE` | Tag obrazu Ollama używany w profilach compose. | `ollama/ollama:0.16.1` |
+   | `OLLAMA_IMAGE` | Tag obrazu Ollama używany w profilach compose. | `ollama/ollama:0.24.0` |
    | `VENOM_RUNTIME_PROFILE` | Profil runtime (`light`, `llm_off`, `full`) dla modelu jednej paczki (`llm_off` = bez lokalnego runtime LLM, ale możliwe API zewnętrzne po konfiguracji kluczy). | `light` |
    | `OLLAMA_HOST` | Adres nasłuchu Ollama wewnątrz kontenera. | `0.0.0.0` |
    | `VENOM_OLLAMA_PROFILE` | Profil strojenia single-user (`balanced-12-24gb`, `low-vram-8-12gb`, `max-context-24gb-plus`). | `balanced-12-24gb` |

--- a/docs/PL/DOCKER_RELEASE_GUIDE.md
+++ b/docs/PL/DOCKER_RELEASE_GUIDE.md
@@ -91,7 +91,7 @@ cd Venom
 # opcjonalne nadpisania:
 # export BACKEND_IMAGE=ghcr.io/mpieniak01/venom-backend:v1.8.0
 # export FRONTEND_IMAGE=ghcr.io/mpieniak01/venom-frontend:v1.8.0
-# export OLLAMA_IMAGE=ollama/ollama:0.16.1
+# export OLLAMA_IMAGE=ollama/ollama:0.24.0
 # export OLLAMA_MODEL=gemma3:1b
 # export OLLAMA_NO_CLOUD=1
 # export VENOM_ENABLE_GPU=auto

--- a/docs/PL/MODEL_MANAGEMENT.md
+++ b/docs/PL/MODEL_MANAGEMENT.md
@@ -21,7 +21,7 @@ Uwagi operacyjne:
 ## Bazowy runtime Ollama (v1.5 / zadanie 152)
 
 Aktualna baza dla lokalnego runtime Venom:
-1. **Docelowa linia Ollama**: `0.16.x` (stable).
+1. **Docelowa linia Ollama**: `0.24.x` (stable).
 2. **Domyślny profil single-user**: `balanced-12-24gb`.
 3. **Źródło prawdy konfiguracji**: backend env/config (bez hardcodów w frontendzie).
 

--- a/tests/test_academy_adapter_runtime_service.py
+++ b/tests/test_academy_adapter_runtime_service.py
@@ -359,10 +359,12 @@ def test_deploy_adapter_to_chat_runtime_ollama_uses_resolved_from_model_and_expe
                 ),
                 "config_manager_obj": config_manager_obj,
                 "compute_llm_config_hash_fn": lambda *_args: "hash-123",
-                "runtime_endpoint_for_hash_fn": lambda *_args,
-                **_kwargs: "http://localhost:11434/v1",
-                "is_runtime_model_dir_fn": lambda path: Path(path).resolve()
-                == runtime_base.resolve(),
+                "runtime_endpoint_for_hash_fn": lambda *_args, **_kwargs: (
+                    "http://localhost:11434/v1"
+                ),
+                "is_runtime_model_dir_fn": lambda path: (
+                    Path(path).resolve() == runtime_base.resolve()
+                ),
                 "get_active_llm_runtime_fn": get_active_llm_runtime_fn,
             },
         )
@@ -418,7 +420,9 @@ def test_deploy_adapter_to_chat_runtime_ollama_raises_runtime_unavailable_when_d
                 model_id="gemma3:4b",
                 settings_obj=settings_obj,
                 deploy_deps={
-                    "require_trusted_adapter_base_model_fn": lambda **_kw: "gemma-3-4b-it",
+                    "require_trusted_adapter_base_model_fn": lambda **_kw: (
+                        "gemma-3-4b-it"
+                    ),
                     "canonical_runtime_model_id_fn": lambda value: (
                         "gemma-3-4b-it"
                         if value.strip().lower() in {"gemma3:latest", "gemma3:4b"}
@@ -426,8 +430,9 @@ def test_deploy_adapter_to_chat_runtime_ollama_raises_runtime_unavailable_when_d
                     ),
                     "config_manager_obj": MagicMock(),
                     "compute_llm_config_hash_fn": lambda *_args: "hash-offline",
-                    "runtime_endpoint_for_hash_fn": lambda *_args,
-                    **_kwargs: "http://localhost:11434/v1",
+                    "runtime_endpoint_for_hash_fn": lambda *_args, **_kwargs: (
+                        "http://localhost:11434/v1"
+                    ),
                     "is_runtime_model_dir_fn": lambda _path: False,
                     "get_active_llm_runtime_fn": lambda: SimpleNamespace(
                         provider="ollama",
@@ -507,7 +512,9 @@ def test_deploy_adapter_to_chat_runtime_ollama_raises_deploy_failed_when_probe_o
                 model_id="gemma3:4b",
                 settings_obj=settings_obj,
                 deploy_deps={
-                    "require_trusted_adapter_base_model_fn": lambda **_kw: "gemma-3-4b-it",
+                    "require_trusted_adapter_base_model_fn": lambda **_kw: (
+                        "gemma-3-4b-it"
+                    ),
                     "canonical_runtime_model_id_fn": lambda value: (
                         "gemma-3-4b-it"
                         if value.strip().lower() in {"gemma3:latest", "gemma3:4b"}
@@ -515,8 +522,9 @@ def test_deploy_adapter_to_chat_runtime_ollama_raises_deploy_failed_when_probe_o
                     ),
                     "config_manager_obj": MagicMock(),
                     "compute_llm_config_hash_fn": lambda *_args: "hash-probe-ok",
-                    "runtime_endpoint_for_hash_fn": lambda *_args,
-                    **_kwargs: "http://localhost:11434/v1",
+                    "runtime_endpoint_for_hash_fn": lambda *_args, **_kwargs: (
+                        "http://localhost:11434/v1"
+                    ),
                     "is_runtime_model_dir_fn": lambda _path: False,
                     "get_active_llm_runtime_fn": lambda: SimpleNamespace(
                         provider="ollama",
@@ -924,9 +932,12 @@ def test_deploy_adapter_to_vllm_runtime_success_updates_previous_model(
             settings_obj=settings,
             config_manager_obj=config_manager_obj,
             compute_llm_config_hash_fn=lambda *_args: "hash-vllm",
-            runtime_endpoint_for_hash_fn=lambda *_args,
-            **_kwargs: "http://localhost:8001/v1",
-            build_vllm_runtime_model_from_adapter_fn=lambda **_kwargs: runtime_model_dir,
+            runtime_endpoint_for_hash_fn=lambda *_args, **_kwargs: (
+                "http://localhost:8001/v1"
+            ),
+            build_vllm_runtime_model_from_adapter_fn=lambda **_kwargs: (
+                runtime_model_dir
+            ),
             is_runtime_model_dir_fn=lambda _path: True,
             restart_vllm_runtime_fn=restart_runtime,
             get_active_llm_runtime_fn=lambda: SimpleNamespace(
@@ -966,7 +977,9 @@ def test_deploy_adapter_to_vllm_runtime_raises_for_non_runtime_model_dir(
             ars._deploy_adapter_to_vllm_runtime(
                 adapter_id=adapter_id,
                 settings_obj=SimpleNamespace(ACADEMY_MODELS_DIR=str(models_dir)),
-                build_vllm_runtime_model_from_adapter_fn=lambda **_kwargs: runtime_model_dir,
+                build_vllm_runtime_model_from_adapter_fn=lambda **_kwargs: (
+                    runtime_model_dir
+                ),
                 is_runtime_model_dir_fn=lambda _path: False,
                 restart_vllm_runtime_fn=lambda **_kwargs: None,
                 get_active_llm_runtime_fn=lambda: SimpleNamespace(
@@ -1177,3 +1190,125 @@ def test_restart_vllm_runtime_runs_service_and_surfaces_failures(
                 resolve_repo_root_fn=lambda **_kwargs: tmp_path,
                 settings_obj=SimpleNamespace(),
             )
+
+
+def test_append_resource_monitor_entry_warns_when_write_fails(
+    tmp_path: Path, monkeypatch
+) -> None:
+    adapter_dir = _make_adapter_dir(tmp_path, metadata={})
+    warning = MagicMock()
+    monkeypatch.setattr(ars.logger, "warning", warning)
+    monkeypatch.setattr(ars.Path, "open", MagicMock(side_effect=OSError("denied")))
+
+    ars._append_resource_monitor_entry(
+        adapter_dir=adapter_dir,
+        stage="unit",
+        pid=123,
+        peak_rss_mb=42.5,
+        max_rss_mb=128,
+        exceeded=False,
+    )
+
+    warning.assert_called_once_with("Failed to append adapter resource monitor entry.")
+
+
+def test_communicate_or_raise_timeout_returns_output_on_success() -> None:
+    process = MagicMock()
+    process.communicate.return_value = ("stdout", "stderr")
+
+    out, err = ars._communicate_or_raise_timeout(
+        process=process,
+        timeout_sec=3,
+        stage="onnx_export",
+    )
+
+    assert out == "stdout"
+    assert err == "stderr"
+
+
+def test_resolve_local_runtime_model_path_by_name_rejects_escape_and_missing(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True, exist_ok=True)
+    models_dir = repo_root / "models"
+    models_dir.mkdir(parents=True, exist_ok=True)
+    legit = models_dir / "runtime-model"
+    legit.mkdir(parents=True, exist_ok=True)
+
+    mgr = SimpleNamespace(models_dir=models_dir)
+    settings = SimpleNamespace(
+        REPO_ROOT=str(repo_root), ACADEMY_MODELS_DIR=str(models_dir)
+    )
+
+    assert ars._resolve_local_runtime_model_path_by_name(
+        mgr=mgr,
+        model_name="runtime-model",
+        settings_obj=settings,
+    ) == str(legit.resolve())
+    assert (
+        ars._resolve_local_runtime_model_path_by_name(
+            mgr=mgr,
+            model_name="../escape",
+            settings_obj=settings,
+        )
+        == ""
+    )
+    assert (
+        ars._resolve_local_runtime_model_path_by_name(
+            mgr=mgr,
+            model_name="missing-model",
+            settings_obj=settings,
+        )
+        == ""
+    )
+
+
+def test_file_candidate_helpers_cover_relative_and_missing(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True, exist_ok=True)
+    existing = repo_root / "a.json"
+    existing.write_text("{}", encoding="utf-8")
+
+    resolved = ars._resolve_file_candidate(repo_root=repo_root, raw="a.json")
+    assert resolved == existing.resolve()
+    assert ars._resolve_file_candidate(repo_root=repo_root, raw="") is None
+    assert ars._resolve_file_candidate(repo_root=repo_root, raw="missing.json") is None
+
+    first = ars._resolve_first_existing_file(
+        repo_root=repo_root,
+        candidates=["missing.json", "a.json"],
+    )
+    assert first == existing.resolve()
+
+
+def test_resolve_installed_onnx_builder_none_paths(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        ars.importlib, "import_module", MagicMock(side_effect=RuntimeError("nope"))
+    )
+    assert ars._resolve_installed_onnx_builder() is None
+
+    ghost = tmp_path / "ghost_builder.py"
+    monkeypatch.setattr(
+        ars.importlib,
+        "import_module",
+        MagicMock(return_value=SimpleNamespace(__file__=str(ghost))),
+    )
+    assert ars._resolve_installed_onnx_builder() is None
+
+
+def test_safe_path_and_json_writer_reject_nonexistent_parent_dir(
+    tmp_path: Path,
+) -> None:
+    missing_dir = tmp_path / "missing"
+    with pytest.raises(ValueError, match="Parent directory does not exist"):
+        ars._resolve_safe_child_file_path(
+            parent_dir=missing_dir,
+            file_name="entry.json",
+        )
+    with pytest.raises(ValueError, match="Directory does not exist"):
+        ars._write_json_file_in_dir(
+            directory=missing_dir,
+            file_name="entry.json",
+            payload={"ok": True},
+        )

--- a/tests/test_adapter_runtime_service.py
+++ b/tests/test_adapter_runtime_service.py
@@ -1,0 +1,124 @@
+"""Direct new-code coverage entrypoint for adapter_runtime_service.
+
+This module intentionally re-exports academy adapter runtime service tests so
+the changed-lines fallback resolver can pick the canonical direct test path:
+tests/test_adapter_runtime_service.py.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tests.test_academy_adapter_runtime_service import *  # noqa: F401,F403
+from venom_core.services.academy import adapter_runtime_service as ars
+
+
+class _BadStr:
+    def __str__(self) -> str:
+        raise RuntimeError("boom")
+
+
+def test_parse_positive_numeric_defaults_on_bad_str_and_invalid_values() -> None:
+    assert ars._parse_positive_float(_BadStr(), default=0.25) == 0.25
+    assert ars._parse_positive_int(_BadStr(), default=15360) == 15360
+
+
+def test_resolve_limits_defaults_without_env_or_settings(monkeypatch) -> None:
+    monkeypatch.delenv("ACADEMY_ADAPTER_MERGE_MAX_RSS_MB", raising=False)
+    monkeypatch.delenv("VENOM_ADAPTER_MERGE_MAX_RSS_MB", raising=False)
+    monkeypatch.delenv("ACADEMY_ADAPTER_MEMORY_MONITOR_INTERVAL_SEC", raising=False)
+    monkeypatch.delenv("VENOM_ADAPTER_MEMORY_MONITOR_INTERVAL_SEC", raising=False)
+    settings = SimpleNamespace(
+        ACADEMY_ADAPTER_MERGE_MAX_RSS_MB=None,
+        ACADEMY_ADAPTER_MEMORY_MONITOR_INTERVAL_SEC=None,
+    )
+    assert ars._resolve_merge_memory_limit_mb(settings_obj=settings) == 15360
+    assert ars._resolve_memory_monitor_interval_sec(settings_obj=settings) == 0.25
+
+
+def test_read_process_rss_mb_returns_zero_when_proc_unavailable() -> None:
+    assert ars._read_process_rss_mb(pid=999999999) == 0.0
+
+
+def test_terminate_process_with_grace_calls_kill_when_still_running(
+    monkeypatch,
+) -> None:
+    class _Proc:
+        def __init__(self) -> None:
+            self.signaled = False
+            self.killed = False
+
+        def send_signal(self, _sig) -> None:
+            self.signaled = True
+
+        def poll(self):
+            return None
+
+        def kill(self) -> None:
+            self.killed = True
+
+    proc = _Proc()
+    with patch.object(ars.time, "monotonic", side_effect=[0.0, 10.0]):
+        ars._terminate_process_with_grace(
+            process=proc, stop_event=ars.threading.Event()
+        )
+    assert proc.signaled is True
+    assert proc.killed is True
+
+
+def test_monitor_subprocess_memory_marks_exceeded_and_terminates(monkeypatch) -> None:
+    class _Proc:
+        pid = 123
+
+        def poll(self):
+            return None
+
+    state = {"peak_rss_mb": 0.0, "exceeded": False}
+    stop = ars.threading.Event()
+    monkeypatch.setattr(ars, "_read_process_rss_mb", lambda pid: 200.0)
+    terminated = {"called": False}
+
+    def _terminate(*, process, stop_event):
+        terminated["called"] = True
+        stop_event.set()
+
+    monkeypatch.setattr(ars, "_terminate_process_with_grace", _terminate)
+    ars._monitor_subprocess_memory(
+        process=_Proc(),
+        state=state,
+        stop_event=stop,
+        max_rss_mb=100,
+        monitor_interval_sec=0.01,
+    )
+    assert state["exceeded"] is True
+    assert terminated["called"] is True
+
+
+def test_build_onnx_export_cmd_covers_execution_provider_and_precision(
+    tmp_path: Path,
+) -> None:
+    cmd = ars._build_onnx_export_cmd(
+        builder_script=tmp_path / "builder.py",
+        export_input=tmp_path / "input",
+        execution_provider="cpu",
+        precision="int4",
+        tmp_dir=tmp_path / "out",
+    )
+    assert cmd[0] == ars.sys.executable
+    assert "-e" in cmd and "cpu" in cmd
+    assert "-p" in cmd and "int4" in cmd
+
+
+def test_resolve_onnx_builder_script_error_message_includes_default_paths(monkeypatch):
+    monkeypatch.delenv("ONNX_GENAI_BUILDER_SCRIPT", raising=False)
+    with (
+        patch.object(ars, "_resolve_first_existing_file", return_value=None),
+        patch.object(ars, "_resolve_installed_onnx_builder", return_value=None),
+        patch.object(ars, "_resolve_repo_root", return_value=Path("/tmp/repo")),
+    ):
+        with pytest.raises(FileNotFoundError, match="default paths"):
+            ars._resolve_onnx_builder_script(
+                settings_obj=SimpleNamespace(ONNX_BUILDER_SCRIPT="")
+            )

--- a/tests/test_llm_simple_service_streaming.py
+++ b/tests/test_llm_simple_service_streaming.py
@@ -128,6 +128,62 @@ def test_build_payload_includes_top_p_when_provided():
     assert payload["top_p"] == 0.9
 
 
+def test_build_payload_includes_logprobs_and_top_logprobs():
+    request = SimpleChatRequest(
+        content="hello",
+        logprobs=True,
+        top_logprobs=3,
+    )
+    runtime = _Runtime("openai")
+    payload = llm_simple_service._build_payload(
+        request=request,
+        runtime=runtime,
+        model_name="model-x",
+        messages=[{"role": "user", "content": "hello"}],
+        stream=False,
+    )
+    assert payload["logprobs"] is True
+    assert payload["top_logprobs"] == 3
+
+
+def test_extract_logprobs_telemetry_guard_branches():
+    assert llm_simple_service._extract_logprobs_telemetry({}) is None
+    assert llm_simple_service._extract_logprobs_telemetry({"choices": [{}]}) is None
+    assert (
+        llm_simple_service._extract_logprobs_telemetry(
+            {"choices": [{"logprobs": {"content": "bad"}}]}
+        )
+        is None
+    )
+
+
+def test_extract_logprobs_telemetry_normalizes_valid_items():
+    payload = {
+        "choices": [
+            {
+                "logprobs": {
+                    "content": [
+                        {
+                            "token": "A",
+                            "logprob": -0.1,
+                            "top_logprobs": [
+                                None,
+                                {"token": "B", "logprob": -0.2},
+                            ],
+                        },
+                        {"token": "skip", "logprob": "bad"},
+                    ]
+                }
+            }
+        ]
+    }
+    telemetry = llm_simple_service._extract_logprobs_telemetry(payload)
+    assert telemetry is not None
+    assert telemetry["kind"] == "logprobs"
+    assert telemetry["content"][0]["token"] == "A"
+    assert telemetry["content"][0]["top_logprobs"][0]["token"] == "B"
+
+
 @pytest.mark.asyncio
 async def test_get_active_adapter_id_variants(monkeypatch):
     monkeypatch.setattr(llm_simple_service, "get_model_manager", lambda: None)

--- a/tests/test_llm_simple_service_streaming.py
+++ b/tests/test_llm_simple_service_streaming.py
@@ -180,6 +180,7 @@ def test_extract_logprobs_telemetry_normalizes_valid_items():
     telemetry = llm_simple_service._extract_logprobs_telemetry(payload)
     assert telemetry is not None
     assert telemetry["kind"] == "logprobs"
+    assert len(telemetry["content"]) == 1
     assert telemetry["content"][0]["token"] == "A"
     assert telemetry["content"][0]["top_logprobs"][0]["token"] == "B"
 

--- a/tests/test_model_introspection_analysis_service.py
+++ b/tests/test_model_introspection_analysis_service.py
@@ -224,6 +224,7 @@ async def test_analysis_collects_streamed_answer(
     assert result["analysis"]["analysis_capabilities"]["total_count"] == 3
     assert result["analysis"]["analysis_capabilities"]["probe_profile"] == "dev"
     assert result["analysis"]["analysis_capabilities"]["limits"]["max_head_count"] == 32
+    assert result["analysis"]["introspection_level"] in {"full", "lite", "none"}
     assert "run_trends" in result["analysis"]
 
 
@@ -790,21 +791,31 @@ def test_classify_stream_quality_variants() -> None:
 
 def test_build_logit_lens_timeline_step_for_failed_probe() -> None:
     step = analysis_service._build_logit_lens_timeline_step(
-        logit_lens={"status": "failed", "code": "probe_timeout"},
+        logit_lens={
+            "status": "failed",
+            "code": "probe_timeout",
+            "message": "Probe request timed out on active runtime",
+        },
         at_ms=100.0,
     )
     assert step["status"] == "failed"
-    assert step["detail"] == "probe_timeout"
+    assert step["detail"] == "Probe request timed out on active runtime (probe_timeout)"
     assert step["reason_code"] == "probe_timeout"
 
 
 def test_build_logit_lens_timeline_step_for_unavailable_probe() -> None:
     step = analysis_service._build_logit_lens_timeline_step(
-        logit_lens={"status": "probe_unavailable", "code": "probe_disabled"},
+        logit_lens={
+            "status": "probe_unavailable",
+            "code": "probe_disabled",
+            "message": "Probe is disabled by runtime configuration",
+        },
         at_ms=100.0,
     )
     assert step["status"] == "skipped"
-    assert step["detail"] == "probe_disabled"
+    assert (
+        step["detail"] == "Probe is disabled by runtime configuration (probe_disabled)"
+    )
     assert step["reason_code"] == "probe_disabled"
 
 
@@ -812,11 +823,18 @@ def test_build_probe_timeline_step_for_failed_probe() -> None:
     step = analysis_service._build_probe_timeline_step(
         step_id="attention_probe",
         step_label="Attention probe",
-        payload={"status": "failed", "code": "probe_transport_error"},
+        payload={
+            "status": "failed",
+            "code": "probe_transport_error",
+            "message": "Probe transport error on active runtime",
+        },
         at_ms=42.0,
     )
     assert step["status"] == "failed"
-    assert step["detail"] == "probe_transport_error"
+    assert (
+        step["detail"]
+        == "Probe transport error on active runtime (probe_transport_error)"
+    )
     assert step["reason_code"] == "probe_transport_error"
 
 
@@ -927,6 +945,81 @@ def test_analysis_capabilities_marks_failed_and_unavailable_classes() -> None:
     assert payload["attention"]["availability_class"] == "failed"
     assert payload["saliency"]["availability_class"] == "unavailable"
     assert payload["logit_lens"]["availability_class"] == "native_ok"
+
+
+def test_analysis_capabilities_marks_probe_lite_as_available_proxy() -> None:
+    payload = analysis_service._build_analysis_capabilities_payload(
+        attention={"source": "probe_unavailable", "status": "probe_unavailable"},
+        saliency={"source": "probe_unavailable", "status": "probe_unavailable"},
+        logit_lens={
+            "source": "probe_lite",
+            "status": "ok",
+            "code": "ollama_logprobs_lite",
+        },
+        probe_health={"enabled": False, "healthy": False, "runtime_supported": False},
+    )
+    assert payload["available_count"] == 1
+    assert payload["native_available_count"] == 0
+    assert payload["proxy_active"] is True
+    assert payload["internals_verdict"] == "partial"
+    assert payload["logit_lens"]["availability_class"] == "proxy_ok"
+
+
+@pytest.mark.asyncio
+async def test_analysis_ollama_requests_non_stream_logprobs_and_uses_lite_logit_lens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    snapshot = _build_snapshot()
+    snapshot["runtime"]["provider"] = "ollama"
+    snapshot["runtime"]["model"] = "gemma3:latest"
+    snapshot["runtime"]["endpoint"] = "http://localhost:11434/v1"
+    snapshot["runtime"]["label"] = "gemma3:latest · ollama @ localhost:11434"
+
+    async def fake_snapshot(**kwargs):
+        return snapshot
+
+    async def fake_stream_simple_chat(request):
+        assert request.stream is False
+        assert request.logprobs is True
+        assert request.top_logprobs == 3
+        return _FakeStreamingResponse(
+            [
+                "event: start\ndata: {}\n\n",
+                'event: telemetry\ndata: {"kind":"logprobs","content":[{"token":"Słońce","logprob":-0.1,"top_logprobs":[{"token":"Słońce","logprob":-0.1},{"token":"Planeta","logprob":-2.0}]}]}\n\n',
+                'event: content\ndata: {"text":"Słońce to gwiazda."}\n\n',
+                "event: done\ndata: {}\n\n",
+            ]
+        )
+
+    async def _unexpected_probe_call(**_kwargs):
+        raise AssertionError("probe path should not be used for ollama lite mode")
+
+    monkeypatch.setattr(
+        analysis_service,
+        "build_model_introspection_snapshot",
+        fake_snapshot,
+    )
+    monkeypatch.setattr(analysis_service, "stream_simple_chat", fake_stream_simple_chat)
+    monkeypatch.setattr(
+        analysis_service,
+        "_collect_logit_lens_payload_safe",
+        _unexpected_probe_call,
+    )
+
+    result = await analysis_service.analyze_model_with_optional_live_run(
+        prompt="Co to jest slonce?",
+        live_analysis_enabled=True,
+    )
+
+    assert result["status"] == "completed"
+    assert result["analysis"]["logit_lens"]["source"] == "probe_lite"
+    assert result["analysis"]["logit_lens"]["status"] == "ok"
+    assert (
+        result["analysis"]["analysis_capabilities"]["logit_lens"]["available"] is True
+    )
+    assert result["analysis"]["analysis_capabilities"]["logit_lens"]["proxy"] is True
+    assert result["analysis"]["analysis_capabilities"]["introspection_level"] == "lite"
+    assert result["analysis"]["introspection_level"] == "lite"
 
 
 def test_operator_conclusion_uses_proxy_reason_code() -> None:

--- a/tests/test_model_registry_clients_additional.py
+++ b/tests/test_model_registry_clients_additional.py
@@ -274,6 +274,48 @@ async def test_ollama_list_tags_returns_empty_on_exception():
 
 
 @pytest.mark.asyncio
+async def test_ollama_get_model_show_strips_v1_suffix_for_api_call():
+    client = mrc.OllamaClient(endpoint="http://localhost:11434/v1")
+    response = MagicMock()
+    response.json.return_value = {"model": "gemma3:latest"}
+
+    with patch(
+        "venom_core.core.model_registry_clients.TrafficControlledHttpClient"
+    ) as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.apost = AsyncMock(return_value=response)
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        payload = await client.get_model_show("gemma3:latest")
+
+    assert payload == {"model": "gemma3:latest"}
+    called_url = mock_client.apost.await_args.args[0]
+    assert called_url == "http://localhost:11434/api/show"
+
+
+@pytest.mark.asyncio
+async def test_ollama_chat_strips_v1_suffix_for_api_call():
+    client = mrc.OllamaClient(endpoint="http://localhost:11434/v1")
+    response = MagicMock()
+    response.json.return_value = {"message": {"content": "ok"}}
+
+    with patch(
+        "venom_core.core.model_registry_clients.TrafficControlledHttpClient"
+    ) as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.apost = AsyncMock(return_value=response)
+        mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        payload = await client.chat({"model": "gemma3:latest"})
+
+    assert payload == {"message": {"content": "ok"}}
+    called_url = mock_client.apost.await_args.args[0]
+    assert called_url == "http://localhost:11434/api/chat"
+
+
+@pytest.mark.asyncio
 async def test_ollama_search_models_success_and_failure():
     client = mrc.OllamaClient(endpoint="http://localhost:11434")
 

--- a/tests/test_models_introspection_api.py
+++ b/tests/test_models_introspection_api.py
@@ -49,6 +49,8 @@ def test_model_introspection_includes_runtime_packages() -> None:
     snapshot = payload["snapshot"]
     assert payload["success"] is True
     assert snapshot["summary"]["introspection_ready"] is True
+    assert snapshot["summary"]["introspection_level"] in {"full", "lite", "none"}
+    assert snapshot["introspection_level"] in {"full", "lite", "none"}
     assert snapshot["reuse"]["brain"]["path"] == "/brain"
     assert snapshot["reuse"]["diagnostics"][0]["id"] == "217da"
     assert snapshot["model_manager"]["available"] is True

--- a/tests/test_models_introspection_api.py
+++ b/tests/test_models_introspection_api.py
@@ -116,3 +116,29 @@ def test_probe_package_handles_version_lookup_failures(
     probe_generic = snapshot_service._probe_package("x.module", "x-package")
     assert probe_generic["available"] is True
     assert probe_generic["version"] is None
+
+
+def test_resolve_snapshot_introspection_level_full_and_none() -> None:
+    full = snapshot_service._resolve_snapshot_introspection_level(
+        runtime_provider="multi_runtime",
+        probe_health={
+            "enabled": True,
+            "runtime_supported": True,
+            "endpoint_configured": True,
+            "model_whitelisted": True,
+            "healthy": True,
+        },
+    )
+    assert full == "full"
+
+    none = snapshot_service._resolve_snapshot_introspection_level(
+        runtime_provider="multi_runtime",
+        probe_health={
+            "enabled": True,
+            "runtime_supported": True,
+            "endpoint_configured": True,
+            "model_whitelisted": False,
+            "healthy": True,
+        },
+    )
+    assert none == "none"

--- a/tests/test_providers_api_edges.py
+++ b/tests/test_providers_api_edges.py
@@ -147,7 +147,7 @@ async def test_check_ollama_status_connected_includes_runtime_version(
             responses_by_url={
                 "http://localhost:11434/api/tags": _DummyResponse(200),
                 "http://localhost:11434/api/version": _DummyResponse(
-                    200, {"version": "0.16.1"}
+                    200, {"version": "0.24.0"}
                 ),
             }
         ),
@@ -155,7 +155,7 @@ async def test_check_ollama_status_connected_includes_runtime_version(
 
     status = await providers_route._check_ollama_status()
     assert status.status == "connected"
-    assert status.runtime_version == "0.16.1"
+    assert status.runtime_version == "0.24.0"
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_controller_api.py
+++ b/tests/test_runtime_controller_api.py
@@ -142,7 +142,7 @@ class TestRuntimeStatusAPI:
             mock_ollama.uptime_seconds = None
             mock_ollama.last_log = None
             mock_ollama.error_message = None
-            mock_ollama.runtime_version = "0.16.1"
+            mock_ollama.runtime_version = "0.24.0"
             mock_ollama.actionable = True
             mock_controller.get_all_services_status.return_value = [mock_ollama]
 
@@ -150,7 +150,7 @@ class TestRuntimeStatusAPI:
 
             assert response.status_code == 200
             data = response.json()
-            assert data["services"][0]["runtime_version"] == "0.16.1"
+            assert data["services"][0]["runtime_version"] == "0.24.0"
 
     def test_runtime_status_error(self, client):
         """Test błędu podczas pobierania statusu runtime."""

--- a/venom_core/api/schemas/llm_simple.py
+++ b/venom_core/api/schemas/llm_simple.py
@@ -13,6 +13,9 @@ class SimpleChatRequest(BaseModel):
     max_tokens: Optional[int] = None
     temperature: Optional[float] = None
     top_p: Optional[float] = Field(default=None, gt=0.0, le=1.0)
+    logprobs: Optional[bool] = None
+    top_logprobs: Optional[int] = Field(default=None, ge=0, le=20)
+    stream: Optional[bool] = None
     response_format: Optional[dict[str, Any] | str] = None
     format: Optional[dict[str, Any] | str] = None
     tools: Optional[list[dict[str, Any]]] = None

--- a/venom_core/core/model_registry_clients.py
+++ b/venom_core/core/model_registry_clients.py
@@ -19,6 +19,14 @@ from venom_core.utils.url_policy import build_http_url
 logger = get_logger(__name__)
 
 
+def _normalize_ollama_endpoint(endpoint: str) -> str:
+    """Normalizuje endpoint Ollama do bazowego URL bez sufiksu `/v1`."""
+    normalized = endpoint.rstrip("/")
+    if normalized.endswith("/v1"):
+        return normalized[: -len("/v1")]
+    return normalized
+
+
 def _normalize_hf_papers_month(month: Optional[str]) -> str:
     """Zwraca bezpieczny segment URL miesiąca w formacie YYYY-MM."""
     if month:
@@ -39,7 +47,8 @@ class OllamaClient:
     """Klient do integracji z Ollama (HTTP + CLI)."""
 
     def __init__(self, endpoint: Optional[str] = None):
-        self.endpoint = (endpoint or build_http_url("localhost", 11434)).rstrip("/")
+        resolved_endpoint = endpoint or build_http_url("localhost", 11434)
+        self.endpoint = _normalize_ollama_endpoint(resolved_endpoint)
 
     async def list_tags(self) -> Dict[str, Any]:
         async with TrafficControlledHttpClient(

--- a/venom_core/services/llm_simple_service.py
+++ b/venom_core/services/llm_simple_service.py
@@ -433,6 +433,19 @@ def _build_payload(
 
 
 def _extract_logprobs_telemetry(data: dict[str, Any]) -> dict[str, Any] | None:
+    content = _extract_logprobs_content(data)
+    if content is None:
+        return None
+    normalized = _normalize_logprobs_content(content)
+    if not normalized:
+        return None
+    return {
+        "kind": "logprobs",
+        "content": normalized,
+    }
+
+
+def _extract_logprobs_content(data: dict[str, Any]) -> list[Any] | None:
     choices = data.get("choices")
     if not isinstance(choices, list) or not choices:
         return None
@@ -443,46 +456,49 @@ def _extract_logprobs_telemetry(data: dict[str, Any]) -> dict[str, Any] | None:
     if not isinstance(logprobs, dict):
         return None
     content = logprobs.get("content")
-    if not isinstance(content, list):
-        return None
+    return content if isinstance(content, list) else None
 
+
+def _normalize_logprobs_content(content: list[Any]) -> list[dict[str, Any]]:
     normalized: list[dict[str, Any]] = []
     for item in content[:128]:
-        if not isinstance(item, dict):
-            continue
-        token = str(item.get("token") or "")
-        raw_logprob = item.get("logprob")
-        if not isinstance(raw_logprob, (int, float)):
-            continue
-        top_logprobs_raw = item.get("top_logprobs")
-        top_logprobs: list[dict[str, Any]] = []
-        if isinstance(top_logprobs_raw, list):
-            for top_item in top_logprobs_raw[:8]:
-                if not isinstance(top_item, dict):
-                    continue
-                top_token = str(top_item.get("token") or "")
-                top_logprob = top_item.get("logprob")
-                if not isinstance(top_logprob, (int, float)):
-                    continue
-                top_logprobs.append(
-                    {
-                        "token": top_token,
-                        "logprob": float(top_logprob),
-                    }
-                )
-        normalized.append(
-            {
-                "token": token,
-                "logprob": float(raw_logprob),
-                "top_logprobs": top_logprobs,
-            }
-        )
-    if not normalized:
+        normalized_item = _normalize_logprobs_item(item)
+        if normalized_item is not None:
+            normalized.append(normalized_item)
+    return normalized
+
+
+def _normalize_logprobs_item(item: Any) -> dict[str, Any] | None:
+    if not isinstance(item, dict):
+        return None
+    raw_logprob = item.get("logprob")
+    if not isinstance(raw_logprob, (int, float)):
         return None
     return {
-        "kind": "logprobs",
-        "content": normalized,
+        "token": str(item.get("token") or ""),
+        "logprob": float(raw_logprob),
+        "top_logprobs": _normalize_top_logprobs(item.get("top_logprobs")),
     }
+
+
+def _normalize_top_logprobs(top_logprobs_raw: Any) -> list[dict[str, Any]]:
+    if not isinstance(top_logprobs_raw, list):
+        return []
+    normalized: list[dict[str, Any]] = []
+    for top_item in top_logprobs_raw[:8]:
+        normalized_item = _normalize_top_logprobs_item(top_item)
+        if normalized_item is not None:
+            normalized.append(normalized_item)
+    return normalized
+
+
+def _normalize_top_logprobs_item(top_item: Any) -> dict[str, Any] | None:
+    if not isinstance(top_item, dict):
+        return None
+    top_logprob = top_item.get("logprob")
+    if not isinstance(top_logprob, (int, float)):
+        return None
+    return {"token": str(top_item.get("token") or ""), "logprob": float(top_logprob)}
 
 
 def _extract_message_content(data: dict[str, object], fallback_text: str = "") -> str:

--- a/venom_core/services/llm_simple_service.py
+++ b/venom_core/services/llm_simple_service.py
@@ -425,7 +425,64 @@ def _build_payload(
         payload["temperature"] = request.temperature
     if request.top_p is not None:
         payload["top_p"] = request.top_p
+    if request.logprobs is not None:
+        payload["logprobs"] = bool(request.logprobs)
+    if request.top_logprobs is not None:
+        payload["top_logprobs"] = int(request.top_logprobs)
     return payload
+
+
+def _extract_logprobs_telemetry(data: dict[str, Any]) -> dict[str, Any] | None:
+    choices = data.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return None
+    first_choice = choices[0]
+    if not isinstance(first_choice, dict):
+        return None
+    logprobs = first_choice.get("logprobs")
+    if not isinstance(logprobs, dict):
+        return None
+    content = logprobs.get("content")
+    if not isinstance(content, list):
+        return None
+
+    normalized: list[dict[str, Any]] = []
+    for item in content[:128]:
+        if not isinstance(item, dict):
+            continue
+        token = str(item.get("token") or "")
+        raw_logprob = item.get("logprob")
+        if not isinstance(raw_logprob, (int, float)):
+            continue
+        top_logprobs_raw = item.get("top_logprobs")
+        top_logprobs: list[dict[str, Any]] = []
+        if isinstance(top_logprobs_raw, list):
+            for top_item in top_logprobs_raw[:8]:
+                if not isinstance(top_item, dict):
+                    continue
+                top_token = str(top_item.get("token") or "")
+                top_logprob = top_item.get("logprob")
+                if not isinstance(top_logprob, (int, float)):
+                    continue
+                top_logprobs.append(
+                    {
+                        "token": top_token,
+                        "logprob": float(top_logprob),
+                    }
+                )
+        normalized.append(
+            {
+                "token": token,
+                "logprob": float(raw_logprob),
+                "top_logprobs": top_logprobs,
+            }
+        )
+    if not normalized:
+        return None
+    return {
+        "kind": "logprobs",
+        "content": normalized,
+    }
 
 
 def _extract_message_content(data: dict[str, object], fallback_text: str = "") -> str:
@@ -1067,6 +1124,13 @@ async def _stream_simple_chunks_non_stream(
             return
 
         content = _extract_message_content(data, fallback_text="")
+        logprobs_telemetry = _extract_logprobs_telemetry(data)
+        if logprobs_telemetry is not None:
+            yield (
+                "event: telemetry\ndata: "
+                + json.dumps(logprobs_telemetry, ensure_ascii=False)
+                + "\n\n"
+            )
         if content:
             chunks.append(content)
             _trace_first_chunk(request_id, stream_start, content)
@@ -1144,7 +1208,8 @@ async def stream_simple_chat(request: SimpleChatRequest):
             headers=headers,
         )
 
-    if is_multi_runtime(runtime_provider):
+    force_non_stream = request.stream is False
+    if is_multi_runtime(runtime_provider) or force_non_stream:
         if not completions_url:
             raise HTTPException(status_code=503, detail="Brak endpointu LLM.")
         return StreamingResponse(

--- a/venom_core/services/model_introspection_analysis_service.py
+++ b/venom_core/services/model_introspection_analysis_service.py
@@ -1680,6 +1680,30 @@ async def _collect_streaming_response(response: Any) -> dict[str, Any]:
     }
 
 
+def _ollama_lite_probe_unavailable_payload(runtime: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "source": "probe_unavailable",
+        "status": "probe_unavailable",
+        "code": "ollama_logprobs_unavailable",
+        "message": "Token-level logprobs are unavailable for this run",
+        "runtime_label": runtime.get("label"),
+        "checkpoints": [],
+        "signals": {
+            "early_unstable": False,
+            "late_stabilized": False,
+            "low_confidence_path": False,
+        },
+        "interpretability": {
+            "interpretable": False,
+            "confidence_band": "unknown",
+            "token_noise_ratio": 1.0,
+            "readable_top_tokens": 0,
+            "total_top_tokens": 0,
+        },
+        "diagnostics": {},
+    }
+
+
 def _build_ollama_lite_logit_lens_payload(
     *,
     prompt: str,
@@ -1697,27 +1721,7 @@ def _build_ollama_lite_logit_lens_payload(
         None,
     )
     if not isinstance(logprobs_packet, dict):
-        return {
-            "source": "probe_unavailable",
-            "status": "probe_unavailable",
-            "code": "ollama_logprobs_unavailable",
-            "message": "Token-level logprobs are unavailable for this run",
-            "runtime_label": runtime.get("label"),
-            "checkpoints": [],
-            "signals": {
-                "early_unstable": False,
-                "late_stabilized": False,
-                "low_confidence_path": False,
-            },
-            "interpretability": {
-                "interpretable": False,
-                "confidence_band": "unknown",
-                "token_noise_ratio": 1.0,
-                "readable_top_tokens": 0,
-                "total_top_tokens": 0,
-            },
-            "diagnostics": {},
-        }
+        return _ollama_lite_probe_unavailable_payload(runtime)
 
     content_raw = logprobs_packet.get("content")
     content = content_raw if isinstance(content_raw, list) else []
@@ -1754,27 +1758,7 @@ def _build_ollama_lite_logit_lens_payload(
         )
 
     if not normalized_tokens:
-        return {
-            "source": "probe_unavailable",
-            "status": "probe_unavailable",
-            "code": "ollama_logprobs_unavailable",
-            "message": "Token-level logprobs are unavailable for this run",
-            "runtime_label": runtime.get("label"),
-            "checkpoints": [],
-            "signals": {
-                "early_unstable": False,
-                "late_stabilized": False,
-                "low_confidence_path": False,
-            },
-            "interpretability": {
-                "interpretable": False,
-                "confidence_band": "unknown",
-                "token_noise_ratio": 1.0,
-                "readable_top_tokens": 0,
-                "total_top_tokens": 0,
-            },
-            "diagnostics": {},
-        }
+        return _ollama_lite_probe_unavailable_payload(runtime)
 
     token_count = len(normalized_tokens)
     checkpoint_indices = sorted(
@@ -1798,7 +1782,7 @@ def _build_ollama_lite_logit_lens_payload(
         checkpoints.append(
             {
                 "id": f"cp_{idx}",
-                "percent": int(round((token_index / max(1, token_count - 1)) * 100)),
+                "percent": round((token_index / max(1, token_count - 1)) * 100),
                 "layer": -1,
                 "top_k": top_k,
                 "top_token": token,
@@ -1808,7 +1792,7 @@ def _build_ollama_lite_logit_lens_payload(
         )
         previous_token = token
 
-    avg_prob = sum(probabilities) / len(probabilities)
+    avg_prob = (sum(probabilities) / len(probabilities)) if probabilities else 0.0
     confidence_band = (
         "high" if avg_prob >= 0.75 else ("medium" if avg_prob >= 0.5 else "low")
     )

--- a/venom_core/services/model_introspection_analysis_service.py
+++ b/venom_core/services/model_introspection_analysis_service.py
@@ -132,31 +132,95 @@ def _consume_sse_events(
     telemetry_packets: list[dict[str, Any]] | None = None,
 ) -> tuple[int, float | None]:
     for event_name, payload in drained_events:
-        events.append(event_name)
-        if event_name == "telemetry" and telemetry_packets is not None:
-            parsed_telemetry = _parse_json_dict(payload)
-            if parsed_telemetry:
-                telemetry_packets.append(parsed_telemetry)
-        if event_name == "error":
-            parsed_error = _parse_json_dict(payload)
-            message = str(
-                parsed_error.get("message")
-                or parsed_error.get("code")
-                or payload
-                or _ANALYSIS_STREAM_FAILED
-            )
-            raise RuntimeError(message)
-        if event_name != "content":
-            continue
-        text = _extract_content_text(payload)
-        if not text:
-            continue
-        content_parts.append(text)
-        chunk_count += 1
-        if content_event_times_ms is not None:
-            content_event_times_ms.append(chunk_at_ms)
-        if first_content_at_ms is None:
-            first_content_at_ms = chunk_at_ms
+        chunk_count, first_content_at_ms = _consume_single_sse_event(
+            event_name=event_name,
+            payload=payload,
+            events=events,
+            content_parts=content_parts,
+            chunk_count=chunk_count,
+            first_content_at_ms=first_content_at_ms,
+            chunk_at_ms=chunk_at_ms,
+            content_event_times_ms=content_event_times_ms,
+            telemetry_packets=telemetry_packets,
+        )
+    return chunk_count, first_content_at_ms
+
+
+def _consume_single_sse_event(
+    *,
+    event_name: str,
+    payload: str,
+    events: list[str],
+    content_parts: list[str],
+    chunk_count: int,
+    first_content_at_ms: float | None,
+    chunk_at_ms: float,
+    content_event_times_ms: list[float] | None,
+    telemetry_packets: list[dict[str, Any]] | None,
+) -> tuple[int, float | None]:
+    events.append(event_name)
+    _append_telemetry_packet_if_present(
+        event_name=event_name,
+        payload=payload,
+        telemetry_packets=telemetry_packets,
+    )
+    _raise_error_event_if_needed(event_name=event_name, payload=payload)
+    if event_name != "content":
+        return chunk_count, first_content_at_ms
+    return _append_content_event(
+        payload=payload,
+        content_parts=content_parts,
+        chunk_count=chunk_count,
+        first_content_at_ms=first_content_at_ms,
+        chunk_at_ms=chunk_at_ms,
+        content_event_times_ms=content_event_times_ms,
+    )
+
+
+def _append_telemetry_packet_if_present(
+    *,
+    event_name: str,
+    payload: str,
+    telemetry_packets: list[dict[str, Any]] | None,
+) -> None:
+    if event_name != "telemetry" or telemetry_packets is None:
+        return
+    parsed_telemetry = _parse_json_dict(payload)
+    if parsed_telemetry:
+        telemetry_packets.append(parsed_telemetry)
+
+
+def _raise_error_event_if_needed(*, event_name: str, payload: str) -> None:
+    if event_name != "error":
+        return
+    parsed_error = _parse_json_dict(payload)
+    message = str(
+        parsed_error.get("message")
+        or parsed_error.get("code")
+        or payload
+        or _ANALYSIS_STREAM_FAILED
+    )
+    raise RuntimeError(message)
+
+
+def _append_content_event(
+    *,
+    payload: str,
+    content_parts: list[str],
+    chunk_count: int,
+    first_content_at_ms: float | None,
+    chunk_at_ms: float,
+    content_event_times_ms: list[float] | None,
+) -> tuple[int, float | None]:
+    text = _extract_content_text(payload)
+    if not text:
+        return chunk_count, first_content_at_ms
+    content_parts.append(text)
+    chunk_count += 1
+    if content_event_times_ms is not None:
+        content_event_times_ms.append(chunk_at_ms)
+    if first_content_at_ms is None:
+        first_content_at_ms = chunk_at_ms
     return chunk_count, first_content_at_ms
 
 
@@ -1710,92 +1774,16 @@ def _build_ollama_lite_logit_lens_payload(
     runtime: dict[str, Any],
     stream_payload: dict[str, Any],
 ) -> dict[str, Any]:
-    telemetry_raw = stream_payload.get("telemetry")
-    telemetry_packets = telemetry_raw if isinstance(telemetry_raw, list) else []
-    logprobs_packet = next(
-        (
-            packet
-            for packet in telemetry_packets
-            if isinstance(packet, dict) and str(packet.get("kind") or "") == "logprobs"
-        ),
-        None,
-    )
-    if not isinstance(logprobs_packet, dict):
+    logprobs_packet = _resolve_ollama_logprobs_packet(stream_payload)
+    if logprobs_packet is None:
         return _ollama_lite_probe_unavailable_payload(runtime)
-
-    content_raw = logprobs_packet.get("content")
-    content = content_raw if isinstance(content_raw, list) else []
-    normalized_tokens: list[dict[str, Any]] = []
-    for item in content:
-        if not isinstance(item, dict):
-            continue
-        token = str(item.get("token") or "")
-        raw_logprob = item.get("logprob")
-        if not isinstance(raw_logprob, (int, float)):
-            continue
-        top_raw = item.get("top_logprobs")
-        top_items = top_raw if isinstance(top_raw, list) else []
-        top_k: list[dict[str, Any]] = []
-        for top_item in top_items:
-            if not isinstance(top_item, dict):
-                continue
-            top_token = str(top_item.get("token") or "")
-            top_logprob = top_item.get("logprob")
-            if not isinstance(top_logprob, (int, float)):
-                continue
-            top_k.append(
-                {
-                    "token": top_token,
-                    "score": float(top_logprob),
-                }
-            )
-        normalized_tokens.append(
-            {
-                "token": token,
-                "logprob": float(raw_logprob),
-                "top_k": top_k,
-            }
-        )
-
+    normalized_tokens = _normalize_ollama_logprobs_tokens(logprobs_packet)
     if not normalized_tokens:
         return _ollama_lite_probe_unavailable_payload(runtime)
-
     token_count = len(normalized_tokens)
-    checkpoint_indices = sorted(
-        {
-            0,
-            token_count // 3,
-            (2 * token_count) // 3,
-            token_count - 1,
-        }
-    )
-    checkpoints: list[dict[str, Any]] = []
-    probabilities: list[float] = []
-    previous_token: str | None = None
-    for idx, token_index in enumerate(checkpoint_indices):
-        item = normalized_tokens[token_index]
-        top_k = item.get("top_k") or []
-        logprob = float(item["logprob"])
-        confidence = max(0.0, min(1.0, math.exp(logprob)))
-        probabilities.append(confidence)
-        token = str(item["token"])
-        checkpoints.append(
-            {
-                "id": f"cp_{idx}",
-                "percent": round((token_index / max(1, token_count - 1)) * 100),
-                "layer": -1,
-                "top_k": top_k,
-                "top_token": token,
-                "confidence": confidence,
-                "changed": previous_token is not None and token != previous_token,
-            }
-        )
-        previous_token = token
-
-    avg_prob = (sum(probabilities) / len(probabilities)) if probabilities else 0.0
-    confidence_band = (
-        "high" if avg_prob >= 0.75 else ("medium" if avg_prob >= 0.5 else "low")
-    )
+    checkpoints, probabilities = _build_ollama_checkpoint_series(normalized_tokens)
+    avg_prob = _average_probability(probabilities)
+    confidence_band = _resolve_confidence_band(avg_prob)
     return {
         "source": "probe_lite",
         "status": "ok",
@@ -1831,6 +1819,104 @@ def _build_ollama_lite_logit_lens_payload(
             "avg_top1_prob": round(avg_prob, 4),
         },
     }
+
+
+def _resolve_ollama_logprobs_packet(
+    stream_payload: dict[str, Any],
+) -> dict[str, Any] | None:
+    telemetry_raw = stream_payload.get("telemetry")
+    telemetry_packets = telemetry_raw if isinstance(telemetry_raw, list) else []
+    for packet in telemetry_packets:
+        if isinstance(packet, dict) and str(packet.get("kind") or "") == "logprobs":
+            return packet
+    return None
+
+
+def _normalize_ollama_logprobs_tokens(
+    logprobs_packet: dict[str, Any],
+) -> list[dict[str, Any]]:
+    content_raw = logprobs_packet.get("content")
+    content = content_raw if isinstance(content_raw, list) else []
+    normalized: list[dict[str, Any]] = []
+    for item in content:
+        normalized_item = _normalize_ollama_logprobs_token(item)
+        if normalized_item is not None:
+            normalized.append(normalized_item)
+    return normalized
+
+
+def _normalize_ollama_logprobs_token(item: Any) -> dict[str, Any] | None:
+    if not isinstance(item, dict):
+        return None
+    raw_logprob = item.get("logprob")
+    if not isinstance(raw_logprob, (int, float)):
+        return None
+    return {
+        "token": str(item.get("token") or ""),
+        "logprob": float(raw_logprob),
+        "top_k": _normalize_ollama_logprobs_top_k(item.get("top_logprobs")),
+    }
+
+
+def _normalize_ollama_logprobs_top_k(top_raw: Any) -> list[dict[str, Any]]:
+    top_items = top_raw if isinstance(top_raw, list) else []
+    normalized: list[dict[str, Any]] = []
+    for top_item in top_items:
+        normalized_item = _normalize_ollama_top_k_item(top_item)
+        if normalized_item is not None:
+            normalized.append(normalized_item)
+    return normalized
+
+
+def _normalize_ollama_top_k_item(top_item: Any) -> dict[str, Any] | None:
+    if not isinstance(top_item, dict):
+        return None
+    top_logprob = top_item.get("logprob")
+    if not isinstance(top_logprob, (int, float)):
+        return None
+    return {"token": str(top_item.get("token") or ""), "score": float(top_logprob)}
+
+
+def _build_ollama_checkpoint_series(
+    normalized_tokens: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[float]]:
+    token_count = len(normalized_tokens)
+    checkpoint_indices = sorted(
+        {0, token_count // 3, (2 * token_count) // 3, token_count - 1}
+    )
+    checkpoints: list[dict[str, Any]] = []
+    probabilities: list[float] = []
+    previous_token: str | None = None
+    for idx, token_index in enumerate(checkpoint_indices):
+        item = normalized_tokens[token_index]
+        confidence = max(0.0, min(1.0, math.exp(float(item["logprob"]))))
+        probabilities.append(confidence)
+        token = str(item["token"])
+        checkpoints.append(
+            {
+                "id": f"cp_{idx}",
+                "percent": round((token_index / max(1, token_count - 1)) * 100),
+                "layer": -1,
+                "top_k": item.get("top_k") or [],
+                "top_token": token,
+                "confidence": confidence,
+                "changed": previous_token is not None and token != previous_token,
+            }
+        )
+        previous_token = token
+    return checkpoints, probabilities
+
+
+def _average_probability(probabilities: list[float]) -> float:
+    return (sum(probabilities) / len(probabilities)) if probabilities else 0.0
+
+
+def _resolve_confidence_band(avg_prob: float) -> str:
+    if avg_prob >= 0.75:
+        return "high"
+    if avg_prob >= 0.5:
+        return "medium"
+    return "low"
 
 
 def _build_logit_lens_timeline_step(
@@ -2369,6 +2455,126 @@ async def _finalize_completed_analysis(
     return payload, refreshed_snapshot, effective_snapshot_after_at_ms
 
 
+@dataclass(frozen=True)
+class _LiveAnalysisBootstrap:
+    flow_started_at: float
+    snapshot: dict[str, Any]
+    runtime: dict[str, Any]
+    request_ready_at_ms: float
+    request: SimpleChatRequest
+    ollama_lite_mode: bool
+
+
+async def _prepare_live_analysis_bootstrap(
+    *,
+    prompt: str,
+    live_analysis_enabled: bool,
+    max_tokens: int | None,
+    temperature: float | None,
+    top_p: float | None,
+    model_manager: Any,
+    settings: Any,
+) -> _LiveAnalysisBootstrap | dict[str, Any]:
+    flow_started_at = time.perf_counter()
+    snapshot = await build_model_introspection_snapshot(
+        model_manager=model_manager,
+        settings=settings,
+    )
+    runtime = snapshot["runtime"]
+    if not live_analysis_enabled:
+        return {
+            "kind": "skipped",
+            "payload": _build_skipped_analysis_result(prompt, runtime),
+            "snapshot": snapshot,
+        }
+    if not prompt.strip():
+        raise ValueError("prompt cannot be empty")
+    drift_issue = _extract_model_drift_issue(snapshot)
+    if drift_issue is not None:
+        request_ready_at_ms = (time.perf_counter() - flow_started_at) * 1000.0
+        return {
+            "kind": "drift",
+            "payload": _build_model_drift_skipped_result(
+                prompt=prompt,
+                runtime=runtime,
+                request_ready_at_ms=request_ready_at_ms,
+                drift_issue=drift_issue,
+            ),
+            "snapshot": snapshot,
+        }
+
+    request_ready_at_ms = (time.perf_counter() - flow_started_at) * 1000.0
+    ollama_lite_mode = _is_ollama_runtime(runtime)
+    request = _build_live_analysis_request(
+        prompt=prompt,
+        runtime=runtime,
+        max_tokens=max_tokens,
+        temperature=temperature,
+        top_p=top_p,
+        ollama_lite_mode=ollama_lite_mode,
+    )
+    return _LiveAnalysisBootstrap(
+        flow_started_at=flow_started_at,
+        snapshot=snapshot,
+        runtime=runtime,
+        request_ready_at_ms=request_ready_at_ms,
+        request=request,
+        ollama_lite_mode=ollama_lite_mode,
+    )
+
+
+def _is_ollama_runtime(runtime: dict[str, Any]) -> bool:
+    runtime_provider = str(runtime.get("provider") or "").strip().lower()
+    return runtime_provider == "ollama"
+
+
+def _build_live_analysis_request(
+    *,
+    prompt: str,
+    runtime: dict[str, Any],
+    max_tokens: int | None,
+    temperature: float | None,
+    top_p: float | None,
+    ollama_lite_mode: bool,
+) -> SimpleChatRequest:
+    return SimpleChatRequest(
+        content=prompt,
+        model=runtime["model"],
+        max_tokens=max_tokens,
+        temperature=temperature,
+        top_p=top_p,
+        stream=False if ollama_lite_mode else None,
+        logprobs=True if ollama_lite_mode else None,
+        top_logprobs=3 if ollama_lite_mode else None,
+    )
+
+
+async def _collect_probe_payloads(
+    *,
+    prompt: str,
+    runtime: dict[str, Any],
+    stream_payload: dict[str, Any],
+    response_text: str,
+    ollama_lite_mode: bool,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    if ollama_lite_mode:
+        logit_lens = _build_ollama_lite_logit_lens_payload(
+            prompt=prompt,
+            runtime=runtime,
+            stream_payload=stream_payload,
+        )
+        attention, saliency = await asyncio.gather(
+            _collect_attention_payload_safe(prompt=prompt),
+            _collect_saliency_payload_safe(prompt=prompt, response_text=response_text),
+        )
+        return logit_lens, attention, saliency
+    return await asyncio.gather(
+        _collect_logit_lens_payload_safe(prompt=prompt, response_text=response_text),
+        _collect_attention_payload_safe(prompt=prompt),
+        _collect_saliency_payload_safe(prompt=prompt, response_text=response_text),
+    )
+
+
 async def stream_model_introspection_analysis(
     *,
     prompt: str,
@@ -2380,47 +2586,27 @@ async def stream_model_introspection_analysis(
     settings: Any = None,
 ) -> AsyncIterator[str]:
     """Stream introspection analysis as SSE, including live model chunks."""
-
-    flow_started_at = time.perf_counter()
-    snapshot = await build_model_introspection_snapshot(
-        model_manager=model_manager, settings=settings
-    )
-    runtime = snapshot["runtime"]
-    if not live_analysis_enabled:
-        skipped_result = _build_skipped_analysis_result(prompt, runtime)
-        yield _serialize_sse_event("analysis_start", skipped_result)
-        yield _serialize_sse_event("analysis_done", skipped_result)
-        return
-
-    if not prompt.strip():
-        raise ValueError("prompt cannot be empty")
-
-    drift_issue = _extract_model_drift_issue(snapshot)
-    if drift_issue is not None:
-        request_ready_at_ms = (time.perf_counter() - flow_started_at) * 1000.0
-        skipped_result = _build_model_drift_skipped_result(
-            prompt=prompt,
-            runtime=runtime,
-            request_ready_at_ms=request_ready_at_ms,
-            drift_issue=drift_issue,
-        )
-        yield _serialize_sse_event("analysis_start", skipped_result)
-        yield _serialize_sse_event("analysis_done", skipped_result)
-        return
-
-    runtime_provider = str(runtime.get("provider") or "").strip().lower()
-    ollama_lite_mode = runtime_provider == "ollama"
-    request = SimpleChatRequest(
-        content=prompt,
-        model=runtime["model"],
+    bootstrap = await _prepare_live_analysis_bootstrap(
+        prompt=prompt,
+        live_analysis_enabled=live_analysis_enabled,
         max_tokens=max_tokens,
         temperature=temperature,
         top_p=top_p,
-        stream=False if ollama_lite_mode else None,
-        logprobs=True if ollama_lite_mode else None,
-        top_logprobs=3 if ollama_lite_mode else None,
+        model_manager=model_manager,
+        settings=settings,
     )
-    request_ready_at_ms = (time.perf_counter() - flow_started_at) * 1000.0
+    if isinstance(bootstrap, dict):
+        skipped_result = dict(bootstrap["payload"])
+        yield _serialize_sse_event("analysis_start", skipped_result)
+        yield _serialize_sse_event("analysis_done", skipped_result)
+        return
+
+    flow_started_at = bootstrap.flow_started_at
+    snapshot = bootstrap.snapshot
+    runtime = bootstrap.runtime
+    request_ready_at_ms = bootstrap.request_ready_at_ms
+    request = bootstrap.request
+    ollama_lite_mode = bootstrap.ollama_lite_mode
     running_result = _build_running_analysis_result(
         prompt=prompt,
         runtime=runtime,
@@ -2551,31 +2737,13 @@ async def stream_model_introspection_analysis(
         "content_event_times_ms": content_event_times_ms,
         "telemetry": telemetry_packets,
     }
-    if ollama_lite_mode:
-        logit_lens = _build_ollama_lite_logit_lens_payload(
-            prompt=prompt,
-            runtime=runtime,
-            stream_payload=stream_payload,
-        )
-        attention, saliency = await asyncio.gather(
-            _collect_attention_payload_safe(prompt=prompt),
-            _collect_saliency_payload_safe(
-                prompt=prompt,
-                response_text=response_text,
-            ),
-        )
-    else:
-        logit_lens, attention, saliency = await asyncio.gather(
-            _collect_logit_lens_payload_safe(
-                prompt=prompt,
-                response_text=response_text,
-            ),
-            _collect_attention_payload_safe(prompt=prompt),
-            _collect_saliency_payload_safe(
-                prompt=prompt,
-                response_text=response_text,
-            ),
-        )
+    logit_lens, attention, saliency = await _collect_probe_payloads(
+        prompt=prompt,
+        runtime=runtime,
+        stream_payload=stream_payload,
+        response_text=response_text,
+        ollama_lite_mode=ollama_lite_mode,
+    )
     (
         analysis_payload,
         refreshed_snapshot,
@@ -2621,45 +2789,26 @@ async def analyze_model_with_optional_live_run(
     settings: Any = None,
 ) -> dict[str, Any]:
     """Build snapshot and optionally execute the active model for a prompt."""
-
-    flow_started_at = time.perf_counter()
-    snapshot = await build_model_introspection_snapshot(
-        model_manager=model_manager, settings=settings
-    )
-    runtime = snapshot["runtime"]
-    if not live_analysis_enabled:
-        skipped_result = _build_skipped_analysis_result(prompt, runtime)
-        skipped_result["snapshot"] = snapshot
-        return skipped_result
-
-    if not prompt.strip():
-        raise ValueError("prompt cannot be empty")
-
-    drift_issue = _extract_model_drift_issue(snapshot)
-    if drift_issue is not None:
-        request_ready_at_ms = (time.perf_counter() - flow_started_at) * 1000.0
-        skipped_result = _build_model_drift_skipped_result(
-            prompt=prompt,
-            runtime=runtime,
-            request_ready_at_ms=request_ready_at_ms,
-            drift_issue=drift_issue,
-        )
-        skipped_result["snapshot"] = snapshot
-        return skipped_result
-
-    runtime_provider = str(runtime.get("provider") or "").strip().lower()
-    ollama_lite_mode = runtime_provider == "ollama"
-    request = SimpleChatRequest(
-        content=prompt,
-        model=runtime["model"],
+    bootstrap = await _prepare_live_analysis_bootstrap(
+        prompt=prompt,
+        live_analysis_enabled=live_analysis_enabled,
         max_tokens=max_tokens,
         temperature=temperature,
         top_p=top_p,
-        stream=False if ollama_lite_mode else None,
-        logprobs=True if ollama_lite_mode else None,
-        top_logprobs=3 if ollama_lite_mode else None,
+        model_manager=model_manager,
+        settings=settings,
     )
-    request_ready_at_ms = (time.perf_counter() - flow_started_at) * 1000.0
+    if isinstance(bootstrap, dict):
+        skipped_result = dict(bootstrap["payload"])
+        skipped_result["snapshot"] = bootstrap["snapshot"]
+        return skipped_result
+
+    flow_started_at = bootstrap.flow_started_at
+    snapshot = bootstrap.snapshot
+    runtime = bootstrap.runtime
+    request_ready_at_ms = bootstrap.request_ready_at_ms
+    request = bootstrap.request
+    ollama_lite_mode = bootstrap.ollama_lite_mode
     result: dict[str, Any] = {
         "analysis_enabled": True,
         "status": "running",
@@ -2706,31 +2855,13 @@ async def analyze_model_with_optional_live_run(
         raise
     elapsed_ms = (time.perf_counter() - flow_started_at) * 1000.0
     response_text = str(stream_payload.get("response_text") or "")
-    if ollama_lite_mode:
-        logit_lens = _build_ollama_lite_logit_lens_payload(
-            prompt=prompt,
-            runtime=runtime,
-            stream_payload=stream_payload,
-        )
-        attention, saliency = await asyncio.gather(
-            _collect_attention_payload_safe(prompt=prompt),
-            _collect_saliency_payload_safe(
-                prompt=prompt,
-                response_text=response_text,
-            ),
-        )
-    else:
-        logit_lens, attention, saliency = await asyncio.gather(
-            _collect_logit_lens_payload_safe(
-                prompt=prompt,
-                response_text=response_text,
-            ),
-            _collect_attention_payload_safe(prompt=prompt),
-            _collect_saliency_payload_safe(
-                prompt=prompt,
-                response_text=response_text,
-            ),
-        )
+    logit_lens, attention, saliency = await _collect_probe_payloads(
+        prompt=prompt,
+        runtime=runtime,
+        stream_payload=stream_payload,
+        response_text=response_text,
+        ollama_lite_mode=ollama_lite_mode,
+    )
     (
         analysis_payload,
         refreshed_snapshot,

--- a/venom_core/services/model_introspection_analysis_service.py
+++ b/venom_core/services/model_introspection_analysis_service.py
@@ -1889,7 +1889,9 @@ def _build_ollama_checkpoint_series(
     previous_token: str | None = None
     for idx, token_index in enumerate(checkpoint_indices):
         item = normalized_tokens[token_index]
-        confidence = max(0.0, min(1.0, math.exp(float(item["logprob"]))))
+        raw_logprob = float(item["logprob"])
+        bounded_logprob = min(0.0, max(-60.0, raw_logprob))
+        confidence = max(0.0, min(1.0, math.exp(bounded_logprob)))
         probabilities.append(confidence)
         token = str(item["token"])
         checkpoints.append(

--- a/venom_core/services/model_introspection_analysis_service.py
+++ b/venom_core/services/model_introspection_analysis_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import math
 import re
 import time
 from dataclasses import dataclass
@@ -128,9 +129,14 @@ def _consume_sse_events(
     first_content_at_ms: float | None,
     chunk_at_ms: float,
     content_event_times_ms: list[float] | None = None,
+    telemetry_packets: list[dict[str, Any]] | None = None,
 ) -> tuple[int, float | None]:
     for event_name, payload in drained_events:
         events.append(event_name)
+        if event_name == "telemetry" and telemetry_packets is not None:
+            parsed_telemetry = _parse_json_dict(payload)
+            if parsed_telemetry:
+                telemetry_packets.append(parsed_telemetry)
         if event_name == "error":
             parsed_error = _parse_json_dict(payload)
             message = str(
@@ -671,10 +677,10 @@ def _build_operator_conclusion_payload(
 def _capability_from_probe_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
     source = str((payload or {}).get("source") or "probe_unavailable")
     status = str((payload or {}).get("status") or "probe_unavailable")
-    available = source == "probe_runtime" and status == "ok"
+    available = source in {"probe_runtime", "probe_lite"} and status == "ok"
     raw_code = (payload or {}).get("code")
     code = str(raw_code).strip() if isinstance(raw_code, str) else ""
-    proxy = bool(code and "_proxy_" in code)
+    proxy = source == "probe_lite" or bool(code and "_proxy_" in code)
     native = bool(available and not proxy)
     reason = code or ("ok" if available else "probe_unavailable")
     availability_class = _resolve_availability_class(
@@ -790,6 +796,11 @@ def _build_analysis_capabilities_payload(
         native_available_count=native_available_count,
         total_count=total_count,
     )
+    introspection_level = "none"
+    if native_available_count == total_count:
+        introspection_level = "full"
+    elif available_count > 0:
+        introspection_level = "lite"
     return {
         "attention": attention_capability,
         "saliency": saliency_capability,
@@ -801,11 +812,13 @@ def _build_analysis_capabilities_payload(
         "probe_profile": str(probe_health_dict.get("profile") or "unknown"),
         "probe_enabled": bool(probe_health_dict.get("enabled")),
         "probe_healthy": bool(probe_health_dict.get("healthy")),
+        "probe_status": str(probe_health_dict.get("status") or "unknown"),
         "runtime_supported": bool(probe_health_dict.get("runtime_supported")),
         "endpoint_configured": bool(probe_health_dict.get("endpoint_configured")),
         "model_whitelisted": bool(probe_health_dict.get("model_whitelisted")),
         "limits": _build_probe_limits_payload(limits_dict),
         "internals_verdict": internals_verdict,
+        "introspection_level": introspection_level,
     }
 
 
@@ -1611,6 +1624,7 @@ async def _collect_streaming_response(response: Any) -> dict[str, Any]:
     chunk_count = 0
     first_content_at_ms: float | None = None
     content_event_times_ms: list[float] = []
+    telemetry_packets: list[dict[str, Any]] = []
     stream_started_at = time.perf_counter()
 
     body_iterator = getattr(response, "body_iterator", None)
@@ -1639,6 +1653,7 @@ async def _collect_streaming_response(response: Any) -> dict[str, Any]:
             first_content_at_ms=first_content_at_ms,
             chunk_at_ms=chunk_at_ms,
             content_event_times_ms=content_event_times_ms,
+            telemetry_packets=telemetry_packets,
         )
 
     if sse_tail.strip():
@@ -1651,6 +1666,7 @@ async def _collect_streaming_response(response: Any) -> dict[str, Any]:
             first_content_at_ms=first_content_at_ms,
             chunk_at_ms=(time.perf_counter() - stream_started_at) * 1000.0,
             content_event_times_ms=content_event_times_ms,
+            telemetry_packets=telemetry_packets,
         )
 
     return {
@@ -1660,6 +1676,176 @@ async def _collect_streaming_response(response: Any) -> dict[str, Any]:
         "raw_chunks": raw_chunks,
         "first_content_at_ms": first_content_at_ms,
         "content_event_times_ms": content_event_times_ms,
+        "telemetry": telemetry_packets,
+    }
+
+
+def _build_ollama_lite_logit_lens_payload(
+    *,
+    prompt: str,
+    runtime: dict[str, Any],
+    stream_payload: dict[str, Any],
+) -> dict[str, Any]:
+    telemetry_raw = stream_payload.get("telemetry")
+    telemetry_packets = telemetry_raw if isinstance(telemetry_raw, list) else []
+    logprobs_packet = next(
+        (
+            packet
+            for packet in telemetry_packets
+            if isinstance(packet, dict) and str(packet.get("kind") or "") == "logprobs"
+        ),
+        None,
+    )
+    if not isinstance(logprobs_packet, dict):
+        return {
+            "source": "probe_unavailable",
+            "status": "probe_unavailable",
+            "code": "ollama_logprobs_unavailable",
+            "message": "Token-level logprobs are unavailable for this run",
+            "runtime_label": runtime.get("label"),
+            "checkpoints": [],
+            "signals": {
+                "early_unstable": False,
+                "late_stabilized": False,
+                "low_confidence_path": False,
+            },
+            "interpretability": {
+                "interpretable": False,
+                "confidence_band": "unknown",
+                "token_noise_ratio": 1.0,
+                "readable_top_tokens": 0,
+                "total_top_tokens": 0,
+            },
+            "diagnostics": {},
+        }
+
+    content_raw = logprobs_packet.get("content")
+    content = content_raw if isinstance(content_raw, list) else []
+    normalized_tokens: list[dict[str, Any]] = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        token = str(item.get("token") or "")
+        raw_logprob = item.get("logprob")
+        if not isinstance(raw_logprob, (int, float)):
+            continue
+        top_raw = item.get("top_logprobs")
+        top_items = top_raw if isinstance(top_raw, list) else []
+        top_k: list[dict[str, Any]] = []
+        for top_item in top_items:
+            if not isinstance(top_item, dict):
+                continue
+            top_token = str(top_item.get("token") or "")
+            top_logprob = top_item.get("logprob")
+            if not isinstance(top_logprob, (int, float)):
+                continue
+            top_k.append(
+                {
+                    "token": top_token,
+                    "score": float(top_logprob),
+                }
+            )
+        normalized_tokens.append(
+            {
+                "token": token,
+                "logprob": float(raw_logprob),
+                "top_k": top_k,
+            }
+        )
+
+    if not normalized_tokens:
+        return {
+            "source": "probe_unavailable",
+            "status": "probe_unavailable",
+            "code": "ollama_logprobs_unavailable",
+            "message": "Token-level logprobs are unavailable for this run",
+            "runtime_label": runtime.get("label"),
+            "checkpoints": [],
+            "signals": {
+                "early_unstable": False,
+                "late_stabilized": False,
+                "low_confidence_path": False,
+            },
+            "interpretability": {
+                "interpretable": False,
+                "confidence_band": "unknown",
+                "token_noise_ratio": 1.0,
+                "readable_top_tokens": 0,
+                "total_top_tokens": 0,
+            },
+            "diagnostics": {},
+        }
+
+    token_count = len(normalized_tokens)
+    checkpoint_indices = sorted(
+        {
+            0,
+            token_count // 3,
+            (2 * token_count) // 3,
+            token_count - 1,
+        }
+    )
+    checkpoints: list[dict[str, Any]] = []
+    probabilities: list[float] = []
+    previous_token: str | None = None
+    for idx, token_index in enumerate(checkpoint_indices):
+        item = normalized_tokens[token_index]
+        top_k = item.get("top_k") or []
+        logprob = float(item["logprob"])
+        confidence = max(0.0, min(1.0, math.exp(logprob)))
+        probabilities.append(confidence)
+        token = str(item["token"])
+        checkpoints.append(
+            {
+                "id": f"cp_{idx}",
+                "percent": int(round((token_index / max(1, token_count - 1)) * 100)),
+                "layer": -1,
+                "top_k": top_k,
+                "top_token": token,
+                "confidence": confidence,
+                "changed": previous_token is not None and token != previous_token,
+            }
+        )
+        previous_token = token
+
+    avg_prob = sum(probabilities) / len(probabilities)
+    confidence_band = (
+        "high" if avg_prob >= 0.75 else ("medium" if avg_prob >= 0.5 else "low")
+    )
+    return {
+        "source": "probe_lite",
+        "status": "ok",
+        "code": "ollama_logprobs_lite",
+        "message": "Token-level logprobs from ollama non-stream chat completion",
+        "runtime_label": runtime.get("label"),
+        "input_tokens": prompt.split(),
+        "output_tokens": [
+            str(item.get("token") or "") for item in normalized_tokens[:64]
+        ],
+        "raw_input_tokens": prompt.split(),
+        "raw_output_tokens": [
+            str(item.get("token") or "") for item in normalized_tokens[:64]
+        ],
+        "checkpoints": checkpoints,
+        "signals": {
+            "early_unstable": bool(probabilities and probabilities[0] < 0.4),
+            "late_stabilized": bool(
+                len(probabilities) >= 2 and probabilities[-1] >= probabilities[0]
+            ),
+            "low_confidence_path": avg_prob < 0.45,
+        },
+        "interpretability": {
+            "interpretable": True,
+            "confidence_band": confidence_band,
+            "token_noise_ratio": max(0.0, min(1.0, 1.0 - avg_prob)),
+            "readable_top_tokens": len(checkpoints),
+            "total_top_tokens": len(checkpoints),
+        },
+        "diagnostics": {
+            "token_count": token_count,
+            "checkpoints_count": len(checkpoints),
+            "avg_top1_prob": round(avg_prob, 4),
+        },
     }
 
 
@@ -1675,6 +1861,7 @@ def _build_logit_lens_timeline_step(
     code = str(logit_lens.get("code") or "probe_unavailable")
     checkpoints = logit_lens.get("checkpoints")
     checkpoint_count = len(checkpoints) if isinstance(checkpoints, list) else 0
+    message = str(logit_lens.get("message") or "").strip()
     if status == "ok":
         detail = (
             f"{checkpoint_count} checkpoint(s) · {elapsed_ms:.1f} ms"
@@ -1683,10 +1870,10 @@ def _build_logit_lens_timeline_step(
         )
         step_status = "done"
     elif _is_probe_failure_status_or_code(status=status, code=code):
-        detail = code
+        detail = f"{message} ({code})" if message else code
         step_status = "failed"
     else:
-        detail = code
+        detail = f"{message} ({code})" if message else code
         step_status = "skipped"
     return {
         "id": "logit_lens_probe",
@@ -1727,6 +1914,7 @@ def _build_probe_timeline_step(
     elapsed_ms = diagnostics_dict.get("elapsed_ms")
     status = str(payload.get("status") or "probe_unavailable")
     code = str(payload.get("code") or "probe_unavailable")
+    message = str(payload.get("message") or "").strip()
     if status == "ok":
         detail = (
             f"ok · {elapsed_ms:.1f} ms"
@@ -1735,10 +1923,10 @@ def _build_probe_timeline_step(
         )
         step_status = "done"
     elif _is_probe_failure_status_or_code(status=status, code=code):
-        detail = code
+        detail = f"{message} ({code})" if message else code
         step_status = "failed"
     else:
-        detail = code
+        detail = f"{message} ({code})" if message else code
         step_status = "skipped"
     return {
         "id": step_id,
@@ -2041,6 +2229,9 @@ def _build_completed_analysis_payload(
         "evidence_coverage": context.evidence_coverage,
         "operator_conclusion": context.operator_conclusion,
         "analysis_capabilities": context.analysis_capabilities,
+        "introspection_level": str(
+            context.analysis_capabilities.get("introspection_level") or "none"
+        ),
         "run_trends": context.run_trends,
     }
 
@@ -2233,12 +2424,17 @@ async def stream_model_introspection_analysis(
         yield _serialize_sse_event("analysis_done", skipped_result)
         return
 
+    runtime_provider = str(runtime.get("provider") or "").strip().lower()
+    ollama_lite_mode = runtime_provider == "ollama"
     request = SimpleChatRequest(
         content=prompt,
         model=runtime["model"],
         max_tokens=max_tokens,
         temperature=temperature,
         top_p=top_p,
+        stream=False if ollama_lite_mode else None,
+        logprobs=True if ollama_lite_mode else None,
+        top_logprobs=3 if ollama_lite_mode else None,
     )
     request_ready_at_ms = (time.perf_counter() - flow_started_at) * 1000.0
     running_result = _build_running_analysis_result(
@@ -2279,6 +2475,7 @@ async def stream_model_introspection_analysis(
     chunk_count = 0
     first_content_at_ms: float | None = None
     content_event_times_ms: list[float] = []
+    telemetry_packets: list[dict[str, Any]] = []
     sse_tail = ""
 
     body_iterator = getattr(response, "body_iterator", None)
@@ -2322,6 +2519,7 @@ async def stream_model_introspection_analysis(
                 first_content_at_ms=first_content_at_ms,
                 chunk_at_ms=chunk_at_ms,
                 content_event_times_ms=content_event_times_ms,
+                telemetry_packets=telemetry_packets,
             )
             yield chunk_text
 
@@ -2335,6 +2533,7 @@ async def stream_model_introspection_analysis(
                 first_content_at_ms=first_content_at_ms,
                 chunk_at_ms=(time.perf_counter() - flow_started_at) * 1000.0,
                 content_event_times_ms=content_event_times_ms,
+                telemetry_packets=telemetry_packets,
             )
     except Exception as exc:
         elapsed_ms = (time.perf_counter() - flow_started_at) * 1000.0
@@ -2360,24 +2559,39 @@ async def stream_model_introspection_analysis(
         return
 
     response_text = "".join(content_parts)
-    logit_lens, attention, saliency = await asyncio.gather(
-        _collect_logit_lens_payload_safe(
-            prompt=prompt,
-            response_text=response_text,
-        ),
-        _collect_attention_payload_safe(prompt=prompt),
-        _collect_saliency_payload_safe(
-            prompt=prompt,
-            response_text=response_text,
-        ),
-    )
     stream_payload = {
         "response_text": "".join(content_parts),
         "chunk_count": chunk_count,
         "events": events,
         "first_content_at_ms": first_content_at_ms,
         "content_event_times_ms": content_event_times_ms,
+        "telemetry": telemetry_packets,
     }
+    if ollama_lite_mode:
+        logit_lens = _build_ollama_lite_logit_lens_payload(
+            prompt=prompt,
+            runtime=runtime,
+            stream_payload=stream_payload,
+        )
+        attention, saliency = await asyncio.gather(
+            _collect_attention_payload_safe(prompt=prompt),
+            _collect_saliency_payload_safe(
+                prompt=prompt,
+                response_text=response_text,
+            ),
+        )
+    else:
+        logit_lens, attention, saliency = await asyncio.gather(
+            _collect_logit_lens_payload_safe(
+                prompt=prompt,
+                response_text=response_text,
+            ),
+            _collect_attention_payload_safe(prompt=prompt),
+            _collect_saliency_payload_safe(
+                prompt=prompt,
+                response_text=response_text,
+            ),
+        )
     (
         analysis_payload,
         refreshed_snapshot,
@@ -2449,12 +2663,17 @@ async def analyze_model_with_optional_live_run(
         skipped_result["snapshot"] = snapshot
         return skipped_result
 
+    runtime_provider = str(runtime.get("provider") or "").strip().lower()
+    ollama_lite_mode = runtime_provider == "ollama"
     request = SimpleChatRequest(
         content=prompt,
         model=runtime["model"],
         max_tokens=max_tokens,
         temperature=temperature,
         top_p=top_p,
+        stream=False if ollama_lite_mode else None,
+        logprobs=True if ollama_lite_mode else None,
+        top_logprobs=3 if ollama_lite_mode else None,
     )
     request_ready_at_ms = (time.perf_counter() - flow_started_at) * 1000.0
     result: dict[str, Any] = {
@@ -2503,17 +2722,31 @@ async def analyze_model_with_optional_live_run(
         raise
     elapsed_ms = (time.perf_counter() - flow_started_at) * 1000.0
     response_text = str(stream_payload.get("response_text") or "")
-    logit_lens, attention, saliency = await asyncio.gather(
-        _collect_logit_lens_payload_safe(
+    if ollama_lite_mode:
+        logit_lens = _build_ollama_lite_logit_lens_payload(
             prompt=prompt,
-            response_text=response_text,
-        ),
-        _collect_attention_payload_safe(prompt=prompt),
-        _collect_saliency_payload_safe(
-            prompt=prompt,
-            response_text=response_text,
-        ),
-    )
+            runtime=runtime,
+            stream_payload=stream_payload,
+        )
+        attention, saliency = await asyncio.gather(
+            _collect_attention_payload_safe(prompt=prompt),
+            _collect_saliency_payload_safe(
+                prompt=prompt,
+                response_text=response_text,
+            ),
+        )
+    else:
+        logit_lens, attention, saliency = await asyncio.gather(
+            _collect_logit_lens_payload_safe(
+                prompt=prompt,
+                response_text=response_text,
+            ),
+            _collect_attention_payload_safe(prompt=prompt),
+            _collect_saliency_payload_safe(
+                prompt=prompt,
+                response_text=response_text,
+            ),
+        )
     (
         analysis_payload,
         refreshed_snapshot,

--- a/venom_core/services/model_introspection_service.py
+++ b/venom_core/services/model_introspection_service.py
@@ -25,6 +25,30 @@ _INTROSPECTION_PACKAGES: tuple[tuple[str, str], ...] = (
 )
 
 
+def _resolve_snapshot_introspection_level(
+    *,
+    runtime_provider: str,
+    probe_health: dict[str, Any],
+) -> str:
+    provider = str(runtime_provider or "").strip().lower()
+    if provider == "ollama":
+        return "lite"
+    probe_enabled = bool(probe_health.get("enabled"))
+    runtime_supported = bool(probe_health.get("runtime_supported"))
+    endpoint_configured = bool(probe_health.get("endpoint_configured"))
+    model_whitelisted = bool(probe_health.get("model_whitelisted"))
+    healthy = bool(probe_health.get("healthy"))
+    if (
+        probe_enabled
+        and runtime_supported
+        and endpoint_configured
+        and model_whitelisted
+        and healthy
+    ):
+        return "full"
+    return "none"
+
+
 def _build_graph_snapshot(
     *,
     runtime: dict[str, Any],
@@ -174,6 +198,10 @@ async def build_model_introspection_snapshot(
     )
 
     probe_health = build_probe_health_payload(active_runtime)
+    introspection_level = _resolve_snapshot_introspection_level(
+        runtime_provider=str(runtime.get("provider") or ""),
+        probe_health=probe_health,
+    )
 
     runtime_probe_node = {
         "id": "probe",
@@ -204,6 +232,7 @@ async def build_model_introspection_snapshot(
         "missing_packages": missing_packages,
         "model_manager": model_manager_snapshot,
         "probe": probe_health,
+        "introspection_level": introspection_level,
         "graph": graph_snapshot,
         "reuse": {
             "brain": {
@@ -221,5 +250,6 @@ async def build_model_introspection_snapshot(
             "provider": runtime["provider"],
             "runtime_label": runtime["label"],
             "introspection_ready": True,
+            "introspection_level": introspection_level,
         },
     }

--- a/web-next/components/inspector/model-introspection-dashboard-sections.tsx
+++ b/web-next/components/inspector/model-introspection-dashboard-sections.tsx
@@ -1455,12 +1455,14 @@ export function AnalysisResultsPanel(props: AnalysisResultsPanelProps) {
                 key={`${step.id}:${step.path ?? "none"}:${step.at_ms}:${index}`}
                 className="rounded-xl border border-white/10 bg-black/20 px-3 py-3"
               >
-                <div className="flex flex-wrap items-center justify-between gap-2">
-                  <div>
+                <div className="flex flex-col gap-2">
+                  <div className="min-w-0">
                     <p className="text-sm text-white">{step.label}</p>
-                    <p className="mt-1 text-xs text-zinc-400">{step.detail}</p>
+                    <p className="mt-1 text-xs text-zinc-400 break-words whitespace-pre-wrap">
+                      {step.detail}
+                    </p>
                   </div>
-                  <div className="flex items-center gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
                     {step.path && (
                       <Badge tone={getTimelinePathTone(step.path)}>{step.path}</Badge>
                     )}
@@ -1470,6 +1472,8 @@ export function AnalysisResultsPanel(props: AnalysisResultsPanelProps) {
                     {step.reason_code && step.status !== "done" && (
                       <Badge tone="danger">{step.reason_code}</Badge>
                     )}
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
                     <Badge tone={timelineBadgeTone(step.status)}>{step.status}</Badge>
                     <span className="font-mono text-xs text-zinc-400">{step.at_ms.toFixed(1)} ms</span>
                   </div>

--- a/web-next/components/inspector/model-introspection-dashboard-sections.tsx
+++ b/web-next/components/inspector/model-introspection-dashboard-sections.tsx
@@ -1458,7 +1458,7 @@ export function AnalysisResultsPanel(props: AnalysisResultsPanelProps) {
                 <div className="flex flex-col gap-2">
                   <div className="min-w-0">
                     <p className="text-sm text-white">{step.label}</p>
-                    <p className="mt-1 text-xs text-zinc-400 break-words whitespace-pre-wrap">
+                    <p className="mt-1 text-xs text-zinc-400 break-words whitespace-pre-wrap [overflow-wrap:anywhere] max-w-full">
                       {step.detail}
                     </p>
                   </div>

--- a/web-next/components/inspector/model-introspection-dashboard-types.ts
+++ b/web-next/components/inspector/model-introspection-dashboard-types.ts
@@ -8,6 +8,7 @@ export type PackageProbe = {
 };
 
 export type IntrospectionSnapshot = {
+  introspection_level?: "full" | "lite" | "none";
   runtime: {
     provider: string;
     model: string;
@@ -62,6 +63,7 @@ export type IntrospectionSnapshot = {
     provider: string;
     runtime_label: string;
     introspection_ready: boolean;
+    introspection_level?: "full" | "lite" | "none";
   };
   graph?: {
     nodes: Array<{
@@ -499,6 +501,7 @@ export type AnalysisResult = {
       probe_profile?: string;
       probe_enabled?: boolean;
       probe_healthy?: boolean;
+      probe_status?: string;
       runtime_supported?: boolean;
       endpoint_configured?: boolean;
       model_whitelisted?: boolean;
@@ -511,7 +514,9 @@ export type AnalysisResult = {
         max_prompt_tokens?: number;
       };
       internals_verdict?: string;
+      introspection_level?: "full" | "lite" | "none";
     } | null;
+    introspection_level?: "full" | "lite" | "none";
     run_trends?: {
       runs?: number;
       window?: number;

--- a/web-next/components/inspector/model-introspection-dashboard-types.ts
+++ b/web-next/components/inspector/model-introspection-dashboard-types.ts
@@ -115,6 +115,17 @@ export type SnapshotComparison = {
 };
 
 export type AnalysisTimelinePath = "answer_path" | "internals_path";
+export type AnalysisProbeStatus =
+  | "ok"
+  | "failed"
+  | "disabled"
+  | "runtime_not_supported"
+  | "model_not_whitelisted"
+  | "endpoint_missing"
+  | "metadata_only"
+  | "verified"
+  | "unknown"
+  | (string & {});
 
 export type AnalysisTimelineEntry = {
   id: string;
@@ -501,7 +512,7 @@ export type AnalysisResult = {
       probe_profile?: string;
       probe_enabled?: boolean;
       probe_healthy?: boolean;
-      probe_status?: string;
+      probe_status?: AnalysisProbeStatus;
       runtime_supported?: boolean;
       endpoint_configured?: boolean;
       model_whitelisted?: boolean;

--- a/web-next/components/inspector/model-introspection-dashboard.tsx
+++ b/web-next/components/inspector/model-introspection-dashboard.tsx
@@ -346,7 +346,7 @@ function resolveIntrospectionLevel(args: {
   analysisLevel: string | null | undefined;
   snapshotLevel: string | null | undefined;
 }): IntrospectionLevel {
-  const candidate = String(args.analysisLevel || args.snapshotLevel || "none").toLowerCase();
+  const candidate = (args.analysisLevel ?? args.snapshotLevel ?? "none").toLowerCase();
   if (candidate === "full" || candidate === "lite" || candidate === "none") {
     return candidate;
   }
@@ -1156,12 +1156,18 @@ export function ModelIntrospectionDashboard() {
     allInternalsUnavailable,
     anyInternalsAvailable,
   } = resolveInternalsAvailability(attention, saliency, logitLens);
-  const isLiteIntrospection = introspectionLevel === "lite";
-  const logitLensTitle = isLiteIntrospection
-    ? "Token confidence (lite)"
+  const runtimeProviderNormalized = String(
+    analysisResult?.analysis?.provider ?? snapshot?.runtime?.provider ?? "",
+  ).toLowerCase();
+  const isOllamaLiteRuntime =
+    introspectionLevel === "lite" &&
+    runtimeProviderNormalized === "ollama" &&
+    logitLens?.source === "probe_lite";
+  const logitLensTitle = isOllamaLiteRuntime
+    ? t("inspector.modelIntrospection.dashboard.results.logitLens.titleLite")
     : t("inspector.modelIntrospection.dashboard.results.logitLens.title");
-  const internalsHowToFull = isLiteIntrospection
-    ? "Full internals are available on multi_runtime. Switch runtime to multi_runtime to enable native attention/saliency probes."
+  const internalsHowToFull = isOllamaLiteRuntime
+    ? t("inspector.modelIntrospection.dashboard.results.internalsHowToFull")
     : null;
   const unavailableInternalsRows = internalsCapabilityRows.filter(
     (row) => row.availabilityClass === "unavailable" || row.availabilityClass === "failed",
@@ -1459,7 +1465,9 @@ export function ModelIntrospectionDashboard() {
           )}
           {internalsHowToFull && (
             <div className="mb-4 rounded-2xl border border-cyan-400/25 bg-cyan-500/10 p-4">
-              <p className="text-xs uppercase tracking-wide text-cyan-100">How to get full internals</p>
+              <p className="text-xs uppercase tracking-wide text-cyan-100">
+                {t("inspector.modelIntrospection.dashboard.results.internalsHowToFullTitle")}
+              </p>
               <p className="mt-2 text-sm text-cyan-50/90">{internalsHowToFull}</p>
             </div>
           )}
@@ -1470,8 +1478,8 @@ export function ModelIntrospectionDashboard() {
               title={t("inspector.modelIntrospection.dashboard.results.attention.title")}
               emptyLabel={t("inspector.modelIntrospection.dashboard.results.attention.empty")}
               unavailableLabel={
-                isLiteIntrospection
-                  ? "Not available on this runtime (ollama). Switch to multi_runtime for native attention internals."
+                isOllamaLiteRuntime
+                  ? t("inspector.modelIntrospection.dashboard.results.attention.unavailableLite")
                   : t("inspector.modelIntrospection.dashboard.results.attention.unavailable")
               }
             />
@@ -1483,8 +1491,8 @@ export function ModelIntrospectionDashboard() {
               title={t("inspector.modelIntrospection.dashboard.results.saliency.title")}
               emptyLabel={t("inspector.modelIntrospection.dashboard.results.saliency.empty")}
               unavailableLabel={
-                isLiteIntrospection
-                  ? "Not available on this runtime (ollama). Switch to multi_runtime for native saliency internals."
+                isOllamaLiteRuntime
+                  ? t("inspector.modelIntrospection.dashboard.results.saliency.unavailableLite")
                   : t("inspector.modelIntrospection.dashboard.results.saliency.unavailable")
               }
             />

--- a/web-next/components/inspector/model-introspection-dashboard.tsx
+++ b/web-next/components/inspector/model-introspection-dashboard.tsx
@@ -97,6 +97,12 @@ type ResultStepMarker = {
   status: ResultStepStatus;
   tone: ResultStepTone;
 };
+type ResultStepDef = {
+  number: number;
+  key: string;
+  labelKey: string;
+  timelineIds: readonly string[];
+};
 
 type SnapshotLoadingPanelProps = Readonly<{
   snapshot: IntrospectionSnapshot | null;
@@ -184,7 +190,7 @@ type TechnicalLayerPanelProps = Readonly<{
   analysisActive: boolean;
   selectedGraphNodeIdEffective: string | null;
   selectedGraphNode: { id: string; label: string; kind: string; status: string } | null;
-  selectedGraphNodeDetails: GraphNodeDetails;
+  selectedGraphNodeDetails: GraphNodeDetails | null;
   selectedGraphTypeHint: string;
   onToggleGraphLayer: () => void;
   onSelectGraphNode: (id: string | null) => void;
@@ -347,7 +353,7 @@ function resolveIntrospectionLevel(args: {
   return "none";
 }
 
-const RESULT_STEP_DEFS = [
+const RESULT_STEP_DEFS: readonly ResultStepDef[] = [
   {
     number: 1,
     key: "snapshot_before",
@@ -402,7 +408,7 @@ const RESULT_STEP_DEFS = [
     labelKey: "inspector.modelIntrospection.dashboard.results.steps.saliencyProbe",
     timelineIds: ["saliency_probe", "internals:saliency_probe"],
   },
-] as const;
+];
 
 function getStepTone(status: ResultStepStatus): ResultStepTone {
   if (status === "done") return "success";

--- a/web-next/components/inspector/model-introspection-dashboard.tsx
+++ b/web-next/components/inspector/model-introspection-dashboard.tsx
@@ -88,6 +88,88 @@ type InternalsNoticeProps = {
   rowKeyPrefix: string;
   extraBadge?: string;
 };
+
+type DashboardRuntimeInternalsContext = {
+  allInternalsUnavailable: boolean;
+  anyInternalsAvailable: boolean;
+  isOllamaLiteRuntime: boolean;
+  logitLensTitle: string;
+  internalsHowToFull: string | null;
+  unavailableInternalsRows: InternalsCapabilityRow[];
+  proxyInternalsRows: InternalsCapabilityRow[];
+  availableInternalsCount: number;
+  internalsProcessing: boolean;
+  ragStepMarker: ResultStepMarker | null;
+  responseStepMarker: ResultStepMarker | null;
+  snapshotStepMarker: ResultStepMarker | null;
+  logitStepMarker: ResultStepMarker | null;
+  attentionStepMarker: ResultStepMarker | null;
+  saliencyStepMarker: ResultStepMarker | null;
+};
+
+function deriveDashboardRuntimeInternalsContext(args: {
+  analysisResult: ReturnType<typeof useModelIntrospectionAnalysisStream>["analysisResult"];
+  snapshot: IntrospectionSnapshot | null;
+  introspectionLevel: IntrospectionLevel;
+  logitLens: ReturnType<typeof buildLogitLensModel> | null;
+  attention: ReturnType<typeof buildAttentionModel> | null;
+  saliency: ReturnType<typeof buildSaliencyModel> | null;
+  analysisTimeline: AnalysisTimelineEntry[];
+  internalsCapabilityRows: InternalsCapabilityRow[];
+  analysisLoading: boolean;
+  analysisStreaming: boolean;
+  t: ReturnType<typeof useTranslation>;
+}): DashboardRuntimeInternalsContext {
+  const {
+    allInternalsUnavailable,
+    anyInternalsAvailable,
+  } = resolveInternalsAvailability(args.attention, args.saliency, args.logitLens);
+  const runtimeProviderNormalized = String(
+    args.analysisResult?.analysis?.provider ?? args.snapshot?.runtime?.provider ?? "",
+  ).toLowerCase();
+  const isOllamaLiteRuntime =
+    args.introspectionLevel === "lite" &&
+    runtimeProviderNormalized === "ollama" &&
+    args.logitLens?.source === "probe_lite";
+  const logitLensTitle = isOllamaLiteRuntime
+    ? args.t("inspector.modelIntrospection.dashboard.results.logitLens.titleLite")
+    : args.t("inspector.modelIntrospection.dashboard.results.logitLens.title");
+  const internalsHowToFull = isOllamaLiteRuntime
+    ? args.t("inspector.modelIntrospection.dashboard.results.internalsHowToFull")
+    : null;
+  const unavailableInternalsRows = args.internalsCapabilityRows.filter(
+    (row) => row.availabilityClass === "unavailable" || row.availabilityClass === "failed",
+  );
+  const proxyInternalsRows = args.internalsCapabilityRows.filter(
+    (row) => row.availabilityClass === "proxy_ok",
+  );
+  const availableInternalsCount =
+    args.internalsCapabilityRows.length - unavailableInternalsRows.length;
+  const internalsProcessing = args.analysisLoading || args.analysisStreaming;
+  return {
+    allInternalsUnavailable,
+    anyInternalsAvailable,
+    isOllamaLiteRuntime,
+    logitLensTitle,
+    internalsHowToFull,
+    unavailableInternalsRows,
+    proxyInternalsRows,
+    availableInternalsCount,
+    internalsProcessing,
+    ragStepMarker: resolveResultStepMarker("request_ready", args.analysisTimeline),
+    responseStepMarker: resolveResultStepMarker(
+      "response_finalized",
+      args.analysisTimeline,
+    ),
+    snapshotStepMarker: resolveResultStepMarker("snapshot_after", args.analysisTimeline),
+    logitStepMarker: resolveResultStepMarker("logit_lens_probe", args.analysisTimeline),
+    attentionStepMarker: resolveResultStepMarker(
+      "attention_probe",
+      args.analysisTimeline,
+    ),
+    saliencyStepMarker: resolveResultStepMarker("saliency_probe", args.analysisTimeline),
+  };
+}
 type ResultStepTone = "success" | "warning" | "neutral" | "danger";
 type ResultStepStatus = "done" | "running" | "pending" | "failed";
 type ResultStepMarker = {
@@ -1155,34 +1237,32 @@ export function ModelIntrospectionDashboard() {
   const {
     allInternalsUnavailable,
     anyInternalsAvailable,
-  } = resolveInternalsAvailability(attention, saliency, logitLens);
-  const runtimeProviderNormalized = String(
-    analysisResult?.analysis?.provider ?? snapshot?.runtime?.provider ?? "",
-  ).toLowerCase();
-  const isOllamaLiteRuntime =
-    introspectionLevel === "lite" &&
-    runtimeProviderNormalized === "ollama" &&
-    logitLens?.source === "probe_lite";
-  const logitLensTitle = isOllamaLiteRuntime
-    ? t("inspector.modelIntrospection.dashboard.results.logitLens.titleLite")
-    : t("inspector.modelIntrospection.dashboard.results.logitLens.title");
-  const internalsHowToFull = isOllamaLiteRuntime
-    ? t("inspector.modelIntrospection.dashboard.results.internalsHowToFull")
-    : null;
-  const unavailableInternalsRows = internalsCapabilityRows.filter(
-    (row) => row.availabilityClass === "unavailable" || row.availabilityClass === "failed",
-  );
-  const proxyInternalsRows = internalsCapabilityRows.filter(
-    (row) => row.availabilityClass === "proxy_ok",
-  );
-  const availableInternalsCount = internalsCapabilityRows.length - unavailableInternalsRows.length;
-  const internalsProcessing = analysisLoading || analysisStreaming;
-  const ragStepMarker = resolveResultStepMarker("request_ready", analysisTimeline);
-  const responseStepMarker = resolveResultStepMarker("response_finalized", analysisTimeline);
-  const snapshotStepMarker = resolveResultStepMarker("snapshot_after", analysisTimeline);
-  const logitStepMarker = resolveResultStepMarker("logit_lens_probe", analysisTimeline);
-  const attentionStepMarker = resolveResultStepMarker("attention_probe", analysisTimeline);
-  const saliencyStepMarker = resolveResultStepMarker("saliency_probe", analysisTimeline);
+    isOllamaLiteRuntime,
+    logitLensTitle,
+    internalsHowToFull,
+    unavailableInternalsRows,
+    proxyInternalsRows,
+    availableInternalsCount,
+    internalsProcessing,
+    ragStepMarker,
+    responseStepMarker,
+    snapshotStepMarker,
+    logitStepMarker,
+    attentionStepMarker,
+    saliencyStepMarker,
+  } = deriveDashboardRuntimeInternalsContext({
+    analysisResult,
+    snapshot,
+    introspectionLevel,
+    logitLens,
+    attention,
+    saliency,
+    analysisTimeline,
+    internalsCapabilityRows,
+    analysisLoading,
+    analysisStreaming,
+    t,
+  });
 
   return (
     <div className="space-y-6 pb-10">

--- a/web-next/components/inspector/model-introspection-dashboard.tsx
+++ b/web-next/components/inspector/model-introspection-dashboard.tsx
@@ -77,6 +77,7 @@ type InternalsCapabilityRow = {
   reason: string;
   availabilityClass: "native_ok" | "proxy_ok" | "unavailable" | "failed";
 };
+type IntrospectionLevel = "full" | "lite" | "none";
 type InternalsNoticeProps = {
   title: string;
   message: string;
@@ -286,7 +287,12 @@ function buildInternalsCapabilityRow(
   const reasonMap: Record<string, string> = {
     ok: "ok",
     probe_unavailable: "probe unavailable",
+    probe_disabled: "probe disabled in runtime config",
     probe_failed: "probe failed",
+    runtime_not_supported: "runtime not supported for probe",
+    model_not_whitelisted: "model not whitelisted for probe",
+    endpoint_missing: "probe endpoint missing",
+    live_analysis_disabled: "live analysis disabled",
     attention_unavailable: "attention unavailable",
     saliency_unavailable: "saliency unavailable",
     logit_lens_unavailable: "logit lens unavailable",
@@ -328,6 +334,17 @@ function buildProbeLimitsLabel(limits: {
     return "limits: n/a";
   }
   return `limits: t=${limits.timeout_seconds ?? 0}s · att=${limits.max_attempts ?? 0} · top_k=${limits.max_top_k ?? 0} · layers=${limits.max_layer_count ?? 0} · heads=${limits.max_head_count ?? 0} · prompt=${limits.max_prompt_tokens ?? 0}`;
+}
+
+function resolveIntrospectionLevel(args: {
+  analysisLevel: string | null | undefined;
+  snapshotLevel: string | null | undefined;
+}): IntrospectionLevel {
+  const candidate = String(args.analysisLevel || args.snapshotLevel || "none").toLowerCase();
+  if (candidate === "full" || candidate === "lite" || candidate === "none") {
+    return candidate;
+  }
+  return "none";
 }
 
 const RESULT_STEP_DEFS = [
@@ -865,6 +882,10 @@ function useDashboardDerivedState(args: {
   const attention = buildAttentionModel(analysisResult?.analysis?.attention ?? null);
   const saliency = buildSaliencyModel(analysisResult?.analysis?.saliency ?? null);
   const analysisCapabilities = analysisResult?.analysis?.analysis_capabilities ?? null;
+  const introspectionLevel = resolveIntrospectionLevel({
+    analysisLevel: analysisResult?.analysis?.introspection_level,
+    snapshotLevel: snapshot?.summary?.introspection_level ?? snapshot?.introspection_level,
+  });
   const internalsProbeElapsedMs = useMemo(
     () =>
       sumProbeElapsedMs([
@@ -901,12 +922,22 @@ function useDashboardDerivedState(args: {
     }
     const availableCount = Number(analysisCapabilities.available_count ?? 0);
     const totalCount = Number(analysisCapabilities.total_count ?? 3);
+    const probeGateDetails = [
+      `probe_status:${String(analysisCapabilities.probe_status ?? "unknown")}`,
+      `probe_enabled:${analysisCapabilities.probe_enabled ? "yes" : "no"}`,
+      `runtime_supported:${analysisCapabilities.runtime_supported ? "yes" : "no"}`,
+      `model_whitelisted:${analysisCapabilities.model_whitelisted ? "yes" : "no"}`,
+      `endpoint_configured:${analysisCapabilities.endpoint_configured ? "yes" : "no"}`,
+    ];
     return {
       verdict: internalsVerdictLabel,
       tone: internalsVerdictTone,
       availableCount,
       totalCount,
-      details: internalsCapabilityRows.map((row) => `${row.label}:${row.reason}`),
+      details: [
+        ...internalsCapabilityRows.map((row) => `${row.label}:${row.reason}`),
+        ...probeGateDetails,
+      ],
     };
   }, [analysisCapabilities, internalsCapabilityRows, internalsVerdictLabel, internalsVerdictTone]);
   const operatorConclusion = buildOperatorConclusion({
@@ -1013,6 +1044,7 @@ function useDashboardDerivedState(args: {
     attention,
     saliency,
     analysisCapabilities,
+    introspectionLevel,
     internalsProbeElapsedMs,
     internalsCapabilityRows,
     internalsVerdictLabel,
@@ -1072,6 +1104,7 @@ export function ModelIntrospectionDashboard() {
     attention,
     saliency,
     analysisCapabilities,
+    introspectionLevel,
     internalsProbeElapsedMs,
     internalsCapabilityRows,
     internalsVerdictLabel,
@@ -1117,6 +1150,13 @@ export function ModelIntrospectionDashboard() {
     allInternalsUnavailable,
     anyInternalsAvailable,
   } = resolveInternalsAvailability(attention, saliency, logitLens);
+  const isLiteIntrospection = introspectionLevel === "lite";
+  const logitLensTitle = isLiteIntrospection
+    ? "Token confidence (lite)"
+    : t("inspector.modelIntrospection.dashboard.results.logitLens.title");
+  const internalsHowToFull = isLiteIntrospection
+    ? "Full internals are available on multi_runtime. Switch runtime to multi_runtime to enable native attention/saliency probes."
+    : null;
   const unavailableInternalsRows = internalsCapabilityRows.filter(
     (row) => row.availabilityClass === "unavailable" || row.availabilityClass === "failed",
   );
@@ -1327,7 +1367,7 @@ export function ModelIntrospectionDashboard() {
             <ResultStepHeader marker={logitStepMarker} t={t} />
             <LogitLensPanel
               logitLens={logitLens}
-              title={t("inspector.modelIntrospection.dashboard.results.logitLens.title")}
+              title={logitLensTitle}
               emptyLabel={t("inspector.modelIntrospection.dashboard.results.logitLens.empty")}
               unavailableLabel={t(
                 "inspector.modelIntrospection.dashboard.results.logitLens.unavailable",
@@ -1411,15 +1451,23 @@ export function ModelIntrospectionDashboard() {
               extraBadge={probeLimitsLabel}
             />
           )}
+          {internalsHowToFull && (
+            <div className="mb-4 rounded-2xl border border-cyan-400/25 bg-cyan-500/10 p-4">
+              <p className="text-xs uppercase tracking-wide text-cyan-100">How to get full internals</p>
+              <p className="mt-2 text-sm text-cyan-50/90">{internalsHowToFull}</p>
+            </div>
+          )}
           <ResultStepContainer marker={attentionStepMarker} className="mb-4" t={t}>
             <ResultStepHeader marker={attentionStepMarker} t={t} />
             <AttentionPanel
               attention={attention}
               title={t("inspector.modelIntrospection.dashboard.results.attention.title")}
               emptyLabel={t("inspector.modelIntrospection.dashboard.results.attention.empty")}
-              unavailableLabel={t(
-                "inspector.modelIntrospection.dashboard.results.attention.unavailable",
-              )}
+              unavailableLabel={
+                isLiteIntrospection
+                  ? "Not available on this runtime (ollama). Switch to multi_runtime for native attention internals."
+                  : t("inspector.modelIntrospection.dashboard.results.attention.unavailable")
+              }
             />
           </ResultStepContainer>
           <ResultStepContainer marker={saliencyStepMarker} className="mb-4" t={t}>
@@ -1428,9 +1476,11 @@ export function ModelIntrospectionDashboard() {
               saliency={saliency}
               title={t("inspector.modelIntrospection.dashboard.results.saliency.title")}
               emptyLabel={t("inspector.modelIntrospection.dashboard.results.saliency.empty")}
-              unavailableLabel={t(
-                "inspector.modelIntrospection.dashboard.results.saliency.unavailable",
-              )}
+              unavailableLabel={
+                isLiteIntrospection
+                  ? "Not available on this runtime (ollama). Switch to multi_runtime for native saliency internals."
+                  : t("inspector.modelIntrospection.dashboard.results.saliency.unavailable")
+              }
             />
           </ResultStepContainer>
           </div>

--- a/web-next/components/voice/voice-chat-screen.tsx
+++ b/web-next/components/voice/voice-chat-screen.tsx
@@ -151,14 +151,15 @@ function VoiceSystemStatusBar({ status }: Readonly<{ status: VoiceStatusUpdate |
   const voiceProbeFailed = probeStatus === "failed";
   const voiceProbeBlocking = voiceProbeFailed && isNativeVoiceRuntime;
   const allOk = sttOk && ttsOk && llmOk && !voiceProbeBlocking;
+  const voiceProbeToneClass = resolveVoiceProbeToneClass(voiceProbeFailed, voiceProbeBlocking);
+  const voiceProbeDotClass = resolveVoiceProbeDotClass(voiceProbeFailed, voiceProbeBlocking);
+  const containerClass = allOk
+    ? "border border-emerald-500/20 bg-emerald-500/[0.04] text-emerald-400"
+    : "border border-amber-500/20 bg-amber-500/[0.04] text-amber-400";
 
   return (
     <div
-      className={`rounded-2xl px-4 py-2 flex items-center justify-between gap-3 text-[11px] ${
-        allOk
-          ? "border border-emerald-500/20 bg-emerald-500/[0.04] text-emerald-400"
-          : "border border-amber-500/20 bg-amber-500/[0.04] text-amber-400"
-      }`}
+      className={`rounded-2xl px-4 py-2 flex items-center justify-between gap-3 text-[11px] ${containerClass}`}
     >
       <span className="font-medium">
         {allOk ? t("voice.status.systemReady") : t("voice.status.systemPartial")}
@@ -180,23 +181,31 @@ function VoiceSystemStatusBar({ status }: Readonly<{ status: VoiceStatusUpdate |
           TTS
         </span>
         <span
-          className={`flex items-center gap-1 ${
-            voiceProbeFailed
-              ? (voiceProbeBlocking ? "text-rose-400" : "text-amber-400")
-              : "text-emerald-400"
-          }`}
+          className={`flex items-center gap-1 ${voiceProbeToneClass}`}
         >
-          <span
-            className={`h-1.5 w-1.5 rounded-full ${
-              voiceProbeFailed
-                ? (voiceProbeBlocking ? "bg-rose-400" : "bg-amber-400")
-                : "bg-emerald-400"
-            }`}
-          />
+          <span className={`h-1.5 w-1.5 rounded-full ${voiceProbeDotClass}`} />
           {" "}
           {probeStatus ?? "—"}
         </span>
       </span>
     </div>
   );
+}
+
+function resolveVoiceProbeToneClass(
+  voiceProbeFailed: boolean,
+  voiceProbeBlocking: boolean,
+): string {
+  if (!voiceProbeFailed) return "text-emerald-400";
+  if (voiceProbeBlocking) return "text-rose-400";
+  return "text-amber-400";
+}
+
+function resolveVoiceProbeDotClass(
+  voiceProbeFailed: boolean,
+  voiceProbeBlocking: boolean,
+): string {
+  if (!voiceProbeFailed) return "bg-emerald-400";
+  if (voiceProbeBlocking) return "bg-rose-400";
+  return "bg-amber-400";
 }

--- a/web-next/components/voice/voice-chat-screen.tsx
+++ b/web-next/components/voice/voice-chat-screen.tsx
@@ -49,6 +49,7 @@ const VOICE_MODES: VoiceModeCard[] = [
     icon: ListTodo,
   },
 ];
+const NATIVE_VOICE_RUNTIME_PREFIXES = ["multi_runtime", "gemma4_audio"] as const;
 
 type VoiceChatScreenProps = Readonly<{
   isDevMode?: boolean;
@@ -144,9 +145,9 @@ function VoiceSystemStatusBar({ status }: Readonly<{ status: VoiceStatusUpdate |
   const runtimeModel = String(status.runtime_snapshot?.model_name ?? "").trim();
   const probeStatus = status.runtime_snapshot?.runtime_capabilities?.probe_status ?? null;
   const llmOk = runtimeProvider.length > 0 && runtimeModel.length > 0;
-  const isNativeVoiceRuntime =
-    runtimeProviderNormalized.startsWith("multi_runtime") ||
-    runtimeProviderNormalized.startsWith("gemma4_audio");
+  const isNativeVoiceRuntime = NATIVE_VOICE_RUNTIME_PREFIXES.some((prefix) =>
+    runtimeProviderNormalized.startsWith(prefix),
+  );
   const voiceProbeFailed = probeStatus === "failed";
   const voiceProbeBlocking = voiceProbeFailed && isNativeVoiceRuntime;
   const allOk = sttOk && ttsOk && llmOk && !voiceProbeBlocking;

--- a/web-next/components/voice/voice-chat-screen.tsx
+++ b/web-next/components/voice/voice-chat-screen.tsx
@@ -140,11 +140,16 @@ function VoiceSystemStatusBar({ status }: Readonly<{ status: VoiceStatusUpdate |
   const sttOk = status.stt_ready === true;
   const ttsOk = status.tts_ready === true;
   const runtimeProvider = String(status.runtime_snapshot?.provider ?? "").trim();
+  const runtimeProviderNormalized = runtimeProvider.toLowerCase();
   const runtimeModel = String(status.runtime_snapshot?.model_name ?? "").trim();
   const probeStatus = status.runtime_snapshot?.runtime_capabilities?.probe_status ?? null;
   const llmOk = runtimeProvider.length > 0 && runtimeModel.length > 0;
+  const isNativeVoiceRuntime =
+    runtimeProviderNormalized.startsWith("multi_runtime") ||
+    runtimeProviderNormalized.startsWith("gemma4_audio");
   const voiceProbeFailed = probeStatus === "failed";
-  const allOk = sttOk && ttsOk && llmOk && !voiceProbeFailed;
+  const voiceProbeBlocking = voiceProbeFailed && isNativeVoiceRuntime;
+  const allOk = sttOk && ttsOk && llmOk && !voiceProbeBlocking;
 
   return (
     <div
@@ -173,8 +178,20 @@ function VoiceSystemStatusBar({ status }: Readonly<{ status: VoiceStatusUpdate |
           {" "}
           TTS
         </span>
-        <span className={`flex items-center gap-1 ${voiceProbeFailed ? "text-amber-400" : "text-emerald-400"}`}>
-          <span className={`h-1.5 w-1.5 rounded-full ${voiceProbeFailed ? "bg-amber-400" : "bg-emerald-400"}`} />
+        <span
+          className={`flex items-center gap-1 ${
+            voiceProbeFailed
+              ? (voiceProbeBlocking ? "text-rose-400" : "text-amber-400")
+              : "text-emerald-400"
+          }`}
+        >
+          <span
+            className={`h-1.5 w-1.5 rounded-full ${
+              voiceProbeFailed
+                ? (voiceProbeBlocking ? "bg-rose-400" : "bg-amber-400")
+                : "bg-emerald-400"
+            }`}
+          />
           {" "}
           {probeStatus ?? "—"}
         </span>

--- a/web-next/lib/i18n/locales/de.ts
+++ b/web-next/lib/i18n/locales/de.ts
@@ -778,6 +778,7 @@ export const de = {
           },
           logitLens: {
             title: "Logit evolution",
+            titleLite: "Token confidence (lite)",
             empty: "Für diesen Lauf sind keine Logit-Lens-Daten verfügbar.",
             unavailable: "Die Logit-Lens-Probe ist vorübergehend nicht verfügbar.",
             source: "source",
@@ -814,11 +815,15 @@ export const de = {
             title: "Attention Head View",
             empty: "Keine Attention-Daten für diesen Analyselauf.",
             unavailable: "Attention-Probe ist für diesen Lauf nicht verfügbar.",
+            unavailableLite:
+              "Not available on this runtime (ollama). Switch to multi_runtime for native attention internals.",
           },
           saliency: {
             title: "Saliency / Attribution",
             empty: "Keine Saliency-Daten für diesen Analyselauf.",
             unavailable: "Saliency-Probe ist für diesen Lauf nicht verfügbar.",
+            unavailableLite:
+              "Not available on this runtime (ollama). Switch to multi_runtime for native saliency internals.",
           },
           internals: {
             title: "Advanced internals",
@@ -836,6 +841,9 @@ export const de = {
           internalsUnavailableTitle: "Probe internals unavailable",
           internalsUnavailableMessage:
             "Für diesen Lauf hat die Probe weder Attention, Saliency noch Logit Lens geliefert. Das Hauptsignal kommt jetzt aus RAG, Evidence und dem Antwort-Verdict.",
+          internalsHowToFullTitle: "How to get full internals",
+          internalsHowToFull:
+            "Full internals are available on multi_runtime. Switch runtime to multi_runtime to enable native attention/saliency probes.",
         },
         snapshotComparison: {
           title: "Snapshot-Vergleich",

--- a/web-next/lib/i18n/locales/en.ts
+++ b/web-next/lib/i18n/locales/en.ts
@@ -778,6 +778,7 @@ export const en = {
           },
           logitLens: {
             title: "Logit evolution",
+            titleLite: "Token confidence (lite)",
             empty: "No logit-lens data is available for this run.",
             unavailable: "Logit-lens probe is temporarily unavailable.",
             source: "source",
@@ -813,11 +814,15 @@ export const en = {
             title: "Attention Head View",
             empty: "No attention data for this analysis run.",
             unavailable: "Attention probe unavailable for this run.",
+            unavailableLite:
+              "Not available on this runtime (ollama). Switch to multi_runtime for native attention internals.",
           },
           saliency: {
             title: "Saliency / Attribution",
             empty: "No saliency data for this analysis run.",
             unavailable: "Saliency probe unavailable for this run.",
+            unavailableLite:
+              "Not available on this runtime (ollama). Switch to multi_runtime for native saliency internals.",
           },
           internals: {
             title: "Advanced internals",
@@ -835,6 +840,9 @@ export const en = {
           internalsUnavailableTitle: "Probe internals unavailable",
           internalsUnavailableMessage:
             "For this run, probe did not return attention, saliency or logit lens. Main signal now comes from RAG, evidence and answer verdict.",
+          internalsHowToFullTitle: "How to get full internals",
+          internalsHowToFull:
+            "Full internals are available on multi_runtime. Switch runtime to multi_runtime to enable native attention/saliency probes.",
         },
         snapshotComparison: {
           title: "Snapshot comparison",

--- a/web-next/lib/i18n/locales/pl.ts
+++ b/web-next/lib/i18n/locales/pl.ts
@@ -779,6 +779,7 @@ export const pl = {
           },
           logitLens: {
             title: "Ewolucja logitów",
+            titleLite: "Token confidence (lite)",
             empty: "Brak danych logit lens dla bieżącej analizy.",
             unavailable: "Probe logit lens jest chwilowo niedostępny.",
             source: "source",
@@ -814,11 +815,15 @@ export const pl = {
             title: "Attention Head View",
             empty: "Brak danych attention dla bieżącej analizy.",
             unavailable: "Attention probe niedostępny dla bieżącego runu.",
+            unavailableLite:
+              "Not available on this runtime (ollama). Switch to multi_runtime for native attention internals.",
           },
           saliency: {
             title: "Saliency / Attribution",
             empty: "Brak danych saliency dla bieżącej analizy.",
             unavailable: "Saliency probe niedostępny dla bieżącego runu.",
+            unavailableLite:
+              "Not available on this runtime (ollama). Switch to multi_runtime for native saliency internals.",
           },
           internals: {
             title: "Advanced internals",
@@ -836,6 +841,9 @@ export const pl = {
           internalsUnavailableTitle: "Probe internals unavailable",
           internalsUnavailableMessage:
             "Dla tego runu probe nie zwrócił attention, saliency ani logit lens. Główny sygnał prowadzi teraz RAG, evidence i verdict odpowiedzi.",
+          internalsHowToFullTitle: "How to get full internals",
+          internalsHowToFull:
+            "Full internals are available on multi_runtime. Switch runtime to multi_runtime to enable native attention/saliency probes.",
         },
         snapshotComparison: {
           title: "Porównanie snapshotów",

--- a/web-next/tests/model-introspection-page.component.test.tsx
+++ b/web-next/tests/model-introspection-page.component.test.tsx
@@ -989,4 +989,132 @@ describe("ModelIntrospectionDashboard", () => {
       assert.ok(step8 < step9);
     });
   });
+
+  it("shows lite internals guidance for ollama runtime", async () => {
+    globalThis.fetch = async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (!url.includes("/api/v1/models/introspection")) {
+        throw new Error(`Unexpected fetch URL: ${url}`);
+      }
+      if (url.includes("/api/v1/models/introspection/analyze/stream")) {
+        const snapshot = {
+          ...makeSnapshotBeforeFixture(),
+          runtime: {
+            ...makeSnapshotBeforeFixture().runtime,
+            provider: "ollama",
+            model: "gemma3:latest",
+            endpoint: "http://localhost:11434/v1",
+            label: "gemma3:latest · ollama @ localhost:11434",
+          },
+          summary: {
+            ...makeSnapshotBeforeFixture().summary,
+            provider: "ollama",
+            runtime_label: "gemma3:latest · ollama @ localhost:11434",
+            introspection_level: "lite",
+          },
+          introspection_level: "lite",
+        };
+        const donePayload = {
+          analysis_enabled: true,
+          status: "completed",
+          snapshot,
+          snapshot_after: snapshot,
+          analysis: {
+            prompt: "Co to jest slonce?",
+            response: "Słońce to gwiazda.",
+            chunk_count: 1,
+            events: ["start", "content", "done"],
+            timeline_step_count: 9,
+            timeline: [
+              { id: "snapshot_before", label: "Snapshot captured", status: "done", detail: snapshot.runtime.label, at_ms: 0, path: "answer_path", progress: 0 },
+              { id: "request_ready", label: "Prompt prepared", status: "done", detail: "Co to jest slonce?", at_ms: 10, path: "answer_path", progress: 10 },
+              { id: "stream_opened", label: "Stream opened", status: "done", detail: "3 event(s) observed", at_ms: 20, path: "answer_path", progress: 20 },
+              { id: "first_chunk", label: "First content chunk", status: "done", detail: "1 chunk(s) total", at_ms: 30, path: "answer_path", progress: 40 },
+              { id: "response_finalized", label: "Response assembled", status: "done", detail: "18 chars", at_ms: 40, path: "answer_path", progress: 85 },
+              { id: "internals:logit_lens_probe", label: "Logit lens probe", status: "done", detail: "4 checkpoint(s)", at_ms: 50, path: "internals_path", progress: 90 },
+              { id: "internals:attention_probe", label: "Attention probe", status: "skipped", detail: "not available", at_ms: 50, path: "internals_path", progress: 93 },
+              { id: "internals:saliency_probe", label: "Saliency probe", status: "skipped", detail: "not available", at_ms: 50, path: "internals_path", progress: 96 },
+              { id: "snapshot_after", label: "Snapshot refreshed", status: "done", detail: "8 packages available", at_ms: 60, path: "answer_path", progress: 100 },
+            ],
+            elapsed_ms: 60,
+            provider: "ollama",
+            model: "gemma3:latest",
+            runtime_label: snapshot.runtime.label,
+            logit_lens: {
+              source: "probe_lite",
+              status: "ok",
+              code: "ollama_logprobs_lite",
+              message: "Token-level logprobs from ollama",
+              runtime_label: snapshot.runtime.label,
+              input_tokens: ["Co", "to", "jest"],
+              output_tokens: ["Słońce", "to", "gwiazda"],
+              raw_input_tokens: ["Co", "to", "jest"],
+              raw_output_tokens: ["Słońce", "to", "gwiazda"],
+              checkpoints: [{ id: "cp_0", percent: 0, layer: -1, top_k: [{ token: "Słońce", token_index: 0, score: -0.1 }], top_token: "Słońce", confidence: 0.9, changed: false }],
+              signals: { early_unstable: false, late_stabilized: true, low_confidence_path: false },
+              interpretability: { interpretable: true, confidence_band: "high", token_noise_ratio: 0.1, readable_top_tokens: 1, total_top_tokens: 1 },
+              diagnostics: {},
+            },
+            attention: { source: "probe_unavailable", status: "probe_unavailable", code: "runtime_not_supported", message: "not available", layers: [] },
+            saliency: { source: "probe_unavailable", status: "probe_unavailable", code: "runtime_not_supported", message: "not available", token_weights: [] },
+            analysis_capabilities: {
+              attention: { available: false, source: "probe_unavailable", status: "probe_unavailable", reason: "runtime_not_supported", availability_class: "unavailable" },
+              saliency: { available: false, source: "probe_unavailable", status: "probe_unavailable", reason: "runtime_not_supported", availability_class: "unavailable" },
+              logit_lens: { available: true, source: "probe_lite", status: "ok", reason: "ollama_logprobs_lite", availability_class: "proxy_ok" },
+              available_count: 1,
+              total_count: 3,
+              probe_profile: "legacy_text_only",
+              probe_enabled: false,
+              probe_healthy: false,
+              probe_status: "disabled",
+              runtime_supported: false,
+              endpoint_configured: true,
+              model_whitelisted: false,
+              limits: { timeout_seconds: 20, max_attempts: 2, max_top_k: 32, max_layer_count: 8, max_head_count: 32, max_prompt_tokens: 1024 },
+              internals_verdict: "partial",
+              introspection_level: "lite",
+            },
+            introspection_level: "lite",
+          },
+        };
+        const encoder = new TextEncoder();
+        const events = [
+          `event: analysis_start\ndata: ${JSON.stringify(makeAnalysisRunningPayload())}\n\n`,
+          "event: start\ndata: {}\n\n",
+          'event: content\ndata: {"text":"Słońce to gwiazda."}\n\n',
+          "event: done\ndata: {}\n\n",
+          `event: analysis_done\ndata: ${JSON.stringify(donePayload)}\n\n`,
+        ];
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              for (const event of events) controller.enqueue(encoder.encode(event));
+              controller.close();
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "text/event-stream" } },
+        );
+      }
+      return new Response(JSON.stringify({ success: true, snapshot: makeSnapshotBeforeFixture() }), {
+        status: 200,
+      });
+    };
+
+    render(
+      <LanguageProvider>
+        <ModelIntrospectionMechanismProvider>
+          <ModelIntrospectionDashboard />
+        </ModelIntrospectionMechanismProvider>
+      </LanguageProvider>,
+    );
+    await waitFor(() => {
+      assert.ok(screen.getByRole("button", { name: /Run analysis|Uruchom analizę/i }));
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Run analysis|Uruchom analizę/i }));
+    await waitFor(() => {
+      assert.ok(screen.getByText("Token confidence (lite)"));
+      assert.ok(screen.getByText(/How to get full internals/i));
+      assert.ok(screen.getByText(/Switch runtime to multi_runtime/i));
+    });
+  });
 });

--- a/web-next/tests/model-introspection-page.component.test.tsx
+++ b/web-next/tests/model-introspection-page.component.test.tsx
@@ -1112,8 +1112,8 @@ describe("ModelIntrospectionDashboard", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: /Run analysis|Uruchom analizę/i }));
     await waitFor(() => {
-      assert.ok(screen.getByText("Token confidence (lite)"));
-      assert.ok(screen.getByText(/How to get full internals/i));
+      assert.ok(screen.getByText(/Token confidence \(lite\)/i));
+      assert.ok(screen.getByText(/How to get full internals|jak uzyskać pełne internals/i));
       assert.ok(screen.getByText(/Switch runtime to multi_runtime/i));
     });
   });


### PR DESCRIPTION
## Cel
Domkniecie PR232 dla `model-introspection` z naciskiem na bezpieczne wsparcie `ollama` bez falszywego sygnalu o natywnych internals.

Ten PR realizuje sciezke **Opcja 1 (szybka, niskie ryzyko): Ollama introspection lite** oraz porzadkuje sygnalizacje statusow w UI.

## Zakres zmian

### 232A - Kontrakt capability levels
- Dodany kontrakt `introspection_level: full | lite | none` w danych analizy/snapshotu.
- Poziom jest wyliczany na podstawie runtime i dostepnosci probe, zamiast niejawnego mapowania po samych statusach timeline.
- Ujednolicenie serializacji, zeby frontend i API czytaly ten sam poziom capability.

### 232B - Ollama probe-lite backend
- Rozszerzenie backendu pod `ollama` o probe-lite (token-level confidence) zamiast udawania full internals.
- Zbieranie i normalizacja sygnalow `logprobs/top_logprobs` tam, gdzie runtime je udostepnia.
- Dodany payload `logit_lite` z metrykami niepewnosci odpowiedzi (w tym metryki zagregowane dla operatora).
- Jawne powody bramek probe (np. `runtime_not_supported`, `disabled`) zamiast samego `probe_disabled`.

### 232C - UI model-introspection
- Dodany widok/panel dla sygnalu `Token confidence (lite)` dla scenariusza `ollama`.
- Dla `attention`/`saliency` w runtime bez natywnego wsparcia pokazywane jest jawne `not available on this runtime`.
- Dodana wskazowka jak uzyskac pelne internals (`multi_runtime`) bez sugerowania, ze to jest dostepne natywnie na `ollama`.
- Poprawka layoutu timeline/badge (zawijanie tekstu), zeby statusy typu `runtime_not_supported`/`skipped` nie wychodzily poza box.

### 232D - Testy i gates
- Rozszerzone testy backendowe: kontrakt `introspection_level`, probe-lite, mapowanie powodow bramek.
- Rozszerzone testy frontendowe: rozdzial `full` vs `lite` vs `none`, rendering statusow i opisow.
- Testy/regresje dla sciezki `ollama`, aby nie raportowac falszywie full internals.

## Kryteria akceptacji - status
1. `ollama` nie sugeruje natywnej dostepnosci `attention/saliency` ✅
2. Operator widzi dodatkowy sygnal diagnostyczny (co najmniej token-level confidence/logprobs) ✅
3. `multi_runtime` zachowuje kontrakt pelnych internals bez regresji ✅
4. Timeline i badges rozrozniaja `native full` / `proxy(lite)` / `unavailable` ✅

## Zmienione obszary (high level)
- Backend: `venom_core/services/*introspection*`, `llm_simple_service`, `model_registry_clients`, schematy API.
- Frontend: dashboard model introspection + typy + testy komponentowe.
- Runtime/ops docs + compose: podbicia i doprecyzowania konfiguracji.

## Walidacja lokalna
Wykonane lokalnie przed PR:
- `make pr-fast` ✅
  - `3270 passed, 4 skipped`
  - changed-lines coverage gate ✅
- `cd web-next && npm run test:unit:ci-lite` ✅
  - `112/112` testow zaliczone

## Ryzyka / uwagi
- Probe-lite zalezy od tego, czy runtime/model faktycznie ekspozytuje sygnaly tokenowe (degradacja do `lite/none` jest kontrolowana kontraktem).
- W UI swiadomie nie emulujemy `attention/saliency` dla `ollama`; pokazujemy brak wsparcia i droge do `multi_runtime`.

## Checklist dla reviewerow
1. Sprawdzic kontrakt `introspection_level` w API i zgodnosc z UI.
2. Zweryfikowac, ze `ollama` nie przechodzi do `full` bez natywnych probe.
3. Zweryfikowac timeline/status badges i wrapping dlugich statusow.
4. Ocenic czy metryki probe-lite sa wystarczajace operacyjnie (uncertainty baseline).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Wprowadzono tryb introspekcji "lite" dla częściowej analizy modeli
  * Dodano telemetrię token confidence (logprobs) w odpowiedziach
  * Dodano wskaźnik poziomu introspekcji (full/lite/none) w wynikach analizy

* **Improvements**
  * Ulepszono układ i prezentację dashboardu introspekcji
  * Poprawiono wykrywanie stanu systemu głosowego i prezentację probe/TTS
  * Dodano komunikaty i instrukcje w UI dla trybu "lite" (PL/EN/DE)

* **Chores**
  * Zaktualizowano domyślny obraz runtime Ollama z 0.16.1 do 0.24.0
  * Zaktualizowano dokumentację dotyczące wersji runtime

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpieniak01/Venom/pull/502?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->