### PR TITLE
feat(pr241): LocalAgentCLI + agentic VS Code extension with full tool suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ PORTS_TO_CLEAN := $(PORT) $(WEB_PORT)
 		local-first-repo-truth-agent \
 		local-first-pr240-orchestrator-routing-probe \
 		local-first-pr240-full-agent-handoff-probe \
+		local-first-pr241-selftest local-first-pr241-selftest-json \
 		local-first-feedback-probe local-first-tool-flake-probe local-first-operator-tool-profile-probe local-first-chat-diagnostics local-first-agent-config-validate \
 		local-first-copilot-chat-output-probe local-first-copilot-agent-session-probe local-first-copilot-chat-output-gate \
 		local-first-local-agent-tool-loop-probe local-first-local-agent-tool-loop-gate local-first-vscode-agent-log-probe local-first-vscode-terminal-tool-loop-probe local-first-local-model-tool-call-probe local-first-pr239-selftest local-first-git-status local-first-repo-truth-reply local-first-chat-tool-bridge \

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ PORTS_TO_CLEAN := $(PORT) $(WEB_PORT)
 		local-first-pr240-orchestrator-routing-probe \
 		local-first-pr240-full-agent-handoff-probe \
 		local-first-pr241-selftest local-first-pr241-selftest-json \
+		local-first-pr241b-probe local-first-pr241b-probe-json \
 		local-first-feedback-probe local-first-tool-flake-probe local-first-operator-tool-profile-probe local-first-chat-diagnostics local-first-agent-config-validate \
 		local-first-copilot-chat-output-probe local-first-copilot-agent-session-probe local-first-copilot-chat-output-gate \
 		local-first-local-agent-tool-loop-probe local-first-local-agent-tool-loop-gate local-first-vscode-agent-log-probe local-first-vscode-terminal-tool-loop-probe local-first-local-model-tool-call-probe local-first-pr239-selftest local-first-git-status local-first-repo-truth-reply local-first-chat-tool-bridge \

--- a/config/pytest-groups/fast.txt
+++ b/config/pytest-groups/fast.txt
@@ -85,6 +85,7 @@ tests/test_chrono_skill.py
 tests/test_chronos.py
 tests/test_cloud_provisioner.py
 tests/test_code_generation_utils.py
+tests/test_code_index_skill.py
 tests/test_code_review_optimization.py
 tests/test_coder.py
 tests/test_coder_agent_mcp.py
@@ -228,6 +229,7 @@ tests/test_llm_simple_payload_service.py
 tests/test_llm_simple_route_model_resolution.py
 tests/test_llm_simple_service_streaming.py
 tests/test_llm_simple_stream.py
+tests/test_local_agent_cli.py
 tests/test_logger_utils.py
 tests/test_main_internal_helpers.py
 tests/test_main_setup_router_dependencies.py
@@ -289,6 +291,7 @@ tests/test_node_protocol.py
 tests/test_nodes_init_exports.py
 tests/test_nodes_utility_contracts.py
 tests/test_notifier.py
+tests/test_ollama_agent_loop.py
 tests/test_ollama_runtime_capabilities.py
 tests/test_ollama_runtime_probe.py
 tests/test_ollama_tuning.py

--- a/config/pytest-groups/sonar-new-code.txt
+++ b/config/pytest-groups/sonar-new-code.txt
@@ -64,6 +64,7 @@ tests/test_check_github_actions_node_runtime.py
 tests/test_chrono_skill.py
 tests/test_chronos.py
 tests/test_cloud_provisioner.py
+tests/test_code_index_skill.py
 tests/test_code_review_optimization.py
 tests/test_coder.py
 tests/test_coder_critic_loop.py
@@ -146,6 +147,7 @@ tests/test_llm_simple_payload_service.py
 tests/test_llm_simple_route_model_resolution.py
 tests/test_llm_simple_service_streaming.py
 tests/test_llm_simple_stream.py
+tests/test_local_agent_cli.py
 tests/test_logger_utils.py
 tests/test_main_internal_helpers.py
 tests/test_main_setup_router_dependencies.py
@@ -196,6 +198,7 @@ tests/test_node_protocol.py
 tests/test_nodes_init_exports.py
 tests/test_nodes_utility_contracts.py
 tests/test_notifier.py
+tests/test_ollama_agent_loop.py
 tests/test_ollama_tuning.py
 tests/test_onnx_llm_client.py
 tests/test_onnx_runtime_cleanup.py

--- a/config/testing/test_catalog.json
+++ b/config/testing/test_catalog.json
@@ -6334,6 +6334,48 @@
       ],
       "legacy_targeted": false,
       "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
+    },
+    {
+      "path": "tests/test_code_index_skill.py",
+      "domain": "skills",
+      "test_type": "unit",
+      "intent": "regression",
+      "primary_lane": "new-code",
+      "allowed_lanes": [
+        "new-code",
+        "ci-lite",
+        "release"
+      ],
+      "legacy_targeted": false,
+      "rationale": "Coverage gate dla CodeIndexSkill (ripgrep + AST) - nowy komponent PR241."
+    },
+    {
+      "path": "tests/test_ollama_agent_loop.py",
+      "domain": "runtime",
+      "test_type": "unit",
+      "intent": "regression",
+      "primary_lane": "new-code",
+      "allowed_lanes": [
+        "new-code",
+        "ci-lite",
+        "release"
+      ],
+      "legacy_targeted": false,
+      "rationale": "Coverage gate dla OllamaAgentLoop (pętla agentowa) - nowy komponent PR241."
+    },
+    {
+      "path": "tests/test_local_agent_cli.py",
+      "domain": "agents",
+      "test_type": "unit",
+      "intent": "regression",
+      "primary_lane": "new-code",
+      "allowed_lanes": [
+        "new-code",
+        "ci-lite",
+        "release"
+      ],
+      "legacy_targeted": false,
+      "rationale": "Coverage gate dla LocalAgentCLI i IntentRouter - nowe komponenty PR241."
     }
   ]
 }

--- a/make/runtime.mk
+++ b/make/runtime.mk
@@ -173,6 +173,14 @@ local-first-pr241-selftest-json:
 	@echo "🧪 PR241 selftest (JSON output)"
 	@$(PYTHON_BIN) scripts/dev/241_local_agent_selftest.py --json
 
+local-first-pr241b-probe:
+	@echo "🧪 PR241B probe: VSCode extension artefakty (participant, tools, agentic loop)"
+	@$(PYTHON_BIN) scripts/dev/241b_vscode_extension_probe.py
+
+local-first-pr241b-probe-json:
+	@echo "🧪 PR241B probe (JSON output)"
+	@$(PYTHON_BIN) scripts/dev/241b_vscode_extension_probe.py --json
+
 local-first-git-status:
 	@echo "📌 PR239 execution lane: exact git status"
 	@bash scripts/dev/239_local_first_git_status.sh "$(if $(REPO_ROOT),$(REPO_ROOT),$(CURDIR))"

--- a/make/runtime.mk
+++ b/make/runtime.mk
@@ -165,6 +165,14 @@ local-first-pr239-selftest:
 	@echo "🧪 PR239 selftest: runtime + model + session + execution lane + extension contract"
 	@$(PYTHON_BIN) scripts/dev/239_pr239_selftest.py
 
+local-first-pr241-selftest:
+	@echo "🧪 PR241 selftest: LocalAgentCLI + CodeIndexSkill + IntentRouter (bez VS Code)"
+	@$(PYTHON_BIN) scripts/dev/241_local_agent_selftest.py
+
+local-first-pr241-selftest-json:
+	@echo "🧪 PR241 selftest (JSON output)"
+	@$(PYTHON_BIN) scripts/dev/241_local_agent_selftest.py --json
+
 local-first-git-status:
 	@echo "📌 PR239 execution lane: exact git status"
 	@bash scripts/dev/239_local_first_git_status.sh "$(if $(REPO_ROOT),$(REPO_ROOT),$(CURDIR))"

--- a/scripts/dev/241_local_agent_selftest.py
+++ b/scripts/dev/241_local_agent_selftest.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""
+Selftest PR241 – weryfikuje LocalAgentCLI bez VS Code, bez Copilot, bez zewnętrznego API.
+
+Testy:
+  1. git_status:   agent.run_once("sprawdz status git") zawiera REPO_ROOT= i blok ## branch
+  2. code_search:  agent.run_once("gdzie jest klasa IntegratorAgent") zawiera ścieżkę pliku i numer linii
+  3. intent_router: IntentRouter klasyfikuje kluczowe klasy intentów
+  4. code_index:   CodeIndexSkill.search_code("IntegratorAgent") zwraca wynik z ścieżką
+  5. no_vscode:    brak zależności od vscode / copilot w imporcie
+
+Uruchomienie:
+    python scripts/dev/241_local_agent_selftest.py
+    python scripts/dev/241_local_agent_selftest.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import traceback
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+
+@dataclass
+class ProbeResult:
+    name: str
+    status: str  # "PASS" | "FAIL" | "SKIP"
+    message: str = ""
+    detail: str = ""
+
+
+@dataclass
+class SelftestReport:
+    probes: List[ProbeResult] = field(default_factory=list)
+
+    def add(self, probe: ProbeResult) -> None:
+        self.probes.append(probe)
+
+    def passed(self) -> bool:
+        return all(p.status in ("PASS", "SKIP") for p in self.probes)
+
+    def summary(self) -> str:
+        lines = ["=== PR241 LocalAgent Selftest ==="]
+        for p in self.probes:
+            icon = "✓" if p.status == "PASS" else ("⚠" if p.status == "SKIP" else "✗")
+            lines.append(f"  {icon} [{p.status}] {p.name}: {p.message}")
+            if p.detail:
+                lines.append(f"          {p.detail[:200]}")
+        lines.append("")
+        lines.append("RESULT: " + ("PASS" if self.passed() else "FAIL"))
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict:
+        return {
+            "result": "PASS" if self.passed() else "FAIL",
+            "probes": [
+                {
+                    "name": p.name,
+                    "status": p.status,
+                    "message": p.message,
+                    "detail": p.detail,
+                }
+                for p in self.probes
+            ],
+        }
+
+
+def probe_import() -> ProbeResult:
+    name = "import_no_vscode"
+    try:
+        from venom_core.agents.local_agent_cli import (  # noqa: F401
+            IntentRouter,
+            LocalAgent,
+            LocalAgentConfig,
+        )
+        from venom_core.execution.ollama_agent_loop import OllamaAgentLoop  # noqa: F401
+        from venom_core.execution.skills.code_index_skill import (  # noqa: F401
+            CodeIndexSkill,
+        )
+
+        return ProbeResult(name, "PASS", "Wszystkie moduły importują się bez vscode")
+    except ImportError as e:
+        return ProbeResult(name, "FAIL", f"Import error: {e}")
+
+
+def probe_intent_router() -> ProbeResult:
+    name = "intent_router"
+    try:
+        from venom_core.agents.local_agent_cli import IntentClass, IntentRouter
+
+        router = IntentRouter()
+        cases = [
+            ("sprawdz status git", IntentClass.GIT_STATUS),
+            ("gdzie jest klasa IntegratorAgent", IntentClass.CODE_SEARCH),
+            ("hello world", IntentClass.GENERAL),
+        ]
+        failures = []
+        for intent, expected in cases:
+            got = router.classify(intent)
+            if got != expected:
+                failures.append(
+                    f"{intent!r}: expected {expected.value}, got {got.value}"
+                )
+        if failures:
+            return ProbeResult(name, "FAIL", "Błędna klasyfikacja", "; ".join(failures))
+        return ProbeResult(name, "PASS", f"Klasyfikacja OK dla {len(cases)} przypadków")
+    except Exception as e:
+        return ProbeResult(name, "FAIL", str(e), traceback.format_exc()[-300:])
+
+
+def probe_code_index_search() -> ProbeResult:
+    name = "code_index_search"
+    try:
+        from venom_core.execution.skills.code_index_skill import CodeIndexSkill
+
+        skill = CodeIndexSkill(workspace_root=str(REPO_ROOT))
+        # Szukamy definicji klasy – pattern ^class IntegratorAgent ogranicza do prawdziwych definicji
+        matches = skill.search_code(
+            "^class IntegratorAgent", path_glob="*.py", max_results=5
+        )
+        if not matches:
+            return ProbeResult(
+                name, "FAIL", "Brak wyników dla '^class IntegratorAgent'"
+            )
+        # Szukamy trafienia z venom_core (nie skrypt diagnostyczny)
+        best = next((m for m in matches if "venom_core" in m.file), matches[0])
+        if "integrator" not in best.file.lower():
+            return ProbeResult(name, "FAIL", f"Nieoczekiwany plik: {best.file}")
+        detail = f"{best.file}:{best.line}"
+        return ProbeResult(
+            name, "PASS", "Znaleziono klasę IntegratorAgent w venom_core", detail
+        )
+    except Exception as e:
+        return ProbeResult(name, "FAIL", str(e), traceback.format_exc()[-300:])
+
+
+def probe_git_status_fast_path() -> ProbeResult:
+    name = "git_status_fast_path"
+    try:
+        from venom_core.agents.local_agent_cli import LocalAgent, LocalAgentConfig
+
+        config = LocalAgentConfig(workspace=str(REPO_ROOT), model="qwen3.5:9b")
+        agent = LocalAgent(config)
+        result = agent.handle_intent("sprawdz status git")
+        if result.stopped_by != "fast_path":
+            return ProbeResult(
+                name, "FAIL", f"stopped_by={result.stopped_by!r}, oczekiwano fast_path"
+            )
+        answer = result.final_answer
+        if "REPO_ROOT=" not in answer:
+            return ProbeResult(
+                name, "FAIL", "Brak REPO_ROOT= w odpowiedzi", answer[:200]
+            )
+        if "##" not in answer:
+            return ProbeResult(
+                name, "FAIL", "Brak bloku ## branch w odpowiedzi", answer[:200]
+            )
+        return ProbeResult(
+            name, "PASS", "REPO_ROOT= i ## branch w odpowiedzi", answer.splitlines()[0]
+        )
+    except Exception as e:
+        return ProbeResult(name, "FAIL", str(e), traceback.format_exc()[-300:])
+
+
+def probe_code_search_via_agent() -> ProbeResult:
+    name = "code_search_via_agent"
+    try:
+        from venom_core.agents.local_agent_cli import LocalAgent, LocalAgentConfig
+
+        config = LocalAgentConfig(workspace=str(REPO_ROOT), model="qwen3.5:9b")
+        agent = LocalAgent(config)
+
+        # Testuj bezpośrednio handler bez LLM (LLM wymaga dostępnego Ollama)
+        result = agent._handle_search_code(
+            "search_code",
+            {"query": "class IntegratorAgent", "path_glob": "*.py", "max_results": 3},
+        )
+        if "integrator" in result.lower() or "IntegratorAgent" in result:
+            return ProbeResult(
+                name,
+                "PASS",
+                "Handler search_code zwraca wynik z klasą IntegratorAgent",
+                result[:150],
+            )
+        return ProbeResult(
+            name, "FAIL", "Brak IntegratorAgent w wynikach search", result[:150]
+        )
+    except Exception as e:
+        return ProbeResult(name, "FAIL", str(e), traceback.format_exc()[-300:])
+
+
+def probe_shell_exec_blocked_by_default() -> ProbeResult:
+    name = "shell_exec_blocked_by_default"
+    try:
+        from venom_core.agents.local_agent_cli import LocalAgent, LocalAgentConfig
+
+        config = LocalAgentConfig(workspace=str(REPO_ROOT), allow_exec=False)
+        agent = LocalAgent(config)
+        result = agent._handle_shell_exec("shell_exec", {"command": "echo test"})
+        if "❌" in result and "allow-exec" in result:
+            return ProbeResult(name, "PASS", "Wykonanie komend zablokowane domyślnie")
+        return ProbeResult(
+            name, "FAIL", "Komenda nie jest zablokowana domyślnie", result[:100]
+        )
+    except Exception as e:
+        return ProbeResult(name, "FAIL", str(e))
+
+
+def run_all() -> SelftestReport:
+    report = SelftestReport()
+    probes = [
+        probe_import,
+        probe_intent_router,
+        probe_code_index_search,
+        probe_git_status_fast_path,
+        probe_code_search_via_agent,
+        probe_shell_exec_blocked_by_default,
+    ]
+    for probe_fn in probes:
+        result = probe_fn()
+        report.add(result)
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="PR241 LocalAgent Selftest")
+    parser.add_argument("--json", action="store_true", help="Wynik jako JSON")
+    args = parser.parse_args()
+
+    report = run_all()
+
+    if args.json:
+        print(json.dumps(report.to_dict(), ensure_ascii=False, indent=2))
+    else:
+        print(report.summary())
+
+    return 0 if report.passed() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/241b_vscode_extension_probe.py
+++ b/scripts/dev/241b_vscode_extension_probe.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""
+Probe kontraktowy PR241B – weryfikuje artefakty rozszerzenia VS Code bez uruchamiania VS Code.
+
+Sprawdza:
+  1. build_ok:         out/extension.js istnieje i jest aktualny po kompilacji TypeScript
+  2. single_participant: package.json zawiera tylko 'venom.agent', brak 'venom.execution'
+  3. tools_registered:  package.json rejestruje wymagane narzędzia LM
+  4. new_settings:      package.json zawiera ustawienia allowExec i maxIterations
+  5. agentic_loop_code: extension.ts zawiera pętlę agentową z LanguageModelToolCallPart
+  6. allowlist_extended: extension.ts zawiera rozszerzoną allowlistę git (min 10 komend)
+  7. search_code_impl:  extension.ts zawiera implementację searchCode z ripgrep
+  8. legacy_alias:      extension.ts zachowuje narzędzie run_git_status jako alias
+
+Uruchomienie:
+    python scripts/dev/241b_vscode_extension_probe.py
+    python scripts/dev/241b_vscode_extension_probe.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+EXTENSION_DIR = REPO_ROOT / "tools" / "vscode-chat-executor"
+EXTENSION_TS = EXTENSION_DIR / "src" / "extension.ts"
+PACKAGE_JSON = EXTENSION_DIR / "package.json"
+OUT_JS = EXTENSION_DIR / "out" / "extension.js"
+
+
+@dataclass
+class ProbeResult:
+    name: str
+    status: str  # "PASS" | "FAIL" | "SKIP"
+    message: str = ""
+    detail: str = ""
+
+
+@dataclass
+class ProbeReport:
+    probes: List[ProbeResult] = field(default_factory=list)
+
+    def add(self, p: ProbeResult) -> None:
+        self.probes.append(p)
+
+    def passed(self) -> bool:
+        return all(p.status in ("PASS", "SKIP") for p in self.probes)
+
+    def summary(self) -> str:
+        lines = ["=== PR241B VSCode Extension Probe ==="]
+        for p in self.probes:
+            icon = "✓" if p.status == "PASS" else ("⚠" if p.status == "SKIP" else "✗")
+            lines.append(f"  {icon} [{p.status}] {p.name}: {p.message}")
+            if p.detail:
+                lines.append(f"          {p.detail[:200]}")
+        lines.append("")
+        lines.append("RESULT: " + ("PASS" if self.passed() else "FAIL"))
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict:
+        return {
+            "result": "PASS" if self.passed() else "FAIL",
+            "probes": [
+                {
+                    "name": p.name,
+                    "status": p.status,
+                    "message": p.message,
+                    "detail": p.detail,
+                }
+                for p in self.probes
+            ],
+        }
+
+
+def probe_build_ok() -> ProbeResult:
+    name = "build_ok"
+    if not OUT_JS.exists():
+        # Spróbuj zbudować
+        result = subprocess.run(
+            ["npm", "run", "build"],
+            cwd=str(EXTENSION_DIR),
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode != 0:
+            return ProbeResult(
+                name, "FAIL", "npm run build nie powiódł się", result.stderr[-300:]
+            )
+    if not OUT_JS.exists():
+        return ProbeResult(name, "FAIL", f"Brak pliku: {OUT_JS.relative_to(REPO_ROOT)}")
+    size = OUT_JS.stat().st_size
+    return ProbeResult(name, "PASS", f"out/extension.js istnieje ({size} bajtów)")
+
+
+def probe_single_participant() -> ProbeResult:
+    name = "single_participant"
+    try:
+        pkg = json.loads(PACKAGE_JSON.read_text())
+    except Exception as e:
+        return ProbeResult(name, "FAIL", f"Błąd odczytu package.json: {e}")
+
+    participants = pkg.get("contributes", {}).get("chatParticipants", [])
+    ids = [p["id"] for p in participants]
+
+    if "venom.execution" in ids:
+        return ProbeResult(
+            name,
+            "FAIL",
+            "Stary participant 'venom.execution' wciąż obecny w package.json",
+            str(ids),
+        )
+    if "venom.agent" not in ids:
+        return ProbeResult(
+            name,
+            "FAIL",
+            "Brak nowego participanta 'venom.agent' w package.json",
+            str(ids),
+        )
+    if len(ids) > 1:
+        return ProbeResult(name, "FAIL", f"Więcej niż jeden participant: {ids}")
+    return ProbeResult(
+        name, "PASS", f"Tylko 'venom.agent' ({participants[0].get('name', '?')})"
+    )
+
+
+def probe_tools_registered() -> ProbeResult:
+    name = "tools_registered"
+    try:
+        pkg = json.loads(PACKAGE_JSON.read_text())
+    except Exception as e:
+        return ProbeResult(name, "FAIL", f"Błąd odczytu package.json: {e}")
+
+    required = {
+        "venom_git_status",
+        "venom_search_code",
+        "venom_read_file",
+        "venom_exec_safe",
+    }
+    registered = {
+        t["name"] for t in pkg.get("contributes", {}).get("languageModelTools", [])
+    }
+    missing = required - registered
+
+    if missing:
+        return ProbeResult(
+            name,
+            "FAIL",
+            f"Brak narzędzi: {sorted(missing)}",
+            f"Zarejestrowane: {sorted(registered)}",
+        )
+    return ProbeResult(
+        name,
+        "PASS",
+        f"Wszystkie {len(required)} narzędzi zarejestrowane",
+        str(sorted(registered)),
+    )
+
+
+def probe_new_settings() -> ProbeResult:
+    name = "new_settings"
+    try:
+        pkg = json.loads(PACKAGE_JSON.read_text())
+    except Exception as e:
+        return ProbeResult(name, "FAIL", f"Błąd odczytu package.json: {e}")
+
+    props = pkg.get("contributes", {}).get("configuration", {}).get("properties", {})
+    required = {"venom.execution.allowExec", "venom.execution.maxIterations"}
+    missing = required - set(props.keys())
+
+    if missing:
+        return ProbeResult(name, "FAIL", f"Brak ustawień: {sorted(missing)}")
+    return ProbeResult(
+        name, "PASS", "Ustawienia allowExec i maxIterations zarejestrowane"
+    )
+
+
+def probe_agentic_loop_code() -> ProbeResult:
+    name = "agentic_loop_code"
+    try:
+        src = EXTENSION_TS.read_text()
+    except Exception as e:
+        return ProbeResult(name, "FAIL", f"Błąd odczytu extension.ts: {e}")
+
+    markers = [
+        "LanguageModelToolCallPart",
+        "LanguageModelToolResultPart",
+        "sendRequest",
+        "while (iterations < maxIter)",
+    ]
+    missing = [m for m in markers if m not in src]
+    if missing:
+        return ProbeResult(name, "FAIL", f"Brak w extension.ts: {missing}")
+    return ProbeResult(
+        name, "PASS", "Pętla agentowa z LanguageModelToolCallPart zaimplementowana"
+    )
+
+
+def probe_allowlist_extended() -> ProbeResult:
+    name = "allowlist_extended"
+    try:
+        src = EXTENSION_TS.read_text()
+    except Exception as e:
+        return ProbeResult(name, "FAIL", f"Błąd odczytu extension.ts: {e}")
+
+    # Proste sprawdzenie: git log powinno być w allowlist
+    required_cmds = ["git log --oneline", "git diff", "git status"]
+    missing = [c for c in required_cmds if c not in src]
+    if missing:
+        return ProbeResult(name, "FAIL", f"Brak komend git w allowliście: {missing}")
+
+    # Policz wpisy w GIT_ALLOWLIST
+    allowlist_section = (
+        src[src.find("GIT_ALLOWLIST") : src.find("GIT_ALLOWLIST") + 2000]
+        if "GIT_ALLOWLIST" in src
+        else ""
+    )
+    entry_count = allowlist_section.count("'git ")
+    if entry_count < 8:
+        return ProbeResult(
+            name, "FAIL", f"Allowlist za mała: {entry_count} wpisów (oczekiwano >=8)"
+        )
+    return ProbeResult(
+        name, "PASS", f"Rozszerzona allowlist git ({entry_count} wpisów)"
+    )
+
+
+def probe_search_code_impl() -> ProbeResult:
+    name = "search_code_impl"
+    try:
+        src = EXTENSION_TS.read_text()
+    except Exception as e:
+        return ProbeResult(name, "FAIL", f"Błąd odczytu extension.ts: {e}")
+
+    markers = ["spawn('rg'", "--json", "searchCode"]
+    missing = [m for m in markers if m not in src]
+    if missing:
+        return ProbeResult(name, "FAIL", f"Brak w searchCode impl: {missing}")
+    return ProbeResult(
+        name, "PASS", "searchCode z ripgrep (spawn rg --json) zaimplementowany"
+    )
+
+
+def probe_legacy_alias() -> ProbeResult:
+    name = "legacy_alias"
+    try:
+        src = EXTENSION_TS.read_text()
+        pkg = json.loads(PACKAGE_JSON.read_text())
+    except Exception as e:
+        return ProbeResult(name, "FAIL", f"Błąd odczytu: {e}")
+
+    tools = {
+        t["name"] for t in pkg.get("contributes", {}).get("languageModelTools", [])
+    }
+    if "run_git_status" not in tools:
+        return ProbeResult(
+            name, "FAIL", "Alias run_git_status brak w package.json languageModelTools"
+        )
+    if "LEGACY_TOOL_NAME" not in src and "run_git_status" not in src:
+        return ProbeResult(name, "FAIL", "Alias run_git_status brak w extension.ts")
+    return ProbeResult(name, "PASS", "Backward-compat alias run_git_status zachowany")
+
+
+def run_all() -> ProbeReport:
+    report = ProbeReport()
+    for fn in [
+        probe_build_ok,
+        probe_single_participant,
+        probe_tools_registered,
+        probe_new_settings,
+        probe_agentic_loop_code,
+        probe_allowlist_extended,
+        probe_search_code_impl,
+        probe_legacy_alias,
+    ]:
+        report.add(fn())
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="PR241B VSCode Extension Probe")
+    parser.add_argument("--json", action="store_true", help="Wynik jako JSON")
+    args = parser.parse_args()
+
+    report = run_all()
+    if args.json:
+        print(json.dumps(report.to_dict(), ensure_ascii=False, indent=2))
+    else:
+        print(report.summary())
+    return 0 if report.passed() else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/241b_vscode_extension_probe.py
+++ b/scripts/dev/241b_vscode_extension_probe.py
@@ -82,17 +82,43 @@ def probe_build_ok() -> ProbeResult:
     name = "build_ok"
     if not OUT_JS.exists():
         # Spróbuj zbudować
-        result = subprocess.run(
-            ["npm", "run", "build"],
-            cwd=str(EXTENSION_DIR),
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-        if result.returncode != 0:
-            return ProbeResult(
-                name, "FAIL", "npm run build nie powiódł się", result.stderr[-300:]
+        try:
+            result = subprocess.run(
+                ["npm", "run", "build"],
+                cwd=str(EXTENSION_DIR),
+                capture_output=True,
+                text=True,
+                timeout=60,
             )
+        except subprocess.TimeoutExpired as e:
+            stdout = (e.stdout or "")[-200:]
+            stderr = (e.stderr or "")[-200:]
+            detail = (
+                f"Timeout build dla {EXTENSION_DIR} (out: {OUT_JS}). "
+                f"stdout={stdout!r} stderr={stderr!r}"
+            )
+            return ProbeResult(name, "FAIL", "npm run build timeout (60s)", detail)
+        except FileNotFoundError as e:
+            return ProbeResult(
+                name,
+                "FAIL",
+                "Brak npm w środowisku",
+                f"{e}; extension_dir={EXTENSION_DIR}; out_js={OUT_JS}",
+            )
+        except Exception as e:
+            return ProbeResult(
+                name,
+                "FAIL",
+                "Błąd uruchomienia npm run build",
+                f"{e}; extension_dir={EXTENSION_DIR}; out_js={OUT_JS}",
+            )
+        if result.returncode != 0:
+            detail = (
+                f"build failed dla {EXTENSION_DIR} (out: {OUT_JS})\n"
+                f"stdout: {result.stdout[-300:]}\n"
+                f"stderr: {result.stderr[-300:]}"
+            )
+            return ProbeResult(name, "FAIL", "npm run build nie powiódł się", detail)
     if not OUT_JS.exists():
         return ProbeResult(name, "FAIL", f"Brak pliku: {OUT_JS.relative_to(REPO_ROOT)}")
     size = OUT_JS.stat().st_size

--- a/tests/test_code_index_skill.py
+++ b/tests/test_code_index_skill.py
@@ -162,6 +162,8 @@ class TestSearchCode:
         assert matches == []
 
     def test_search_finds_pattern(self, skill, tmp_path):
+        if not skill._rg_available:
+            pytest.skip("ripgrep niedostępny w środowisku testowym")
         f = tmp_path / "code.py"
         f.write_text("def hello_world():\n    return 'hello'\n")
         matches = skill.search_code("hello_world", max_results=5)

--- a/tests/test_code_index_skill.py
+++ b/tests/test_code_index_skill.py
@@ -1,0 +1,232 @@
+"""Testy jednostkowe dla CodeIndexSkill."""
+
+import textwrap
+from unittest.mock import patch
+
+import pytest
+
+from venom_core.execution.skills.code_index_skill import (
+    CodeIndexSkill,
+    CodeMatch,
+    FileSymbols,
+)
+
+
+@pytest.fixture
+def skill(tmp_path):
+    return CodeIndexSkill(workspace_root=str(tmp_path))
+
+
+@pytest.fixture
+def py_file(tmp_path):
+    content = textwrap.dedent("""\
+        import os
+        from pathlib import Path
+
+        class MyClass:
+            def method_one(self):
+                pass
+
+            async def async_method(self):
+                pass
+
+        def standalone_func():
+            return 42
+    """)
+    f = tmp_path / "sample.py"
+    f.write_text(content, encoding="utf-8")
+    return f
+
+
+class TestCodeMatch:
+    def test_to_dict_roundtrip(self):
+        m = CodeMatch(
+            file="a.py",
+            line=5,
+            text="def foo():",
+            context_before=["# comment"],
+            context_after=["    pass"],
+        )
+        d = m.to_dict()
+        assert d["file"] == "a.py"
+        assert d["line"] == 5
+        assert d["text"] == "def foo():"
+
+    def test_format_snippet_includes_arrow(self):
+        m = CodeMatch(
+            file="a.py",
+            line=3,
+            text="target line",
+            context_before=["before"],
+            context_after=["after"],
+        )
+        snippet = m.format_snippet()
+        assert "→" in snippet
+        assert "target line" in snippet
+        assert "before" in snippet
+        assert "after" in snippet
+
+
+class TestFileSymbols:
+    def test_format_summary_all_sections(self):
+        fs = FileSymbols(
+            file="x.py",
+            classes=["Foo", "Bar"],
+            functions=["do_thing"],
+            imports=["os", "pathlib"],
+        )
+        summary = fs.format_summary()
+        assert "Foo" in summary
+        assert "Bar" in summary
+        assert "do_thing" in summary
+        assert "os" in summary
+
+    def test_format_summary_empty(self):
+        fs = FileSymbols(file="empty.py", classes=[], functions=[], imports=[])
+        summary = fs.format_summary()
+        assert "empty.py" in summary
+
+
+class TestCodeIndexSkillGetFileSymbols:
+    def test_extracts_classes_and_functions(self, skill, py_file):
+        symbols = skill.get_file_symbols(str(py_file))
+        assert "MyClass" in symbols.classes
+        assert "method_one" in symbols.functions
+        assert "async_method" in symbols.functions
+        assert "standalone_func" in symbols.functions
+
+    def test_extracts_imports(self, skill, py_file):
+        symbols = skill.get_file_symbols(str(py_file))
+        assert "os" in symbols.imports
+        assert "pathlib" in symbols.imports
+
+    def test_nonexistent_file(self, skill):
+        symbols = skill.get_file_symbols("/tmp/does_not_exist_xyz.py")
+        assert symbols.classes == []
+        assert symbols.functions == []
+
+    def test_non_py_file(self, skill, tmp_path):
+        f = tmp_path / "script.sh"
+        f.write_text("echo hello")
+        symbols = skill.get_file_symbols(str(f))
+        assert symbols.classes == []
+        assert symbols.functions == []
+
+    def test_syntax_error_file(self, skill, tmp_path):
+        f = tmp_path / "broken.py"
+        f.write_text("def (broken syntax!!!")
+        symbols = skill.get_file_symbols(str(f))
+        assert isinstance(symbols, FileSymbols)
+
+    def test_deduplicates_symbols(self, skill, tmp_path):
+        f = tmp_path / "dup.py"
+        f.write_text("import os\nimport os\ndef foo(): pass\ndef foo(): pass\n")
+        symbols = skill.get_file_symbols(str(f))
+        assert symbols.imports.count("os") == 1
+        assert symbols.functions.count("foo") == 1
+
+
+class TestReadContext:
+    def test_returns_surrounding_lines(self, skill, tmp_path):
+        f = tmp_path / "test.py"
+        f.write_text("\n".join(f"line {i}" for i in range(1, 21)))
+        ctx = skill.read_context(str(f), line=10, context_lines=2)
+        assert "→" in ctx
+        assert "line 10" in ctx
+        assert "line 8" in ctx
+        assert "line 12" in ctx
+
+    def test_nonexistent_file(self, skill):
+        result = skill.read_context("/nonexistent/file.py", line=1)
+        assert "❌" in result
+
+    def test_line_at_start(self, skill, tmp_path):
+        f = tmp_path / "t.py"
+        f.write_text("a\nb\nc\n")
+        ctx = skill.read_context(str(f), line=1, context_lines=5)
+        assert "→" in ctx
+        assert "a" in ctx
+
+    def test_line_at_end(self, skill, tmp_path):
+        f = tmp_path / "t.py"
+        f.write_text("a\nb\nc\n")
+        ctx = skill.read_context(str(f), line=3, context_lines=5)
+        assert "→" in ctx
+        assert "c" in ctx
+
+
+class TestSearchCode:
+    def test_returns_empty_when_rg_unavailable(self, skill):
+        skill._rg_available = False
+        matches = skill.search_code("anything")
+        assert matches == []
+
+    def test_search_finds_pattern(self, skill, tmp_path):
+        f = tmp_path / "code.py"
+        f.write_text("def hello_world():\n    return 'hello'\n")
+        matches = skill.search_code("hello_world", max_results=5)
+        assert any(m.text.strip().startswith("def hello_world") for m in matches)
+
+    def test_respects_max_results(self, skill, tmp_path):
+        for i in range(20):
+            (tmp_path / f"f{i}.py").write_text(f"# target_{i}\n")
+        matches = skill.search_code("target_", max_results=3)
+        assert len(matches) <= 3
+
+    def test_case_insensitive_default(self, skill, tmp_path):
+        f = tmp_path / "c.py"
+        f.write_text("class FooBar:\n    pass\n")
+        matches = skill.search_code("foobar")
+        assert len(matches) >= 1
+
+    def test_glob_filter(self, skill, tmp_path):
+        (tmp_path / "a.py").write_text("# unique_marker_xyz\n")
+        (tmp_path / "b.md").write_text("unique_marker_xyz\n")
+        py_matches = skill.search_code("unique_marker_xyz", path_glob="*.py")
+        assert all(m.file.endswith(".py") for m in py_matches)
+
+    def test_format_matches_empty(self, skill):
+        result = skill.format_matches_for_llm([])
+        assert result == "Brak wyników."
+
+    def test_format_matches_truncation(self, skill):
+        matches = [
+            CodeMatch(
+                file=f"f{i}.py",
+                line=1,
+                text="x" * 200,
+                context_before=[],
+                context_after=[],
+            )
+            for i in range(50)
+        ]
+        result = skill.format_matches_for_llm(matches, max_chars=500)
+        assert len(result) <= 700
+
+
+class TestSearchCodeRipgrepTimeout:
+    def test_timeout_returns_empty(self, skill, tmp_path):
+        import subprocess
+
+        skill._rg_available = True
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired("rg", 15)):
+            matches = skill.search_code("anything")
+        assert matches == []
+
+
+@pytest.mark.asyncio
+class TestKernelFunctionWrappers:
+    async def test_search_code_tool_no_results(self, skill):
+        skill._rg_available = False
+        result = await skill.search_code_tool(query="xyz")
+        assert result == "Brak wyników."
+
+    async def test_get_file_symbols_tool(self, skill, py_file):
+        result = await skill.get_file_symbols_tool(file_path=str(py_file))
+        assert "MyClass" in result
+
+    async def test_read_context_tool(self, skill, tmp_path):
+        f = tmp_path / "t.py"
+        f.write_text("line1\nline2\nline3\n")
+        result = await skill.read_context_tool(file_path=str(f), line=2)
+        assert "line2" in result

--- a/tests/test_local_agent_cli.py
+++ b/tests/test_local_agent_cli.py
@@ -1,0 +1,290 @@
+"""Testy jednostkowe dla LocalAgentCLI i IntentRouter."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from venom_core.agents.local_agent_cli import (
+    IntentClass,
+    IntentRouter,
+    LocalAgent,
+    LocalAgentConfig,
+    main,
+)
+from venom_core.execution.ollama_agent_loop import AgentLoopResult, ToolCall
+
+
+class TestIntentRouter:
+    @pytest.fixture
+    def router(self):
+        return IntentRouter()
+
+    @pytest.mark.parametrize(
+        "intent",
+        [
+            "sprawdz status git",
+            "stan repo",
+            "git status",
+            "status git",
+            "sprawdz repo git",
+            "jaki jest status repozytorium",
+            "Stan Gita",  # case insensitive
+            "GIT STATUS",
+        ],
+    )
+    def test_git_status_class(self, router, intent):
+        assert router.classify(intent) == IntentClass.GIT_STATUS
+
+    @pytest.mark.parametrize(
+        "intent",
+        [
+            "gdzie jest klasa IntegratorAgent",
+            "znajdź klasę GitSkill",
+            "jak działa OllamaAgentLoop",
+            "pokaż implementację search_code",
+            "co robi klasa IntentRouter",
+            "szukaj w kodzie BaseSkill",
+            "gdzie jest funkcja process",
+        ],
+    )
+    def test_code_search_class(self, router, intent):
+        assert router.classify(intent) == IntentClass.CODE_SEARCH
+
+    @pytest.mark.parametrize(
+        "intent",
+        [
+            "uruchom testy",
+            "wykonaj make pr-fast",
+            "run pytest",
+            "pytest tests/",
+        ],
+    )
+    def test_shell_exec_class(self, router, intent):
+        assert router.classify(intent) == IntentClass.SHELL_EXEC
+
+    @pytest.mark.parametrize(
+        "intent",
+        [
+            "pokaż zawartość pliku config.py",
+            "przeczytaj plik README",
+            "lista plików w tests/",
+        ],
+    )
+    def test_file_op_class(self, router, intent):
+        assert router.classify(intent) == IntentClass.FILE_OP
+
+    @pytest.mark.parametrize(
+        "intent",
+        [
+            "czym jest venom",
+            "opowiedz mi o projekcie",
+            "co to jest orchestrator",
+            "hello",
+        ],
+    )
+    def test_general_class(self, router, intent):
+        assert router.classify(intent) == IntentClass.GENERAL
+
+    def test_git_status_takes_priority_over_code_search(self, router):
+        # "sprawdz status git" powinno być GIT_STATUS, nie CODE_SEARCH
+        result = router.classify("sprawdz status git w repozytorium")
+        assert result == IntentClass.GIT_STATUS
+
+
+class TestLocalAgentConfig:
+    def test_defaults_workspace_from_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("REPO_ROOT", str(tmp_path))
+        config = LocalAgentConfig()
+        assert config.workspace == str(tmp_path)
+
+    def test_explicit_workspace(self, tmp_path):
+        config = LocalAgentConfig(workspace=str(tmp_path))
+        assert config.workspace == str(tmp_path)
+
+    def test_default_model(self):
+        config = LocalAgentConfig(workspace="/tmp")
+        assert config.model == "qwen3.5:9b"
+
+
+class TestLocalAgentGitStatusFastPath:
+    @pytest.fixture
+    def agent(self, tmp_path):
+        config = LocalAgentConfig(workspace=str(tmp_path), model="test-model")
+        a = LocalAgent(config)
+        return a
+
+    def test_git_status_uses_fast_path(self, agent):
+        agent._handle_git_status = MagicMock(return_value="REPO_ROOT=/x\n## main")
+        result = agent.handle_intent("sprawdz status git")
+        assert result.stopped_by == "fast_path"
+        assert result.iterations == 0
+
+    def test_git_status_result_contains_repo_root(self, agent):
+        with patch.object(agent.git_skill, "get_short_status") as mock_status:
+            mock_status.return_value = "## main...origin/main"
+            # Patch asyncio.run to return directly
+            with patch("venom_core.agents.local_agent_cli.asyncio") as mock_asyncio:
+                mock_asyncio.run.return_value = "## main...origin/main"
+                result = agent.handle_intent("sprawdz status git")
+        assert result.stopped_by == "fast_path"
+        assert result.has_evidence()
+
+
+class TestLocalAgentRunOnce:
+    @pytest.fixture
+    def agent(self, tmp_path):
+        config = LocalAgentConfig(workspace=str(tmp_path), model="test-model")
+        return LocalAgent(config)
+
+    def test_run_once_returns_string(self, agent):
+        agent.handle_intent = MagicMock(
+            return_value=AgentLoopResult(
+                final_answer="Odpowiedź agenta", evidence=["evidence"]
+            )
+        )
+        out = agent.run_once("test query")
+        assert "Odpowiedź agenta" in out
+
+    def test_run_once_json_output(self, agent):
+        agent.handle_intent = MagicMock(
+            return_value=AgentLoopResult(
+                final_answer="OK", evidence=["e1"], iterations=1, stopped_by="finish"
+            )
+        )
+        agent.config.json_output = True
+        out = agent.run_once("test")
+        parsed = json.loads(out)
+        assert parsed["final_answer"] == "OK"
+        assert parsed["evidence"] == ["e1"]
+
+    def test_run_once_includes_trace_when_tool_calls(self, agent):
+        tc = ToolCall(
+            call_id="c1",
+            name="search_code",
+            arguments={"query": "foo"},
+            result="bar.py:5",
+        )
+        agent.handle_intent = MagicMock(
+            return_value=AgentLoopResult(final_answer="Wynik", tool_calls=[tc])
+        )
+        out = agent.run_once("test")
+        assert "Trace" in out
+        assert "search_code" in out
+
+
+class TestLocalAgentShellExec:
+    @pytest.fixture
+    def agent_with_exec(self, tmp_path):
+        config = LocalAgentConfig(workspace=str(tmp_path), allow_exec=True)
+        return LocalAgent(config)
+
+    @pytest.fixture
+    def agent_no_exec(self, tmp_path):
+        config = LocalAgentConfig(workspace=str(tmp_path), allow_exec=False)
+        return LocalAgent(config)
+
+    def test_shell_exec_blocked_without_flag(self, agent_no_exec):
+        result = agent_no_exec._handle_shell_exec("shell_exec", {"command": "echo hi"})
+        assert "❌" in result
+        assert "allow-exec" in result
+
+    def test_shell_exec_runs_safe_command(self, agent_with_exec):
+        result = agent_with_exec._handle_shell_exec(
+            "shell_exec", {"command": "echo hello"}
+        )
+        assert "hello" in result
+
+    def test_shell_exec_blocks_destructive(self, agent_with_exec):
+        result = agent_with_exec._handle_shell_exec(
+            "shell_exec", {"command": "rm -rf /"}
+        )
+        assert "❌" in result
+        assert "destrukcyjna" in result
+
+    def test_shell_exec_allows_destructive_with_flag(self, tmp_path):
+        config = LocalAgentConfig(
+            workspace=str(tmp_path), allow_exec=True, allow_destructive=True
+        )
+        agent = LocalAgent(config)
+        result = agent._handle_shell_exec(
+            "shell_exec", {"command": "echo destructive allowed"}
+        )
+        assert "destructive allowed" in result
+
+    def test_shell_exec_timeout(self, agent_with_exec):
+        import subprocess
+
+        with patch(
+            "subprocess.run", side_effect=subprocess.TimeoutExpired("sleep", 30)
+        ):
+            result = agent_with_exec._handle_shell_exec(
+                "shell_exec", {"command": "sleep 100"}
+            )
+        assert "Timeout" in result
+
+    def test_shell_exec_empty_command(self, agent_with_exec):
+        result = agent_with_exec._handle_shell_exec("shell_exec", {"command": ""})
+        assert "❌" in result
+
+
+class TestLocalAgentCodeSearch:
+    @pytest.fixture
+    def agent(self, tmp_path):
+        config = LocalAgentConfig(workspace=str(tmp_path))
+        a = LocalAgent(config)
+        return a
+
+    def test_search_code_handler(self, agent, tmp_path):
+        (tmp_path / "mod.py").write_text("class TargetClass:\n    pass\n")
+        result = agent._handle_search_code("search_code", {"query": "TargetClass"})
+        assert "TargetClass" in result or result == "Brak wyników."
+
+    def test_file_symbols_handler(self, agent, tmp_path):
+        f = tmp_path / "m.py"
+        f.write_text("class Foo:\n    def bar(self): pass\n")
+        result = agent._handle_file_symbols("get_file_symbols", {"file_path": str(f)})
+        assert "Foo" in result
+
+    def test_read_context_handler(self, agent, tmp_path):
+        f = tmp_path / "t.py"
+        f.write_text("a\nb\nc\n")
+        result = agent._handle_read_context(
+            "read_file_context", {"file_path": str(f), "line": 2}
+        )
+        assert "b" in result
+
+
+class TestMainEntryPoint:
+    def test_main_requires_query_or_interactive(self, capsys):
+        ret = main([])
+        assert ret == 1
+        captured = capsys.readouterr()
+        assert "zapytanie" in captured.err or "interactive" in captured.err
+
+    def test_main_git_status(self, tmp_path):
+        with patch(
+            "venom_core.agents.local_agent_cli.LocalAgent.handle_intent",
+            return_value=AgentLoopResult(
+                final_answer=f"REPO_ROOT={tmp_path}\n## main",
+                evidence=[f"REPO_ROOT={tmp_path}\n## main"],
+                stopped_by="fast_path",
+            ),
+        ):
+            ret = main([f"--workspace={tmp_path}", "sprawdz status git"])
+        assert ret == 0
+
+    def test_main_json_output_valid_json(self, tmp_path, capsys):
+        with patch(
+            "venom_core.agents.local_agent_cli.LocalAgent.handle_intent",
+            return_value=AgentLoopResult(final_answer="OK", evidence=["e"]),
+        ):
+            ret = main([f"--workspace={tmp_path}", "--json-output", "test query"])
+        assert ret == 0
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert parsed["final_answer"] == "OK"
+
+    def test_main_unknown_flag_exits(self):
+        with pytest.raises(SystemExit):
+            main(["--unknown-flag-xyz", "query"])

--- a/tests/test_local_agent_cli.py
+++ b/tests/test_local_agent_cli.py
@@ -227,6 +227,13 @@ class TestLocalAgentShellExec:
         result = agent_with_exec._handle_shell_exec("shell_exec", {"command": ""})
         assert "❌" in result
 
+    def test_shell_exec_blocks_shell_metacharacters(self, agent_with_exec):
+        result = agent_with_exec._handle_shell_exec(
+            "shell_exec", {"command": "echo ok; rm -rf /"}
+        )
+        assert "❌" in result
+        assert "metaznaki" in result
+
 
 class TestLocalAgentCodeSearch:
     @pytest.fixture

--- a/tests/test_ollama_agent_loop.py
+++ b/tests/test_ollama_agent_loop.py
@@ -1,0 +1,293 @@
+"""Testy jednostkowe dla OllamaAgentLoop."""
+
+import json
+from unittest.mock import MagicMock
+
+from venom_core.execution.ollama_agent_loop import (
+    AgentLoopResult,
+    OllamaAgentLoop,
+    ToolCall,
+    build_tool_spec,
+)
+
+
+def _make_ollama_response(content: str, tool_calls=None, done_reason="stop"):
+    msg = {"role": "assistant", "content": content}
+    if tool_calls:
+        msg["tool_calls"] = tool_calls
+    return {"message": msg, "done": True, "done_reason": done_reason}
+
+
+def _make_tool_call_response(name: str, args: dict, call_id: str = "call_1"):
+    return _make_ollama_response(
+        content="",
+        tool_calls=[
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {"name": name, "arguments": args},
+            }
+        ],
+    )
+
+
+class TestToolCall:
+    def test_defaults(self):
+        tc = ToolCall(call_id="x", name="foo", arguments={})
+        assert tc.result is None
+        assert tc.error is None
+        assert tc.elapsed_ms == 0
+
+
+class TestAgentLoopResult:
+    def test_has_evidence_false_when_empty(self):
+        r = AgentLoopResult(final_answer="hi")
+        assert not r.has_evidence()
+
+    def test_has_evidence_true(self):
+        r = AgentLoopResult(final_answer="hi", evidence=["git: ## main"])
+        assert r.has_evidence()
+
+    def test_format_trace_no_calls(self):
+        r = AgentLoopResult(final_answer="hi")
+        assert "(brak" in r.format_trace()
+
+    def test_format_trace_with_calls(self):
+        tc = ToolCall(
+            call_id="c1",
+            name="search_code",
+            arguments={"query": "foo"},
+            result="bar.py:5",
+            elapsed_ms=42,
+        )
+        r = AgentLoopResult(final_answer="hi", tool_calls=[tc])
+        trace = r.format_trace()
+        assert "search_code" in trace
+        assert "bar.py:5" in trace
+        assert "42" in trace
+
+    def test_format_trace_with_error(self):
+        tc = ToolCall(call_id="c2", name="bad_tool", arguments={}, error="not found")
+        r = AgentLoopResult(final_answer="hi", tool_calls=[tc])
+        assert "✗" in r.format_trace()
+        assert "not found" in r.format_trace()
+
+
+class TestBuildToolSpec:
+    def test_builds_correct_spec(self):
+        spec = build_tool_spec(
+            name="my_tool",
+            description="Does a thing",
+            properties={"query": {"type": "string", "description": "search query"}},
+            required=["query"],
+        )
+        assert spec["type"] == "function"
+        assert spec["function"]["name"] == "my_tool"
+        assert "query" in spec["function"]["parameters"]["properties"]
+        assert spec["function"]["parameters"]["required"] == ["query"]
+
+
+class TestOllamaAgentLoopInit:
+    def test_default_model(self):
+        loop = OllamaAgentLoop()
+        assert loop.model == "qwen3.5:9b"
+        assert loop.max_iterations == 5
+
+    def test_custom_model(self):
+        loop = OllamaAgentLoop(model="gpt-oss:20b", max_iterations=3)
+        assert loop.model == "gpt-oss:20b"
+        assert loop.max_iterations == 3
+
+    def test_register_tool(self):
+        loop = OllamaAgentLoop()
+        loop.register_tool(
+            name="my_tool",
+            description="test",
+            parameters={"type": "object", "properties": {}},
+            handler=lambda n, a: "result",
+        )
+        assert any(t["function"]["name"] == "my_tool" for t in loop.tools)
+        assert "my_tool" in loop.tool_handlers
+
+
+class TestOllamaAgentLoopRun:
+    def _make_loop(self, responses):
+        loop = OllamaAgentLoop(model="test-model", max_iterations=5)
+        call_idx = [0]
+
+        def fake_call_ollama(messages):
+            idx = call_idx[0]
+            call_idx[0] += 1
+            if idx < len(responses):
+                return responses[idx]
+            return _make_ollama_response("domyślna odpowiedź")
+
+        loop._call_ollama = fake_call_ollama
+        return loop
+
+    def test_direct_answer_no_tool_calls(self):
+        loop = self._make_loop([_make_ollama_response("Odpowiedź bezpośrednia")])
+        result = loop.run("Cześć")
+        assert result.final_answer == "Odpowiedź bezpośrednia"
+        assert result.iterations == 1
+        assert result.stopped_by == "finish"
+        assert result.tool_calls == []
+
+    def test_single_tool_call_then_answer(self):
+        tool_called = []
+
+        def handler(name, args):
+            tool_called.append((name, args))
+            return "wynik_narzedzia"
+
+        loop = self._make_loop(
+            [
+                _make_tool_call_response("my_tool", {"q": "x"}),
+                _make_ollama_response("Finalna odpowiedź z wynikiem: wynik_narzedzia"),
+            ]
+        )
+        loop.register_tool(
+            "my_tool", "test", {"type": "object", "properties": {}}, handler
+        )
+
+        result = loop.run("zrób coś")
+        assert result.final_answer == "Finalna odpowiedź z wynikiem: wynik_narzedzia"
+        assert len(tool_called) == 1
+        assert tool_called[0] == ("my_tool", {"q": "x"})
+        assert result.iterations == 2
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].result == "wynik_narzedzia"
+        assert result.has_evidence()
+
+    def test_tool_args_as_json_string(self):
+        handler = MagicMock(return_value="ok")
+        loop = self._make_loop(
+            [
+                _make_tool_call_response("my_tool", json.dumps({"key": "val"})),
+                _make_ollama_response("done"),
+            ]
+        )
+        loop.register_tool(
+            "my_tool", "t", {"type": "object", "properties": {}}, handler
+        )
+        loop.run("test")
+        call_args = handler.call_args[0][1]
+        assert isinstance(call_args, dict)
+        assert call_args.get("key") == "val"
+
+    def test_missing_tool_handler_records_error(self):
+        loop = self._make_loop(
+            [
+                _make_tool_call_response("unknown_tool", {}),
+                _make_ollama_response("fallback"),
+            ]
+        )
+        result = loop.run("test")
+        assert result.tool_calls[0].error is not None
+        assert "unknown_tool" in result.tool_calls[0].error
+
+    def test_max_iterations_guard(self):
+        # Zawsze zwraca tool_call → wymusi max_iterations
+        always_tool = _make_tool_call_response("endless_tool", {})
+
+        loop = OllamaAgentLoop(model="test", max_iterations=2)
+        call_count = [0]
+
+        def fake_call(messages):
+            call_count[0] += 1
+            if call_count[0] <= 3:
+                return always_tool
+            return _make_ollama_response("podsumowanie")
+
+        loop._call_ollama = fake_call
+        loop.register_tool(
+            "endless_tool", "t", {"type": "object", "properties": {}}, lambda n, a: "x"
+        )
+
+        result = loop.run("test")
+        assert result.stopped_by == "max_iter"
+        assert result.iterations == 2
+
+    def test_ollama_connection_error(self):
+        loop = OllamaAgentLoop(model="test", max_iterations=3)
+        loop._call_ollama = MagicMock(side_effect=RuntimeError("connection refused"))
+        result = loop.run("test")
+        assert result.stopped_by == "error"
+        assert "❌" in result.final_answer
+
+    def test_multiple_tool_calls_in_one_iteration(self):
+        handler_a = MagicMock(return_value="res_a")
+        handler_b = MagicMock(return_value="res_b")
+
+        multi_tool_response = _make_ollama_response(
+            content="",
+            tool_calls=[
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "tool_a", "arguments": {}},
+                },
+                {
+                    "id": "c2",
+                    "type": "function",
+                    "function": {"name": "tool_b", "arguments": {}},
+                },
+            ],
+        )
+        loop = self._make_loop([multi_tool_response, _make_ollama_response("done")])
+        loop.register_tool(
+            "tool_a", "a", {"type": "object", "properties": {}}, handler_a
+        )
+        loop.register_tool(
+            "tool_b", "b", {"type": "object", "properties": {}}, handler_b
+        )
+
+        result = loop.run("test")
+        assert len(result.tool_calls) == 2
+        handler_a.assert_called_once()
+        handler_b.assert_called_once()
+
+    def test_evidence_populated_from_tool_results(self):
+        loop = self._make_loop(
+            [
+                _make_tool_call_response("git_status", {}),
+                _make_ollama_response("branch main, czyste repo"),
+            ]
+        )
+        loop.register_tool(
+            "git_status",
+            "git",
+            {"type": "object", "properties": {}},
+            lambda n, a: "## main...origin/main",
+        )
+        result = loop.run("sprawdz git")
+        assert any("## main" in e for e in result.evidence)
+
+
+class TestDispatchTool:
+    def test_dispatch_existing_handler(self):
+        loop = OllamaAgentLoop()
+        loop.register_tool(
+            "t", "desc", {"type": "object", "properties": {}}, lambda n, a: "42"
+        )
+        result, error = loop._dispatch_tool("t", {})
+        assert result == "42"
+        assert error is None
+
+    def test_dispatch_missing_handler(self):
+        loop = OllamaAgentLoop()
+        result, error = loop._dispatch_tool("nonexistent", {})
+        assert result == ""
+        assert error is not None
+
+    def test_dispatch_handler_exception(self):
+        loop = OllamaAgentLoop()
+        loop.register_tool(
+            "failing",
+            "desc",
+            {"type": "object", "properties": {}},
+            lambda n, a: (_ for _ in ()).throw(ValueError("boom")),
+        )
+        result, error = loop._dispatch_tool("failing", {})
+        assert error is not None
+        assert "boom" in error

--- a/tests/test_ollama_agent_loop.py
+++ b/tests/test_ollama_agent_loop.py
@@ -291,3 +291,16 @@ class TestDispatchTool:
         result, error = loop._dispatch_tool("failing", {})
         assert error is not None
         assert "boom" in error
+
+
+class TestToolCallExtraction:
+    def test_extract_tool_calls_filters_invalid_entries(self):
+        loop = OllamaAgentLoop()
+        out = loop._extract_tool_calls(
+            {"tool_calls": ["x", {"id": "1", "function": {"name": "a"}}]}
+        )
+        assert out == [{"id": "1", "function": {"name": "a"}}]
+
+    def test_extract_tool_calls_handles_non_list(self):
+        loop = OllamaAgentLoop()
+        assert loop._extract_tool_calls({"tool_calls": "invalid"}) == []

--- a/tools/vscode-chat-executor/package.json
+++ b/tools/vscode-chat-executor/package.json
@@ -161,6 +161,13 @@
           "minimum": 1,
           "maximum": 20,
           "description": "Maximum number of agentic loop iterations before @venom-agent stops and reports a partial answer."
+        },
+        "venom.execution.searchTimeoutMs": {
+          "type": "number",
+          "default": 10000,
+          "minimum": 1000,
+          "maximum": 120000,
+          "description": "Timeout for ripgrep-based code search in milliseconds."
         }
       }
     }

--- a/tools/vscode-chat-executor/package.json
+++ b/tools/vscode-chat-executor/package.json
@@ -1,8 +1,8 @@
 {
   "name": "venom-chat-executor",
-  "displayName": "Venom Chat Executor",
-  "description": "Execution-first chat participant for deterministic local git status in VS Code chat.",
-  "version": "0.0.1",
+  "displayName": "Venom Agent",
+  "description": "Agentic developer assistant for Venom projects: code search, git, file reading, and safe command execution via @venom-agent.",
+  "version": "0.1.0",
   "publisher": "venom-local",
   "engines": {
     "vscode": "^1.102.0"
@@ -17,33 +17,40 @@
   "contributes": {
     "chatParticipants": [
       {
-        "id": "venom.execution",
-        "name": "venom-exec",
-        "fullName": "Venom Execution",
-        "description": "Deterministic local command execution participant for git status workflow.",
-        "isSticky": true
-      },
-      {
-        "id": "venom.orchestrator",
+        "id": "venom.agent",
         "name": "venom-agent",
-        "fullName": "Venom Agent Orchestrator",
-        "description": "Routes git-status intent to execution tool and returns final response with evidence.",
+        "fullName": "Venom Agent",
+        "description": "Agentic assistant for Venom projects: code search, git status/log/diff, file reading, and safe test execution.",
         "isSticky": true
       }
     ],
     "languageModelTools": [
       {
-        "name": "run_git_status",
-        "displayName": "Venom Run Command",
-        "modelDescription": "Execute a local workspace command with strict allowlist. Use for repo-truth checks such as git status.",
-        "userDescription": "Run local git read-only command and return exact output.",
+        "name": "venom_git_status",
+        "displayName": "Venom Git",
+        "modelDescription": "Run a read-only git command (status, diff, log, branch, etc.) in the workspace root. Returns exact output with REPO_ROOT prefix.",
+        "userDescription": "Run a git read-only command and return exact output.",
         "canBeReferencedInPrompt": true,
-        "toolReferenceName": "venom-git-status",
-        "tags": [
-          "git",
-          "repo-truth",
-          "local-first"
-        ],
+        "toolReferenceName": "venom-git",
+        "tags": ["git", "repo-truth", "local-first"],
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "command": {
+              "type": "string",
+              "description": "Git command to run, e.g. 'git status --short --branch' or 'git log --oneline -5'."
+            }
+          },
+          "required": ["command"]
+        }
+      },
+      {
+        "name": "run_git_status",
+        "displayName": "Venom Run Command (legacy)",
+        "modelDescription": "Backward-compatible alias for venom_git_status. Prefer venom_git_status for new interactions.",
+        "userDescription": "Run a local git read-only command and return exact output.",
+        "canBeReferencedInPrompt": false,
+        "tags": ["git", "legacy"],
         "inputSchema": {
           "type": "object",
           "properties": {
@@ -52,9 +59,80 @@
               "description": "Command to execute in workspace root."
             }
           },
-          "required": [
-            "command"
-          ]
+          "required": ["command"]
+        }
+      },
+      {
+        "name": "venom_search_code",
+        "displayName": "Venom Search Code",
+        "modelDescription": "Search code in the workspace using ripgrep. Returns file paths, line numbers, and matching lines. Use for finding classes, functions, symbols, or any text pattern.",
+        "userDescription": "Search code in the project using ripgrep.",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "venom-search",
+        "tags": ["code-search", "ripgrep", "local-first"],
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "string",
+              "description": "Search pattern (text or regex) to find in the codebase."
+            },
+            "path_glob": {
+              "type": "string",
+              "description": "Optional glob to restrict search, e.g. '*.py' or '*.ts'."
+            },
+            "max_results": {
+              "type": "number",
+              "description": "Maximum number of results to return (default: 10)."
+            }
+          },
+          "required": ["query"]
+        }
+      },
+      {
+        "name": "venom_read_file",
+        "displayName": "Venom Read File",
+        "modelDescription": "Read a fragment of a file around a specific line number with surrounding context. Use after venom_search_code to get code context.",
+        "userDescription": "Read a file fragment with surrounding context lines.",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "venom-read",
+        "tags": ["file-read", "local-first"],
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "file_path": {
+              "type": "string",
+              "description": "Absolute or workspace-relative path to the file."
+            },
+            "line": {
+              "type": "number",
+              "description": "Line number to center the context around."
+            },
+            "context_lines": {
+              "type": "number",
+              "description": "Number of lines of context around the target line (default: 5)."
+            }
+          },
+          "required": ["file_path", "line"]
+        }
+      },
+      {
+        "name": "venom_exec_safe",
+        "displayName": "Venom Exec Safe",
+        "modelDescription": "Run a safe, allowed command (pytest, make test-*, ruff check, mypy, npm test) in the workspace. Requires venom.execution.allowExec=true in settings.",
+        "userDescription": "Run a safe test/lint command in the workspace (requires allowExec=true).",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "venom-exec",
+        "tags": ["exec", "test", "local-first"],
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "command": {
+              "type": "string",
+              "description": "Command to run, e.g. 'pytest venom_core/tests/', 'ruff check .', 'mypy venom_core'."
+            }
+          },
+          "required": ["command"]
         }
       }
     ],
@@ -65,12 +143,24 @@
       }
     ],
     "configuration": {
-      "title": "Venom Chat Executor",
+      "title": "Venom Agent",
       "properties": {
         "venom.execution.repoRoot": {
           "type": "string",
           "default": "",
-          "description": "Absolute repository root used by Venom execution tool. If empty, extension tries git rev-parse from current workspace."
+          "description": "Absolute repository root used by Venom tools. If empty, auto-detected via git rev-parse from the current workspace."
+        },
+        "venom.execution.allowExec": {
+          "type": "boolean",
+          "default": false,
+          "description": "Allow @venom-agent to execute safe commands (pytest, ruff, mypy, make test-*). Disabled by default for safety."
+        },
+        "venom.execution.maxIterations": {
+          "type": "number",
+          "default": 5,
+          "minimum": 1,
+          "maximum": 20,
+          "description": "Maximum number of agentic loop iterations before @venom-agent stops and reports a partial answer."
         }
       }
     }

--- a/tools/vscode-chat-executor/src/extension.ts
+++ b/tools/vscode-chat-executor/src/extension.ts
@@ -1,233 +1,447 @@
 import * as vscode from 'vscode';
-import { execFile } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
+import * as fs from 'node:fs/promises';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
-const TOOL_NAME = 'run_git_status';
-const ALLOWED_COMMANDS = new Set([
-  'git status --short --branch',
-  'git status',
-  'git diff --shortstat',
-  'git branch --show-current',
-  'git rev-parse --short HEAD'
-]);
+const MAX_ITERATIONS = 5;
+const LEGACY_TOOL_NAME = 'run_git_status'; // backward-compat alias
 
-interface RunCommandInput {
-  command: string;
-}
+// ---------------------------------------------------------------------------
+// Konfiguracja i workspace root
+// ---------------------------------------------------------------------------
 
-function configuredRepoRoot(): string | undefined {
-  const cfg = vscode.workspace.getConfiguration('venom.execution');
-  const value = cfg.get<string>('repoRoot');
-  if (typeof value === 'string' && value.trim()) {
-    return value.trim();
-  }
-  return undefined;
+function getConfig<T>(key: string, fallback: T): T {
+  return vscode.workspace.getConfiguration('venom.execution').get<T>(key) ?? fallback;
 }
 
 async function resolveRepoRoot(): Promise<string | undefined> {
-  const configured = configuredRepoRoot();
-  if (configured) {
-    return configured;
-  }
+  const configured = getConfig<string>('repoRoot', '').trim();
+  if (configured) return configured;
   const candidate = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-  if (!candidate) {
-    return undefined;
-  }
+  if (!candidate) return undefined;
   try {
     const { stdout } = await execFileAsync('git', ['rev-parse', '--show-toplevel'], { cwd: candidate });
-    const root = stdout.trim();
-    return root || candidate;
+    return stdout.trim() || candidate;
   } catch {
     return candidate;
   }
 }
 
-async function runGitStatus(cwd: string): Promise<string> {
-  const { stdout, stderr } = await execFileAsync('git', ['status', '--short', '--branch'], { cwd });
-  if (stderr?.trim()) {
-    return `${stdout}\n${stderr}`.trim();
-  }
-  return stdout.trim();
-}
+// ---------------------------------------------------------------------------
+// Git – rozszerzona allowlista
+// ---------------------------------------------------------------------------
 
-async function runAllowlistedCommand(cwd: string, command: string): Promise<string> {
+const GIT_ALLOWLIST = new Set([
+  'git status --short --branch',
+  'git status',
+  'git diff --shortstat',
+  'git diff --stat',
+  'git diff HEAD --name-only',
+  'git branch --show-current',
+  'git rev-parse --short HEAD',
+  'git log --oneline -5',
+  'git log --oneline -10',
+  'git log --oneline -20',
+  'git show --stat HEAD',
+  'git stash list',
+]);
+
+async function runGitCommand(cwd: string, command: string): Promise<string> {
   const normalized = command.trim().replace(/\s+/g, ' ');
-  if (!ALLOWED_COMMANDS.has(normalized)) {
-    throw new Error(`Komenda poza allowlista: ${normalized}`);
+  if (!GIT_ALLOWLIST.has(normalized)) {
+    throw new Error(`Komenda git poza allowlista: "${normalized}"`);
   }
   const [bin, ...args] = normalized.split(' ');
   const { stdout, stderr } = await execFileAsync(bin, args, { cwd });
-  if (stderr?.trim()) {
-    return `${stdout}\n${stderr}`.trim();
-  }
-  return stdout.trim();
+  return [stdout, stderr?.trim()].filter(Boolean).join('\n').trim();
 }
 
-function isGitStatusIntent(prompt: string): boolean {
-  const p = prompt.toLowerCase();
-  return (
-    p.includes('git status') ||
-    p.includes('status git') ||
-    p.includes('stan gita') ||
-    p.includes('sprawdz stan git')
-  );
+// ---------------------------------------------------------------------------
+// Code search – rg wrapper
+// ---------------------------------------------------------------------------
+
+const SKIP_DIRS = ['.git', '.venv', 'node_modules', '__pycache__', '.pytest_cache', 'out', 'dist', 'models_cache', 'models'];
+
+async function searchCode(cwd: string, query: string, pathGlob?: string, maxResults = 10): Promise<string> {
+  const skipArgs = SKIP_DIRS.flatMap(d => ['--glob', `!${d}`, '--glob', `!**/${d}/**`]);
+  const args = [
+    '--json',
+    '--ignore-case',
+    `--max-count=${maxResults}`,
+    '--context=2',
+    ...skipArgs,
+  ];
+  if (pathGlob) args.push('--glob', pathGlob);
+  args.push(query, cwd);
+
+  return new Promise<string>((resolve) => {
+    const lines: string[] = [];
+    const proc = spawn('rg', args, { cwd });
+    proc.stdout.setEncoding('utf8');
+    proc.stdout.on('data', (d: string) => lines.push(...d.split('\n')));
+    proc.on('close', () => {
+      const results: string[] = [];
+      let count = 0;
+      for (const line of lines) {
+        const l = line.trim();
+        if (!l) continue;
+        try {
+          const entry = JSON.parse(l) as { type: string; data: { path: { text: string }; line_number: number; lines: { text: string } } };
+          if (entry.type === 'match') {
+            const { path: { text: file }, line_number: ln, lines: { text } } = entry.data;
+            results.push(`[${file}:${ln}] ${text.trimEnd()}`);
+            count++;
+            if (count >= maxResults) break;
+          }
+        } catch { /* skip malformed */ }
+      }
+      resolve(results.length > 0 ? results.join('\n') : 'Brak wyników.');
+    });
+    proc.on('error', () => resolve('Błąd: ripgrep nie znaleziony. Zainstaluj: sudo apt install ripgrep'));
+    setTimeout(() => { proc.kill(); resolve('Timeout wyszukiwania (10s).'); }, 10_000);
+  });
 }
+
+// ---------------------------------------------------------------------------
+// File read z kontekstem
+// ---------------------------------------------------------------------------
+
+async function readFileContext(filePath: string, line: number, contextLines: number): Promise<string> {
+  try {
+    const content = await fs.readFile(filePath, 'utf8');
+    const all = content.split('\n');
+    const start = Math.max(0, line - contextLines - 1);
+    const end = Math.min(all.length, line + contextLines);
+    return all
+      .slice(start, end)
+      .map((text, i) => {
+        const ln = start + i + 1;
+        const marker = ln === line ? '→' : ' ';
+        return `${marker} ${String(ln).padStart(4)}: ${text}`;
+      })
+      .join('\n');
+  } catch (e) {
+    return `Błąd odczytu pliku: ${e instanceof Error ? e.message : String(e)}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Safe shell exec (opt-in przez konfigurację)
+// ---------------------------------------------------------------------------
+
+const EXEC_SAFE_PATTERNS = [
+  /^pytest(\s+.*)?$/,
+  /^python -m pytest(\s+.*)?$/,
+  /^make test-[\w-]+$/,
+  /^npm test$/,
+  /^ruff check(\s+.*)?$/,
+  /^mypy(\s+.*)?$/,
+];
+
+async function execSafe(cwd: string, command: string): Promise<string> {
+  const allowExec = getConfig<boolean>('allowExec', false);
+  if (!allowExec) {
+    return 'Wykonanie komend zablokowane. Włącz w ustawieniach: venom.execution.allowExec = true';
+  }
+  const norm = command.trim();
+  const allowed = EXEC_SAFE_PATTERNS.some(p => p.test(norm));
+  if (!allowed) {
+    return `Komenda nie jest na liście dozwolonych: "${norm}". Dozwolone: pytest, make test-*, ruff check, mypy.`;
+  }
+  try {
+    const { stdout, stderr } = await execFileAsync('bash', ['-c', norm], { cwd, timeout: 30_000 });
+    return [stdout, stderr?.trim()].filter(Boolean).join('\n').trim() || '(brak outputu)';
+  } catch (e) {
+    return `Błąd: ${e instanceof Error ? e.message : String(e)}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tool result helper
+// ---------------------------------------------------------------------------
 
 function toolResultToText(result: vscode.LanguageModelToolResult): string {
   return result.content
-    .map((part) => {
-      if (part instanceof vscode.LanguageModelTextPart) {
-        return part.value;
-      }
-      if (typeof part === 'string') {
-        return part;
-      }
-      return '';
-    })
+    .map(part => (part instanceof vscode.LanguageModelTextPart ? part.value : typeof part === 'string' ? part : ''))
     .filter(Boolean)
     .join('\n')
     .trim();
 }
 
-export function activate(context: vscode.ExtensionContext) {
-  const toolDisposable = vscode.lm.registerTool<RunCommandInput>(TOOL_NAME, {
-    async invoke(options) {
-      const root = await resolveRepoRoot();
-      if (!root) {
-        return new vscode.LanguageModelToolResult([
-          new vscode.LanguageModelTextPart('Brak otwartego workspace.')
-        ]);
-      }
-      const command = options.input.command ?? '';
-      try {
-        const output = await runAllowlistedCommand(root, command);
-        return new vscode.LanguageModelToolResult([
-          new vscode.LanguageModelTextPart(`REPO_ROOT=${root}\n${output}`)
-        ]);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        return new vscode.LanguageModelToolResult([
-          new vscode.LanguageModelTextPart(`Blad wykonania: ${message}`)
-        ]);
-      }
-    },
-    prepareInvocation(options) {
-      const cmd = String(options.input.command ?? '').trim();
-      return {
-        invocationMessage: `Venom wykonuje lokalnie: ${cmd}`,
-        confirmationMessages: {
-          title: 'Venom execution tool',
-          message: `Czy uruchomic komendę: ${cmd}?`
-        }
-      };
+// ---------------------------------------------------------------------------
+// Dispatch narzędzi
+// ---------------------------------------------------------------------------
+
+async function dispatchTool(
+  name: string,
+  input: Record<string, unknown>,
+  cwd: string
+): Promise<string> {
+  switch (name) {
+    case 'venom_git_status':
+    case LEGACY_TOOL_NAME: {
+      const command = String(input.command ?? 'git status --short --branch');
+      const out = await runGitCommand(cwd, command);
+      return `REPO_ROOT=${cwd}\n${out}`;
     }
-  });
-  context.subscriptions.push(toolDisposable);
-
-  const participant = vscode.chat.createChatParticipant('venom.execution', async (request, chatContext, stream) => {
-    void chatContext;
-
-    const workspaceRoot = await resolveRepoRoot();
-    if (!workspaceRoot) {
-      stream.markdown('Brak otwartego workspace. Otworz folder repo i sprobuj ponownie.');
-      return;
+    case 'venom_search_code': {
+      const query = String(input.query ?? '');
+      const glob = input.path_glob !== undefined ? String(input.path_glob) : undefined;
+      const max = typeof input.max_results === 'number' ? input.max_results : 10;
+      return searchCode(cwd, query, glob, max);
     }
-
-    const prompt = request.prompt.trim();
-
-    if (!isGitStatusIntent(prompt)) {
-      stream.markdown(
-        [
-          'Ten participant obsluguje tylko execution-first dla statusu Git.',
-          '',
-          'Uzyj: `@venom-exec sprawdz status git`.'
-        ].join('\n')
-      );
-      return;
+    case 'venom_read_file': {
+      const file = String(input.file_path ?? '');
+      const line = typeof input.line === 'number' ? input.line : 1;
+      const ctx = typeof input.context_lines === 'number' ? input.context_lines : 5;
+      const resolved = file.startsWith('/') ? file : `${cwd}/${file}`;
+      return readFileContext(resolved, line, ctx);
     }
+    case 'venom_exec_safe': {
+      const cmd = String(input.command ?? '');
+      return execSafe(cwd, cmd);
+    }
+    default:
+      return `Nieznane narzędzie: ${name}`;
+  }
+}
 
-    stream.progress('Wykonuje lokalnie przez tool API: run_git_status');
+// ---------------------------------------------------------------------------
+// System prompt
+// ---------------------------------------------------------------------------
 
+function buildSystemPrompt(cwd: string): string {
+  const allowExec = getConfig<boolean>('allowExec', false);
+  const execNote = allowExec
+    ? 'Możesz uruchamiać komendy przez venom_exec_safe (pytest, make test-*, ruff, mypy).'
+    : 'Wykonanie komend shell jest wyłączone (venom.execution.allowExec=false).';
+  return [
+    `Jesteś asystentem programisty Venom dla projektu w workspace: ${cwd}.`,
+    'Zawsze wywołuj narzędzia zamiast zgadywać o kodzie lub stanie repo.',
+    'Dla pytań o kod: wywołaj venom_search_code.',
+    'Dla pytań o status/diff/log git: wywołaj venom_git_status.',
+    'Dla pytań o zawartość pliku: wywołaj venom_read_file.',
+    execNote,
+    'Odpowiadaj po polsku, chyba że użytkownik pisze po angielsku.',
+    'Nie generuj listy komend jako finalnej odpowiedzi – wywołaj narzędzie i pokaż evidence.',
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Agentic loop handler
+// ---------------------------------------------------------------------------
+
+async function venomAgentHandler(
+  request: vscode.ChatRequest,
+  _ctx: vscode.ChatContext,
+  stream: vscode.ChatResponseStream,
+  token: vscode.CancellationToken
+): Promise<void> {
+  const cwd = await resolveRepoRoot();
+  if (!cwd) {
+    stream.markdown('Brak otwartego workspace. Otwórz folder repo i spróbuj ponownie.');
+    return;
+  }
+
+  const maxIter = getConfig<number>('maxIterations', MAX_ITERATIONS);
+  const messages: vscode.LanguageModelChatMessage[] = [
+    vscode.LanguageModelChatMessage.User(buildSystemPrompt(cwd)),
+    vscode.LanguageModelChatMessage.User(request.prompt),
+  ];
+
+  // Narzędzia rejestrowane przez extension (filtr po prefikcie venom_)
+  const tools = vscode.lm.tools.filter(
+    t => t.name.startsWith('venom_') || t.name === LEGACY_TOOL_NAME
+  );
+
+  let iterations = 0;
+
+  while (iterations < maxIter) {
+    if (token.isCancellationRequested) break;
+    iterations++;
+
+    let response: vscode.LanguageModelChatResponse;
     try {
-      const toolResult = await vscode.lm.invokeTool(
-        TOOL_NAME,
-        {
-          input: { command: 'git status --short --branch' },
-          toolInvocationToken: request.toolInvocationToken
-        },
-        undefined
-      );
-      const status = toolResultToText(toolResult);
-      stream.markdown(['```bash', status || '(brak outputu)', '```'].join('\n'));
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      stream.markdown(`Blad wykonania komendy: ${message}`);
+      response = await request.model.sendRequest(messages, { tools }, token);
+    } catch (e) {
+      stream.markdown(`Błąd komunikacji z modelem: ${e instanceof Error ? e.message : String(e)}`);
+      return;
     }
-  });
 
+    const toolCalls: Array<{ part: vscode.LanguageModelToolCallPart; result: string }> = [];
+    let hasToolCall = false;
+
+    for await (const chunk of response.stream) {
+      if (token.isCancellationRequested) break;
+      if (chunk instanceof vscode.LanguageModelTextPart) {
+        stream.markdown(chunk.value);
+      } else if (chunk instanceof vscode.LanguageModelToolCallPart) {
+        hasToolCall = true;
+        stream.progress(`Venom: wywołuję ${chunk.name}…`);
+        let toolOutput: string;
+        try {
+          // Próba przez lm.invokeTool (dla zarejestrowanych narzędzi)
+          const invoked = await vscode.lm.invokeTool(
+            chunk.name,
+            { input: chunk.input as Record<string, unknown>, toolInvocationToken: request.toolInvocationToken }
+          );
+          toolOutput = toolResultToText(invoked);
+        } catch {
+          // Fallback: bezpośredni dispatch
+          toolOutput = await dispatchTool(chunk.name, chunk.input as Record<string, unknown>, cwd);
+        }
+        toolCalls.push({ part: chunk, result: toolOutput });
+      }
+    }
+
+    if (!hasToolCall) {
+      // Brak tool callów = finalna odpowiedź, koniec pętli
+      break;
+    }
+
+    // Dodaj odpowiedź asystenta (z tool callami) + wyniki do historii
+    messages.push(
+      vscode.LanguageModelChatMessage.Assistant(
+        toolCalls.map(tc => new vscode.LanguageModelToolCallPart(tc.part.callId, tc.part.name, tc.part.input))
+      )
+    );
+    messages.push(
+      vscode.LanguageModelChatMessage.User(
+        toolCalls.map(tc => new vscode.LanguageModelToolResultPart(tc.part.callId, [new vscode.LanguageModelTextPart(tc.result)]))
+      )
+    );
+  }
+
+  if (iterations >= maxIter) {
+    stream.markdown(`\n\n⚠️ Przekroczono limit iteracji (${maxIter}). Ostatnia odpowiedź może być niekompletna.`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rejestracja narzędzi i participanta
+// ---------------------------------------------------------------------------
+
+export function activate(context: vscode.ExtensionContext) {
+
+  // --- Narzędzie: venom_git_status ---
+  context.subscriptions.push(
+    vscode.lm.registerTool<{ command: string }>('venom_git_status', {
+      async invoke(options) {
+        const root = await resolveRepoRoot();
+        if (!root) return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart('Brak workspace.')]);
+        const command = options.input.command ?? 'git status --short --branch';
+        try {
+          const out = await runGitCommand(root, command);
+          return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart(`REPO_ROOT=${root}\n${out}`)]);
+        } catch (e) {
+          return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart(`Błąd: ${e instanceof Error ? e.message : String(e)}`)]);
+        }
+      },
+      prepareInvocation(options) {
+        const cmd = String(options.input.command ?? '').trim();
+        return {
+          invocationMessage: `Venom git: ${cmd}`,
+          confirmationMessages: { title: 'Venom Git Tool', message: `Uruchomić: ${cmd}?` }
+        };
+      }
+    })
+  );
+
+  // --- Narzędzie: run_git_status (backward-compat alias) ---
+  context.subscriptions.push(
+    vscode.lm.registerTool<{ command: string }>(LEGACY_TOOL_NAME, {
+      async invoke(options) {
+        const root = await resolveRepoRoot();
+        if (!root) return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart('Brak workspace.')]);
+        const command = options.input.command ?? 'git status --short --branch';
+        try {
+          const out = await runGitCommand(root, command);
+          return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart(`REPO_ROOT=${root}\n${out}`)]);
+        } catch (e) {
+          return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart(`Błąd: ${e instanceof Error ? e.message : String(e)}`)]);
+        }
+      },
+      prepareInvocation(options) {
+        const cmd = String(options.input.command ?? '').trim();
+        return { invocationMessage: `Venom wykonuje lokalnie: ${cmd}` };
+      }
+    })
+  );
+
+  // --- Narzędzie: venom_search_code ---
+  context.subscriptions.push(
+    vscode.lm.registerTool<{ query: string; path_glob?: string; max_results?: number }>('venom_search_code', {
+      async invoke(options) {
+        const root = await resolveRepoRoot();
+        if (!root) return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart('Brak workspace.')]);
+        const result = await searchCode(root, options.input.query, options.input.path_glob, options.input.max_results ?? 10);
+        return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart(result)]);
+      },
+      prepareInvocation(options) {
+        return { invocationMessage: `Venom przeszukuje kod: "${options.input.query}"` };
+      }
+    })
+  );
+
+  // --- Narzędzie: venom_read_file ---
+  context.subscriptions.push(
+    vscode.lm.registerTool<{ file_path: string; line: number; context_lines?: number }>('venom_read_file', {
+      async invoke(options) {
+        const root = await resolveRepoRoot();
+        if (!root) return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart('Brak workspace.')]);
+        const file = options.input.file_path.startsWith('/')
+          ? options.input.file_path
+          : `${root}/${options.input.file_path}`;
+        const result = await readFileContext(file, options.input.line, options.input.context_lines ?? 5);
+        return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart(result)]);
+      },
+      prepareInvocation(options) {
+        return { invocationMessage: `Venom czyta plik: ${options.input.file_path}:${options.input.line}` };
+      }
+    })
+  );
+
+  // --- Narzędzie: venom_exec_safe ---
+  context.subscriptions.push(
+    vscode.lm.registerTool<{ command: string }>('venom_exec_safe', {
+      async invoke(options) {
+        const root = await resolveRepoRoot();
+        if (!root) return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart('Brak workspace.')]);
+        const result = await execSafe(root, options.input.command);
+        return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart(result)]);
+      },
+      prepareInvocation(options) {
+        return {
+          invocationMessage: `Venom exec: ${options.input.command}`,
+          confirmationMessages: {
+            title: 'Venom Safe Exec',
+            message: `Uruchomić komendę: ${options.input.command}?`
+          }
+        };
+      }
+    })
+  );
+
+  // --- Participant: @venom-agent (jeden, z agentic loop) ---
+  const participant = vscode.chat.createChatParticipant('venom.agent', venomAgentHandler);
+  participant.iconPath = new vscode.ThemeIcon('robot');
   context.subscriptions.push(participant);
 
-  const orchestrator = vscode.chat.createChatParticipant('venom.orchestrator', async (request, chatContext, stream) => {
-    void chatContext;
-    const workspaceRoot = await resolveRepoRoot();
-    if (!workspaceRoot) {
-      stream.markdown('Brak otwartego workspace. Otworz folder repo i sprobuj ponownie.');
-      return;
-    }
-
-    const prompt = request.prompt.trim();
-    if (!isGitStatusIntent(prompt)) {
-      stream.markdown(
-        [
-          'Ten participant jest execution-first dla statusu Git.',
-          '',
-          'Uzyj: `@venom-agent sprawdz status git`.'
-        ].join('\n')
-      );
-      return;
-    }
-
-    stream.progress('Venom Agent wywoluje tool run_git_status');
-    try {
-      const toolResult = await vscode.lm.invokeTool(
-        TOOL_NAME,
-        {
-          input: { command: 'git status --short --branch' },
-          toolInvocationToken: request.toolInvocationToken
-        },
-        undefined
-      );
-      const status = toolResultToText(toolResult);
-      stream.markdown(['```bash', status || '(brak outputu)', '```'].join('\n'));
-      stream.markdown('Nastepny krok: jesli output jest poprawny, przejdz do `git diff --shortstat`.');
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      stream.markdown(`Blad wykonania komendy: ${message}`);
-    }
-  });
-  context.subscriptions.push(orchestrator);
-
-
-  const cmd = vscode.commands.registerCommand('venom.execution.runGitStatus', async () => {
-    const workspaceRoot = await resolveRepoRoot();
-    if (!workspaceRoot) {
-      vscode.window.showErrorMessage('Brak otwartego workspace.');
-      return;
-    }
-    try {
-      const out = await runGitStatus(workspaceRoot);
-      await vscode.env.clipboard.writeText(out);
-      vscode.window.showInformationMessage('Git status skopiowany do schowka.');
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      vscode.window.showErrorMessage(`Blad: ${message}`);
-    }
-  });
-
-  context.subscriptions.push(cmd);
+  // --- Komenda: Venom Run Git Status (backward-compat) ---
+  context.subscriptions.push(
+    vscode.commands.registerCommand('venom.execution.runGitStatus', async () => {
+      const root = await resolveRepoRoot();
+      if (!root) { vscode.window.showErrorMessage('Brak otwartego workspace.'); return; }
+      try {
+        const out = await runGitCommand(root, 'git status --short --branch');
+        await vscode.env.clipboard.writeText(out);
+        vscode.window.showInformationMessage('Git status skopiowany do schowka.');
+      } catch (e) {
+        vscode.window.showErrorMessage(`Błąd: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    })
+  );
 }
 
-export function deactivate() {
-  // no-op
-}
+export function deactivate() { /* no-op */ }

--- a/tools/vscode-chat-executor/src/extension.ts
+++ b/tools/vscode-chat-executor/src/extension.ts
@@ -1,10 +1,12 @@
 import * as vscode from 'vscode';
 import { execFile, spawn } from 'node:child_process';
 import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
 const MAX_ITERATIONS = 5;
+const DEFAULT_SEARCH_TIMEOUT_MS = 10_000;
 const LEGACY_TOOL_NAME = 'run_git_status'; // backward-compat alias
 
 // ---------------------------------------------------------------------------
@@ -64,6 +66,7 @@ async function runGitCommand(cwd: string, command: string): Promise<string> {
 const SKIP_DIRS = ['.git', '.venv', 'node_modules', '__pycache__', '.pytest_cache', 'out', 'dist', 'models_cache', 'models'];
 
 async function searchCode(cwd: string, query: string, pathGlob?: string, maxResults = 10): Promise<string> {
+  const searchTimeoutMs = Math.max(1_000, getConfig<number>('searchTimeoutMs', DEFAULT_SEARCH_TIMEOUT_MS));
   const skipArgs = SKIP_DIRS.flatMap(d => ['--glob', `!${d}`, '--glob', `!**/${d}/**`]);
   const args = [
     '--json',
@@ -76,11 +79,30 @@ async function searchCode(cwd: string, query: string, pathGlob?: string, maxResu
   args.push(query, cwd);
 
   return new Promise<string>((resolve) => {
+    let settled = false;
+    let buffer = '';
     const lines: string[] = [];
     const proc = spawn('rg', args, { cwd });
+    const finish = (msg: string) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(msg);
+    };
+    const flushBuffer = () => {
+      const tail = buffer.trim();
+      if (tail) lines.push(tail);
+      buffer = '';
+    };
     proc.stdout.setEncoding('utf8');
-    proc.stdout.on('data', (d: string) => lines.push(...d.split('\n')));
+    proc.stdout.on('data', (d: string) => {
+      buffer += d;
+      const chunks = buffer.split('\n');
+      buffer = chunks.pop() ?? '';
+      for (const line of chunks) lines.push(line);
+    });
     proc.on('close', () => {
+      flushBuffer();
       const results: string[] = [];
       let count = 0;
       for (const line of lines) {
@@ -96,10 +118,13 @@ async function searchCode(cwd: string, query: string, pathGlob?: string, maxResu
           }
         } catch { /* skip malformed */ }
       }
-      resolve(results.length > 0 ? results.join('\n') : 'Brak wyników.');
+      finish(results.length > 0 ? results.join('\n') : 'Brak wyników.');
     });
-    proc.on('error', () => resolve('Błąd: ripgrep nie znaleziony. Zainstaluj: sudo apt install ripgrep'));
-    setTimeout(() => { proc.kill(); resolve('Timeout wyszukiwania (10s).'); }, 10_000);
+    proc.on('error', () => finish('Błąd: ripgrep nie znaleziony. Zainstaluj: sudo apt install ripgrep'));
+    const timer = setTimeout(() => {
+      proc.kill();
+      finish(`Timeout wyszukiwania (${searchTimeoutMs}ms).`);
+    }, searchTimeoutMs);
   });
 }
 
@@ -107,7 +132,21 @@ async function searchCode(cwd: string, query: string, pathGlob?: string, maxResu
 // File read z kontekstem
 // ---------------------------------------------------------------------------
 
-async function readFileContext(filePath: string, line: number, contextLines: number): Promise<string> {
+function isPathWithinRoot(root: string, target: string): boolean {
+  const rel = path.relative(path.resolve(root), path.resolve(target));
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+
+function resolveWorkspacePath(root: string, inputPath: string): string | undefined {
+  const workspaceRoot = path.resolve(root);
+  const resolved = path.resolve(workspaceRoot, inputPath);
+  return isPathWithinRoot(workspaceRoot, resolved) ? resolved : undefined;
+}
+
+async function readFileContext(filePath: string, line: number, contextLines: number, workspaceRoot?: string): Promise<string> {
+  if (workspaceRoot && !isPathWithinRoot(workspaceRoot, filePath)) {
+    return `Błąd odczytu pliku: ścieżka poza workspace (${filePath})`;
+  }
   try {
     const content = await fs.readFile(filePath, 'utf8');
     const all = content.split('\n');
@@ -131,12 +170,12 @@ async function readFileContext(filePath: string, line: number, contextLines: num
 // ---------------------------------------------------------------------------
 
 const EXEC_SAFE_PATTERNS = [
-  /^pytest(\s+.*)?$/,
-  /^python -m pytest(\s+.*)?$/,
-  /^make test-[\w-]+$/,
-  /^npm test$/,
-  /^ruff check(\s+.*)?$/,
-  /^mypy(\s+.*)?$/,
+  /^pytest$/,
+  /^python$/,
+  /^make$/,
+  /^npm$/,
+  /^ruff$/,
+  /^mypy$/,
 ];
 
 async function execSafe(cwd: string, command: string): Promise<string> {
@@ -144,13 +183,31 @@ async function execSafe(cwd: string, command: string): Promise<string> {
   if (!allowExec) {
     return 'Wykonanie komend zablokowane. Włącz w ustawieniach: venom.execution.allowExec = true';
   }
-  const norm = command.trim();
-  const allowed = EXEC_SAFE_PATTERNS.some(p => p.test(norm));
+  const norm = command.trim().replace(/\s+/g, ' ');
+  if (!norm) {
+    return 'Komenda nie może być pusta.';
+  }
+  if (/[;&|><`$\\\n\r]/.test(norm)) {
+    return `Komenda zawiera niedozwolone metaznaki shella: "${norm}".`;
+  }
+
+  const parts = norm.split(' ').filter(Boolean);
+  const [bin, ...args] = parts;
+  const allowedBin = EXEC_SAFE_PATTERNS.some(p => p.test(bin));
+  const allowed =
+    allowedBin && (
+      bin === 'pytest' ||
+      bin === 'mypy' ||
+      (bin === 'python' && args.length >= 2 && args[0] === '-m' && args[1] === 'pytest') ||
+      (bin === 'make' && args.length === 1 && /^test-[\w-]+$/.test(args[0])) ||
+      (bin === 'npm' && args.length === 1 && args[0] === 'test') ||
+      (bin === 'ruff' && args.length >= 1 && args[0] === 'check')
+    );
   if (!allowed) {
     return `Komenda nie jest na liście dozwolonych: "${norm}". Dozwolone: pytest, make test-*, ruff check, mypy.`;
   }
   try {
-    const { stdout, stderr } = await execFileAsync('bash', ['-c', norm], { cwd, timeout: 30_000 });
+    const { stdout, stderr } = await execFileAsync(bin, args, { cwd, timeout: 30_000 });
     return [stdout, stderr?.trim()].filter(Boolean).join('\n').trim() || '(brak outputu)';
   } catch (e) {
     return `Błąd: ${e instanceof Error ? e.message : String(e)}`;
@@ -195,8 +252,11 @@ async function dispatchTool(
       const file = String(input.file_path ?? '');
       const line = typeof input.line === 'number' ? input.line : 1;
       const ctx = typeof input.context_lines === 'number' ? input.context_lines : 5;
-      const resolved = file.startsWith('/') ? file : `${cwd}/${file}`;
-      return readFileContext(resolved, line, ctx);
+      const resolved = resolveWorkspacePath(cwd, file);
+      if (!resolved) {
+        return `Błąd odczytu pliku: ścieżka poza workspace (${file})`;
+      }
+      return readFileContext(resolved, line, ctx, cwd);
     }
     case 'venom_exec_safe': {
       const cmd = String(input.command ?? '');
@@ -270,11 +330,13 @@ async function venomAgentHandler(
     }
 
     const toolCalls: Array<{ part: vscode.LanguageModelToolCallPart; result: string }> = [];
+    const assistantTextParts: string[] = [];
     let hasToolCall = false;
 
     for await (const chunk of response.stream) {
       if (token.isCancellationRequested) break;
       if (chunk instanceof vscode.LanguageModelTextPart) {
+        assistantTextParts.push(chunk.value);
         stream.markdown(chunk.value);
       } else if (chunk instanceof vscode.LanguageModelToolCallPart) {
         hasToolCall = true;
@@ -301,10 +363,16 @@ async function venomAgentHandler(
     }
 
     // Dodaj odpowiedź asystenta (z tool callami) + wyniki do historii
+    const assistantParts: Array<vscode.LanguageModelTextPart | vscode.LanguageModelToolCallPart> = [];
+    const assistantText = assistantTextParts.join('');
+    if (assistantText.trim()) {
+      assistantParts.push(new vscode.LanguageModelTextPart(assistantText));
+    }
+    assistantParts.push(
+      ...toolCalls.map(tc => new vscode.LanguageModelToolCallPart(tc.part.callId, tc.part.name, tc.part.input))
+    );
     messages.push(
-      vscode.LanguageModelChatMessage.Assistant(
-        toolCalls.map(tc => new vscode.LanguageModelToolCallPart(tc.part.callId, tc.part.name, tc.part.input))
-      )
+      vscode.LanguageModelChatMessage.Assistant(assistantParts)
     );
     messages.push(
       vscode.LanguageModelChatMessage.User(
@@ -390,10 +458,13 @@ export function activate(context: vscode.ExtensionContext) {
       async invoke(options) {
         const root = await resolveRepoRoot();
         if (!root) return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart('Brak workspace.')]);
-        const file = options.input.file_path.startsWith('/')
-          ? options.input.file_path
-          : `${root}/${options.input.file_path}`;
-        const result = await readFileContext(file, options.input.line, options.input.context_lines ?? 5);
+        const file = resolveWorkspacePath(root, options.input.file_path);
+        if (!file) {
+          return new vscode.LanguageModelToolResult([
+            new vscode.LanguageModelTextPart(`Błąd odczytu pliku: ścieżka poza workspace (${options.input.file_path})`)
+          ]);
+        }
+        const result = await readFileContext(file, options.input.line, options.input.context_lines ?? 5, root);
         return new vscode.LanguageModelToolResult([new vscode.LanguageModelTextPart(result)]);
       },
       prepareInvocation(options) {

--- a/venom_core/agents/local_agent_cli.py
+++ b/venom_core/agents/local_agent_cli.py
@@ -14,9 +14,10 @@ import asyncio
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from enum import Enum
 from pathlib import Path
 from typing import List, Optional
@@ -175,6 +176,7 @@ class LocalAgent:
         r"\b(rm\s+-rf|git\s+reset\s+--hard|drop\s+table|truncate|format\s+[a-z]:|mkfs|dd\s+if=)\b",
         re.IGNORECASE,
     )
+    _SHELL_META_PATTERN = re.compile(r"[;&|><`$\\\n\r]")
 
     def __init__(self, config: LocalAgentConfig):
         self.config = config
@@ -334,15 +336,23 @@ class LocalAgent:
             return "❌ Pusta komenda"
         if not self.config.allow_exec:
             return "❌ Wykonanie komend zablokowane. Użyj --allow-exec."
+        if self._SHELL_META_PATTERN.search(command):
+            return "❌ Komenda zawiera niedozwolone metaznaki shella."
         if not self.config.allow_destructive and self._DESTRUCTIVE_PATTERNS.search(
             command
         ):
             return "❌ Komenda destrukcyjna zablokowana. Użyj --allow-destructive."
+        try:
+            argv = shlex.split(command, posix=True)
+        except ValueError as e:
+            return f"❌ Błąd parsowania komendy: {e}"
+        if not argv:
+            return "❌ Pusta komenda"
         logger.info(f"shell_exec: {command!r}")
         try:
             result = subprocess.run(
-                command,
-                shell=True,
+                argv,
+                shell=False,
                 capture_output=True,
                 text=True,
                 cwd=self.config.workspace,
@@ -387,7 +397,7 @@ class LocalAgent:
                     "evidence": result.evidence,
                     "iterations": result.iterations,
                     "stopped_by": result.stopped_by,
-                    "tool_calls": [tc.to_dict() for tc in result.tool_calls],
+                    "tool_calls": [asdict(tc) for tc in result.tool_calls],
                 },
                 ensure_ascii=False,
                 indent=2,

--- a/venom_core/agents/local_agent_cli.py
+++ b/venom_core/agents/local_agent_cli.py
@@ -1,0 +1,507 @@
+"""
+Moduł: local_agent_cli - samodzielny lokalny agent CLI z indeksacją kodu i wykonywaniem komend.
+
+Użycie:
+    python -m venom_core.agents.local_agent_cli "zapytanie"
+    python -m venom_core.agents.local_agent_cli --interactive
+    python -m venom_core.agents.local_agent_cli --allow-exec "uruchom testy"
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import List, Optional
+
+from venom_core.execution.ollama_agent_loop import (
+    AgentLoopResult,
+    OllamaAgentLoop,
+    build_tool_spec,
+)
+from venom_core.execution.skills.code_index_skill import CodeIndexSkill
+from venom_core.execution.skills.git_skill import GitSkill
+from venom_core.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+_DEFAULT_MODEL = "qwen3.5:9b"
+_DEFAULT_MAX_ITER = 5
+
+
+class IntentClass(str, Enum):
+    GIT_STATUS = "git_status"
+    CODE_SEARCH = "code_search"
+    SHELL_EXEC = "shell_exec"
+    FILE_OP = "file_op"
+    GENERAL = "general"
+
+
+class IntentRouter:
+    """
+    Klasyfikuje intent użytkownika na jedną z klas wykonawczych.
+
+    Rozszerzenie IntegratorAgent._is_repo_truth_request() na pełny router.
+    """
+
+    _GIT_STATUS_MARKERS = (
+        "sprawdz status git",
+        "sprawdz repo git",
+        "stan repo",
+        "stan gita",
+        "git status",
+        "status git",
+        "pokaż status git",
+        "pokaz status git",
+        "jaki jest status repozytorium",
+        "jaki jest status repo",
+    )
+
+    _CODE_SEARCH_MARKERS = (
+        "gdzie jest",
+        "gdzie znajduje się",
+        "gdzie jest klasa",
+        "gdzie jest funkcja",
+        "gdzie jest metoda",
+        "znajdź klasę",
+        "znajdz klase",
+        "znajdź funkcję",
+        "znajdz funkcje",
+        "jak działa",
+        "jak dziala",
+        "pokaż kod",
+        "pokaz kod",
+        "pokaż implementację",
+        "pokaz implementacje",
+        "co robi klasa",
+        "co robi funkcja",
+        "gdzie zdefiniowana",
+        "gdzie zdefiniowany",
+        "pokaż plik",
+        "pokaz plik",
+        "search code",
+        "find class",
+        "find function",
+        "szukaj w kodzie",
+    )
+
+    _SHELL_EXEC_MARKERS = (
+        "uruchom",
+        "wykonaj",
+        "wywołaj",
+        "wywolaj",
+        "run ",
+        "exec ",
+        "uruchom testy",
+        "sprawdź port",
+        "sprawdz port",
+        "zainstaluj",
+        "zbuduj",
+        "build",
+        "make ",
+        "pytest",
+        "pip install",
+    )
+
+    _FILE_OP_MARKERS = (
+        "pokaż zawartość",
+        "pokaz zawartosc",
+        "przeczytaj plik",
+        "otwórz plik",
+        "otworz plik",
+        "zmień nazwę",
+        "zmien nazwe",
+        "stwórz plik",
+        "stworz plik",
+        "usuń plik",
+        "usun plik",
+        "wylistuj pliki",
+        "lista plików",
+        "lista plikow",
+    )
+
+    @staticmethod
+    def _normalize(text: str) -> str:
+        return re.sub(r"\s+", " ", text.strip().lower())
+
+    def classify(self, intent: str) -> IntentClass:
+        n = self._normalize(intent)
+        for marker in self._GIT_STATUS_MARKERS:
+            if marker in n:
+                return IntentClass.GIT_STATUS
+        for marker in self._CODE_SEARCH_MARKERS:
+            if marker in n:
+                return IntentClass.CODE_SEARCH
+        for marker in self._SHELL_EXEC_MARKERS:
+            if marker in n:
+                return IntentClass.SHELL_EXEC
+        for marker in self._FILE_OP_MARKERS:
+            if marker in n:
+                return IntentClass.FILE_OP
+        return IntentClass.GENERAL
+
+
+@dataclass
+class LocalAgentConfig:
+    model: str = _DEFAULT_MODEL
+    workspace: str = ""
+    max_iter: int = _DEFAULT_MAX_ITER
+    allow_exec: bool = False
+    allow_destructive: bool = False
+    json_output: bool = False
+    interactive: bool = False
+    no_think: bool = False
+
+    def __post_init__(self):
+        if not self.workspace:
+            self.workspace = os.environ.get(
+                "REPO_ROOT", os.environ.get("VENOM_WORKSPACE", str(Path.cwd()))
+            )
+
+
+class LocalAgent:
+    """
+    Samodzielny lokalny agent CLI z indeksacją kodu i wykonywaniem komend.
+    """
+
+    _DESTRUCTIVE_PATTERNS = re.compile(
+        r"\b(rm\s+-rf|git\s+reset\s+--hard|drop\s+table|truncate|format\s+[a-z]:|mkfs|dd\s+if=)\b",
+        re.IGNORECASE,
+    )
+
+    def __init__(self, config: LocalAgentConfig):
+        self.config = config
+        self.router = IntentRouter()
+        self.code_index = CodeIndexSkill(workspace_root=config.workspace)
+        self.git_skill = GitSkill(workspace_root=config.workspace)
+
+    def _build_agent_loop(self) -> OllamaAgentLoop:
+        loop = OllamaAgentLoop(
+            model=self.config.model,
+            max_iterations=self.config.max_iter,
+            system_prompt=self._system_prompt(),
+        )
+        self._register_tools(loop)
+        return loop
+
+    def _system_prompt(self) -> str:
+        workspace = self.config.workspace
+        exec_mode = (
+            "z wykonaniem komend" if self.config.allow_exec else "tryb read-only"
+        )
+        return (
+            f"Jesteś lokalnym agentem Venom ({exec_mode}). "
+            f"Workspace: {workspace}. "
+            "Odpowiadasz na pytania operatora na podstawie realnych wyników narzędzi. "
+            "Zawsze wywołuj narzędzia zamiast zgadywać. "
+            "Jeśli narzędzie zwróci wynik, użyj go jako podstawy finalnej odpowiedzi. "
+            "Nie generuj listy komend jako finalnej odpowiedzi – wywołaj narzędzie. "
+            "Odpowiadaj po polsku, chyba że user pisze po angielsku."
+        )
+
+    def _register_tools(self, loop: OllamaAgentLoop) -> None:
+        # Git status
+        loop.register_tool(
+            name="git_short_status",
+            description="Zwraca skrócony status repozytorium Git (git status --short --branch).",
+            parameters=build_tool_spec("git_short_status", "", {}, [])["function"][
+                "parameters"
+            ],
+            handler=self._handle_git_status,
+        )
+
+        # Code search
+        loop.register_tool(
+            name="search_code",
+            description=(
+                "Przeszukuje kod projektu wzorcem tekstowym lub regex. "
+                "Zwraca trafienia z ścieżkami plików i numerami linii."
+            ),
+            parameters=build_tool_spec(
+                "search_code",
+                "",
+                {
+                    "query": {
+                        "type": "string",
+                        "description": "Wzorzec lub nazwa symbolu",
+                    },
+                    "path_glob": {
+                        "type": "string",
+                        "description": "Glob plików np. '*.py' (opcjonalne)",
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "description": "Maks wyników (domyślnie 10)",
+                    },
+                },
+                ["query"],
+            )["function"]["parameters"],
+            handler=self._handle_search_code,
+        )
+
+        # File symbols
+        loop.register_tool(
+            name="get_file_symbols",
+            description="Ekstrahuje klasy, funkcje i importy z pliku Python.",
+            parameters=build_tool_spec(
+                "get_file_symbols",
+                "",
+                {
+                    "file_path": {
+                        "type": "string",
+                        "description": "Ścieżka do pliku .py",
+                    }
+                },
+                ["file_path"],
+            )["function"]["parameters"],
+            handler=self._handle_file_symbols,
+        )
+
+        # Read context
+        loop.register_tool(
+            name="read_file_context",
+            description="Zwraca fragment pliku wokół wskazanej linii.",
+            parameters=build_tool_spec(
+                "read_file_context",
+                "",
+                {
+                    "file_path": {"type": "string", "description": "Ścieżka do pliku"},
+                    "line": {"type": "integer", "description": "Numer linii"},
+                    "context_lines": {
+                        "type": "integer",
+                        "description": "Liczba linii kontekstu (domyślnie 5)",
+                    },
+                },
+                ["file_path", "line"],
+            )["function"]["parameters"],
+            handler=self._handle_read_context,
+        )
+
+        # Shell exec (tylko gdy allow_exec)
+        if self.config.allow_exec:
+            loop.register_tool(
+                name="shell_exec",
+                description="Wykonuje komendę shell na środowisku lokalnym.",
+                parameters=build_tool_spec(
+                    "shell_exec",
+                    "",
+                    {
+                        "command": {
+                            "type": "string",
+                            "description": "Komenda do wykonania",
+                        }
+                    },
+                    ["command"],
+                )["function"]["parameters"],
+                handler=self._handle_shell_exec,
+            )
+
+    def _handle_git_status(self, _name: str, _args: dict) -> str:
+        result = asyncio.run(self.git_skill.get_short_status())
+        repo_root = str(self.code_index.workspace_root)
+        return f"REPO_ROOT={repo_root}\n{result}"
+
+    def _handle_search_code(self, _name: str, args: dict) -> str:
+        query = args.get("query", "")
+        path_glob = args.get("path_glob")
+        max_results = int(args.get("max_results", 10))
+        matches = self.code_index.search_code(
+            query=query, path_glob=path_glob, max_results=max_results
+        )
+        return self.code_index.format_matches_for_llm(matches)
+
+    def _handle_file_symbols(self, _name: str, args: dict) -> str:
+        symbols = self.code_index.get_file_symbols(args.get("file_path", ""))
+        return symbols.format_summary()
+
+    def _handle_read_context(self, _name: str, args: dict) -> str:
+        return self.code_index.read_context(
+            file_path=args.get("file_path", ""),
+            line=int(args.get("line", 1)),
+            context_lines=int(args.get("context_lines", 5)),
+        )
+
+    def _handle_shell_exec(self, _name: str, args: dict) -> str:
+        command = args.get("command", "").strip()
+        if not command:
+            return "❌ Pusta komenda"
+        if not self.config.allow_exec:
+            return "❌ Wykonanie komend zablokowane. Użyj --allow-exec."
+        if not self.config.allow_destructive and self._DESTRUCTIVE_PATTERNS.search(
+            command
+        ):
+            return "❌ Komenda destrukcyjna zablokowana. Użyj --allow-destructive."
+        logger.info(f"shell_exec: {command!r}")
+        try:
+            result = subprocess.run(
+                command,
+                shell=True,
+                capture_output=True,
+                text=True,
+                cwd=self.config.workspace,
+                timeout=30,
+            )
+            output = result.stdout + (
+                f"\nSTDERR: {result.stderr}" if result.stderr.strip() else ""
+            )
+            return output.strip() or "(brak outputu)"
+        except subprocess.TimeoutExpired:
+            return "❌ Timeout komendy (30s)"
+        except Exception as e:
+            return f"❌ Błąd: {e}"
+
+    def handle_intent(self, intent: str) -> AgentLoopResult:
+        """Obsługuje intent przez odpowiednią ścieżkę wykonania."""
+        intent_class = self.router.classify(intent)
+        logger.info(f"Intent class: {intent_class.value} dla: {intent[:60]!r}")
+
+        if intent_class == IntentClass.GIT_STATUS:
+            # Fast path – bez LLM dla prostego git status
+            raw = self._handle_git_status("git_short_status", {})
+            return AgentLoopResult(
+                final_answer=raw,
+                evidence=[raw],
+                iterations=0,
+                stopped_by="fast_path",
+            )
+
+        # Dla pozostałych intentów – pełna pętla agentowa
+        loop = self._build_agent_loop()
+        return loop.run(intent)
+
+    def run_once(self, query: str) -> str:
+        """Uruchamia agenta dla pojedynczego zapytania i zwraca sformatowaną odpowiedź."""
+        result = self.handle_intent(query)
+
+        if self.config.json_output:
+            return json.dumps(
+                {
+                    "final_answer": result.final_answer,
+                    "evidence": result.evidence,
+                    "iterations": result.iterations,
+                    "stopped_by": result.stopped_by,
+                    "tool_calls": [tc.to_dict() for tc in result.tool_calls],
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+
+        lines = [result.final_answer]
+        if result.tool_calls:
+            lines.append("")
+            lines.append("--- Trace ---")
+            lines.append(result.format_trace())
+        return "\n".join(lines)
+
+    def run_interactive(self) -> None:
+        """Interaktywna pętla REPL."""
+        print(
+            f"Venom Local Agent (model: {self.config.model}, workspace: {self.config.workspace})"
+        )
+        print("Wpisz zapytanie lub 'exit' aby zakończyć.\n")
+        while True:
+            try:
+                query = input(">>> ").strip()
+            except (EOFError, KeyboardInterrupt):
+                print("\nZakończono.")
+                break
+            if not query:
+                continue
+            if query.lower() in ("exit", "quit", "q"):
+                print("Zakończono.")
+                break
+            answer = self.run_once(query)
+            print(answer)
+            print()
+
+
+def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Venom Local Agent CLI – lokalny agent z indeksacją kodu i wykonywaniem komend.",
+        prog="venom_core.agents.local_agent_cli",
+    )
+    parser.add_argument(
+        "query",
+        nargs="?",
+        default=None,
+        help="Zapytanie do agenta (pomiń dla --interactive)",
+    )
+    parser.add_argument(
+        "--model",
+        default=_DEFAULT_MODEL,
+        help=f"Model Ollama (domyślnie: {_DEFAULT_MODEL})",
+    )
+    parser.add_argument(
+        "--workspace",
+        default="",
+        help="Ścieżka workspace (domyślnie: REPO_ROOT lub CWD)",
+    )
+    parser.add_argument(
+        "--max-iter",
+        type=int,
+        default=_DEFAULT_MAX_ITER,
+        help=f"Maksymalna liczba iteracji agenta (domyślnie: {_DEFAULT_MAX_ITER})",
+    )
+    parser.add_argument(
+        "--allow-exec",
+        action="store_true",
+        default=False,
+        help="Zezwól na wykonywanie komend shell (domyślnie: zablokowane)",
+    )
+    parser.add_argument(
+        "--allow-destructive",
+        action="store_true",
+        default=False,
+        help="Zezwól na komendy destrukcyjne (wymaga --allow-exec)",
+    )
+    parser.add_argument(
+        "--interactive",
+        action="store_true",
+        default=False,
+        help="Tryb interaktywny REPL",
+    )
+    parser.add_argument(
+        "--json-output",
+        action="store_true",
+        default=False,
+        help="Wyjście w formacie JSON",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = _parse_args(argv)
+
+    config = LocalAgentConfig(
+        model=args.model,
+        workspace=args.workspace,
+        max_iter=args.max_iter,
+        allow_exec=args.allow_exec,
+        allow_destructive=args.allow_destructive,
+        json_output=args.json_output,
+        interactive=args.interactive,
+    )
+    agent = LocalAgent(config)
+
+    if config.interactive:
+        agent.run_interactive()
+        return 0
+
+    if not args.query:
+        print("Błąd: podaj zapytanie lub użyj --interactive", file=sys.stderr)
+        return 1
+
+    output = agent.run_once(args.query)
+    print(output)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/venom_core/execution/ollama_agent_loop.py
+++ b/venom_core/execution/ollama_agent_loop.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import json
-import subprocess
 import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
+from urllib import error as urllib_error
+from urllib import request as urllib_request
 
 from venom_core.utils.logger import get_logger
 
@@ -37,7 +38,7 @@ class AgentLoopResult:
     final_answer: str
     tool_calls: List[ToolCall] = field(default_factory=list)
     iterations: int = 0
-    stopped_by: str = "finish"  # "finish" | "max_iter" | "error"
+    stopped_by: str = "finish"  # "finish" | "max_iter" | "error" | "fast_path"
     evidence: List[str] = field(default_factory=list)
 
     def has_evidence(self) -> bool:
@@ -132,29 +133,34 @@ class OllamaAgentLoop:
             payload["tools"] = self.tools
 
         body = json.dumps(payload)
-        result = subprocess.run(
-            [
-                "curl",
-                "-s",
-                "--max-time",
-                str(self.timeout),
-                "-X",
-                "POST",
-                self.ollama_url,
-                "-H",
-                "Content-Type: application/json",
-                "-d",
-                body,
-            ],
-            capture_output=True,
-            text=True,
-            timeout=self.timeout + 5,
+        req = urllib_request.Request(
+            self.ollama_url,
+            data=body.encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
         )
-        if result.returncode != 0:
-            raise RuntimeError(f"curl błąd {result.returncode}: {result.stderr[:200]}")
-        if not result.stdout.strip():
+        try:
+            with urllib_request.urlopen(req, timeout=self.timeout) as resp:
+                raw = resp.read().decode("utf-8", errors="replace")
+        except urllib_error.HTTPError as e:
+            err_body = e.read().decode("utf-8", errors="replace")
+            raise RuntimeError(f"HTTP {e.code}: {err_body[:200]}") from e
+        except urllib_error.URLError as e:
+            raise RuntimeError(f"Błąd połączenia: {e.reason}") from e
+        except TimeoutError as e:
+            raise RuntimeError(f"Timeout połączenia ({self.timeout}s)") from e
+
+        if not raw.strip():
             raise RuntimeError("Pusta odpowiedź Ollama")
-        return json.loads(result.stdout)
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"Nieprawidłowy JSON z Ollama: {e}") from e
+        if not isinstance(parsed, dict):
+            raise RuntimeError(
+                "Nieprawidłowy format odpowiedzi Ollama (oczekiwano obiektu)"
+            )
+        return parsed
 
     def _dispatch_tool(
         self, name: str, arguments: Dict[str, Any]
@@ -173,7 +179,10 @@ class OllamaAgentLoop:
         self, response_message: Dict[str, Any]
     ) -> List[Dict[str, Any]]:
         """Ekstrahuje tool_calls z odpowiedzi modelu (format Ollama/OpenAI)."""
-        return response_message.get("tool_calls") or []
+        raw = response_message.get("tool_calls")
+        if not isinstance(raw, list):
+            return []
+        return [tc for tc in raw if isinstance(tc, dict)]
 
     def run(self, user_intent: str) -> AgentLoopResult:
         """
@@ -242,17 +251,21 @@ class OllamaAgentLoop:
             # Wywołaj każde narzędzie i dodaj wyniki do messages
             for tc_raw in raw_tool_calls:
                 fn = tc_raw.get("function", {})
-                tc_name = fn.get("name", "")
+                if not isinstance(fn, dict):
+                    fn = {}
+                tc_name = str(fn.get("name", ""))
                 tc_args_raw = fn.get("arguments", {})
                 if isinstance(tc_args_raw, str):
                     try:
                         tc_args = json.loads(tc_args_raw)
                     except json.JSONDecodeError:
                         tc_args = {"raw": tc_args_raw}
-                else:
+                elif isinstance(tc_args_raw, dict):
                     tc_args = tc_args_raw
+                else:
+                    tc_args = {}
 
-                call_id = tc_raw.get("id") or f"call_{iterations}_{tc_name}"
+                call_id = str(tc_raw.get("id") or f"call_{iterations}_{tc_name}")
 
                 t0 = time.monotonic()
                 result_str, error = self._dispatch_tool(tc_name, tc_args)

--- a/venom_core/execution/ollama_agent_loop.py
+++ b/venom_core/execution/ollama_agent_loop.py
@@ -184,7 +184,164 @@ class OllamaAgentLoop:
             return []
         return [tc for tc in raw if isinstance(tc, dict)]
 
+    @staticmethod
+    def _extract_message(response: Dict[str, Any]) -> Dict[str, Any]:
+        message = response.get("message")
+        if isinstance(message, dict):
+            return message
+        return {}
+
+    @staticmethod
+    def _parse_tool_arguments(arguments: Any) -> Dict[str, Any]:
+        if isinstance(arguments, dict):
+            return arguments
+        if isinstance(arguments, str):
+            try:
+                parsed = json.loads(arguments)
+                if isinstance(parsed, dict):
+                    return parsed
+            except json.JSONDecodeError:
+                return {"raw": arguments}
+            return {}
+        return {}
+
+    def _prepare_tool_call(
+        self, tc_raw: Dict[str, Any], iteration: int
+    ) -> tuple[str, str, Dict[str, Any]]:
+        fn = tc_raw.get("function", {})
+        if not isinstance(fn, dict):
+            fn = {}
+        tool_name = str(fn.get("name", ""))
+        tool_args = self._parse_tool_arguments(fn.get("arguments", {}))
+        call_id = str(tc_raw.get("id") or f"call_{iteration}_{tool_name}")
+        return call_id, tool_name, tool_args
+
+    def _invoke_tool_call(
+        self, call_id: str, tool_name: str, tool_args: Dict[str, Any]
+    ) -> ToolCall:
+        t0 = time.monotonic()
+        result_str, error = self._dispatch_tool(tool_name, tool_args)
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+
+        logger.info(
+            f"Tool {tool_name} [{elapsed_ms}ms]: {(result_str or error or '')[:100]}"
+        )
+        return ToolCall(
+            call_id=call_id,
+            name=tool_name,
+            arguments=tool_args,
+            result=result_str if not error else None,
+            error=error,
+            elapsed_ms=elapsed_ms,
+        )
+
+    @staticmethod
+    def _append_tool_result_message(
+        messages: List[Dict[str, Any]],
+        call_id: str,
+        result: Optional[str],
+        error: Optional[str],
+    ) -> None:
+        tool_result_content = result if not error else f"Błąd: {error}"
+        messages.append(
+            {
+                "role": "tool",
+                "content": tool_result_content,
+                "tool_call_id": call_id,
+            }
+        )
+
+    def _process_tool_calls(
+        self,
+        raw_tool_calls: List[Dict[str, Any]],
+        iteration: int,
+        messages: List[Dict[str, Any]],
+        all_tool_calls: List[ToolCall],
+        evidence: List[str],
+    ) -> None:
+        for tc_raw in raw_tool_calls:
+            call_id, tool_name, tool_args = self._prepare_tool_call(tc_raw, iteration)
+            tool_call = self._invoke_tool_call(call_id, tool_name, tool_args)
+            all_tool_calls.append(tool_call)
+            if tool_call.result:
+                evidence.append(f"{tool_name}: {tool_call.result}")
+            self._append_tool_result_message(
+                messages, call_id, tool_call.result, tool_call.error
+            )
+
+    @staticmethod
+    def _final_result_from_message(
+        message: Dict[str, Any],
+        finish_reason: str,
+        iterations: int,
+        all_tool_calls: List[ToolCall],
+        evidence: List[str],
+    ) -> AgentLoopResult:
+        final_answer = str(message.get("content", ""))
+        stopped_by = "finish" if finish_reason != "max_iter" else "max_iter"
+        return AgentLoopResult(
+            final_answer=final_answer,
+            tool_calls=all_tool_calls,
+            iterations=iterations,
+            stopped_by=stopped_by,
+            evidence=evidence,
+        )
+
     def run(self, user_intent: str) -> AgentLoopResult:
+        return self._run_agent_loop(user_intent)
+
+    @staticmethod
+    def _build_error_result(
+        error: Exception,
+        iterations: int,
+        all_tool_calls: List[ToolCall],
+        evidence: List[str],
+    ) -> AgentLoopResult:
+        return AgentLoopResult(
+            final_answer=f"❌ Błąd komunikacji z Ollama: {error}",
+            tool_calls=all_tool_calls,
+            iterations=iterations,
+            stopped_by="error",
+            evidence=evidence,
+        )
+
+    @staticmethod
+    def _build_initial_messages(
+        user_intent: str, system_prompt: str
+    ) -> List[Dict[str, Any]]:
+        return [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_intent},
+        ]
+
+    def _finalize_after_max_iterations(
+        self,
+        messages: List[Dict[str, Any]],
+        all_tool_calls: List[ToolCall],
+        evidence: List[str],
+    ) -> AgentLoopResult:
+        logger.warning(f"max_iterations={self.max_iterations} osiągnięte")
+        try:
+            messages.append(
+                {
+                    "role": "user",
+                    "content": "Podsumuj dotychczasowe wyniki narzędzi w jednej krótkiej odpowiedzi.",
+                }
+            )
+            response = self._call_ollama(messages)
+            final_answer = self._extract_message(response).get("content", "")
+        except Exception as e:
+            final_answer = f"⚠️ Przekroczono limit iteracji. Ostatni błąd: {e}"
+
+        return AgentLoopResult(
+            final_answer=final_answer,
+            tool_calls=all_tool_calls,
+            iterations=self.max_iterations,
+            stopped_by="max_iter",
+            evidence=evidence,
+        )
+
+    def _run_agent_loop(self, user_intent: str) -> AgentLoopResult:
         """
         Uruchamia pętlę agentową dla podanego intentu.
 
@@ -194,48 +351,35 @@ class OllamaAgentLoop:
         Returns:
             AgentLoopResult z finalną odpowiedzią i dowodem wykonania.
         """
-        messages: List[Dict[str, Any]] = [
-            {"role": "system", "content": self.system_prompt},
-            {"role": "user", "content": user_intent},
-        ]
+        messages = self._build_initial_messages(user_intent, self.system_prompt)
 
         all_tool_calls: List[ToolCall] = []
         evidence: List[str] = []
-        iterations = 0
-        stopped_by = "finish"
 
         logger.info(
             f"OllamaAgentLoop start: model={self.model}, intent={user_intent[:80]!r}"
         )
 
-        while iterations < self.max_iterations:
-            iterations += 1
-            logger.debug(f"Iteracja {iterations}/{self.max_iterations}")
+        for iteration in range(1, self.max_iterations + 1):
+            logger.debug(f"Iteracja {iteration}/{self.max_iterations}")
 
             try:
                 response = self._call_ollama(messages)
             except Exception as e:
                 logger.error(f"Błąd Ollama: {e}")
-                return AgentLoopResult(
-                    final_answer=f"❌ Błąd komunikacji z Ollama: {e}",
-                    tool_calls=all_tool_calls,
-                    iterations=iterations,
-                    stopped_by="error",
-                    evidence=evidence,
-                )
+                return self._build_error_result(e, iteration, all_tool_calls, evidence)
 
-            message = response.get("message", {})
+            message = self._extract_message(response)
             finish_reason = response.get("done_reason", "")
             raw_tool_calls = self._extract_tool_calls(message)
 
             if not raw_tool_calls:
-                final_answer = message.get("content", "")
-                logger.info(f"Odpowiedź finalna po {iterations} iteracjach")
-                return AgentLoopResult(
-                    final_answer=final_answer,
-                    tool_calls=all_tool_calls,
-                    iterations=iterations,
-                    stopped_by="finish" if finish_reason != "max_iter" else "max_iter",
+                logger.info(f"Odpowiedź finalna po {iteration} iteracjach")
+                return self._final_result_from_message(
+                    message=message,
+                    finish_reason=str(finish_reason),
+                    iterations=iteration,
+                    all_tool_calls=all_tool_calls,
                     evidence=evidence,
                 )
 
@@ -248,76 +392,15 @@ class OllamaAgentLoop:
                 }
             )
 
-            # Wywołaj każde narzędzie i dodaj wyniki do messages
-            for tc_raw in raw_tool_calls:
-                fn = tc_raw.get("function", {})
-                if not isinstance(fn, dict):
-                    fn = {}
-                tc_name = str(fn.get("name", ""))
-                tc_args_raw = fn.get("arguments", {})
-                if isinstance(tc_args_raw, str):
-                    try:
-                        tc_args = json.loads(tc_args_raw)
-                    except json.JSONDecodeError:
-                        tc_args = {"raw": tc_args_raw}
-                elif isinstance(tc_args_raw, dict):
-                    tc_args = tc_args_raw
-                else:
-                    tc_args = {}
-
-                call_id = str(tc_raw.get("id") or f"call_{iterations}_{tc_name}")
-
-                t0 = time.monotonic()
-                result_str, error = self._dispatch_tool(tc_name, tc_args)
-                elapsed_ms = int((time.monotonic() - t0) * 1000)
-
-                tc = ToolCall(
-                    call_id=call_id,
-                    name=tc_name,
-                    arguments=tc_args,
-                    result=result_str if not error else None,
-                    error=error,
-                    elapsed_ms=elapsed_ms,
-                )
-                all_tool_calls.append(tc)
-                logger.info(
-                    f"Tool {tc_name} [{elapsed_ms}ms]: {(result_str or error or '')[:100]}"
-                )
-
-                if result_str:
-                    evidence.append(f"{tc_name}: {result_str}")
-
-                tool_result_content = result_str if not error else f"Błąd: {error}"
-                messages.append(
-                    {
-                        "role": "tool",
-                        "content": tool_result_content,
-                        "tool_call_id": call_id,
-                    }
-                )
-
-        # Przekroczono max_iterations – wymuś ostatnią odpowiedź
-        stopped_by = "max_iter"
-        logger.warning(f"max_iterations={self.max_iterations} osiągnięte")
-        try:
-            messages.append(
-                {
-                    "role": "user",
-                    "content": "Podsumuj dotychczasowe wyniki narzędzi w jednej krótkiej odpowiedzi.",
-                }
+            self._process_tool_calls(
+                raw_tool_calls=raw_tool_calls,
+                iteration=iteration,
+                messages=messages,
+                all_tool_calls=all_tool_calls,
+                evidence=evidence,
             )
-            response = self._call_ollama(messages)
-            final_answer = response.get("message", {}).get("content", "")
-        except Exception as e:
-            final_answer = f"⚠️ Przekroczono limit iteracji. Ostatni błąd: {e}"
 
-        return AgentLoopResult(
-            final_answer=final_answer,
-            tool_calls=all_tool_calls,
-            iterations=iterations,
-            stopped_by=stopped_by,
-            evidence=evidence,
-        )
+        return self._finalize_after_max_iterations(messages, all_tool_calls, evidence)
 
 
 def build_tool_spec(

--- a/venom_core/execution/ollama_agent_loop.py
+++ b/venom_core/execution/ollama_agent_loop.py
@@ -1,0 +1,328 @@
+"""Moduł: ollama_agent_loop - zamknięta pętla agentowa przez Ollama /api/chat z tool-calling."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+from venom_core.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+_DEFAULT_OLLAMA_URL = "http://localhost:11434/api/chat"
+_DEFAULT_MODEL = "qwen3.5:9b"
+_DEFAULT_MAX_ITERATIONS = 5
+_DEFAULT_TIMEOUT = 60
+
+
+@dataclass
+class ToolCall:
+    """Pojedyncze wywołanie narzędzia przez LLM."""
+
+    call_id: str
+    name: str
+    arguments: Dict[str, Any]
+    result: Optional[str] = None
+    error: Optional[str] = None
+    elapsed_ms: int = 0
+
+
+@dataclass
+class AgentLoopResult:
+    """Wynik pełnej pętli agentowej."""
+
+    final_answer: str
+    tool_calls: List[ToolCall] = field(default_factory=list)
+    iterations: int = 0
+    stopped_by: str = "finish"  # "finish" | "max_iter" | "error"
+    evidence: List[str] = field(default_factory=list)
+
+    def has_evidence(self) -> bool:
+        return bool(self.evidence)
+
+    def format_trace(self) -> str:
+        if not self.tool_calls:
+            return "(brak wywołań narzędzi)"
+        lines = []
+        for tc in self.tool_calls:
+            status = "✓" if tc.error is None else "✗"
+            lines.append(f"  {status} {tc.name}({tc.arguments}) [{tc.elapsed_ms}ms]")
+            if tc.result:
+                lines.append(f"    → {tc.result[:200]}")
+            if tc.error:
+                lines.append(f"    ✗ {tc.error}")
+        return "\n".join(lines)
+
+
+ToolHandler = Callable[[str, Dict[str, Any]], str]
+
+
+class OllamaAgentLoop:
+    """
+    Zamknięta pętla agentowa oparta na Ollama /api/chat z tool-calling.
+
+    Format OpenAI-kompatybilny (obsługiwany przez qwen3.5:9b, gpt-oss:20b).
+
+    Pętla:
+        1. Zbuduj messages = [system_prompt, user_intent, ...tool_results]
+        2. Wywołaj Ollama /api/chat z tools
+        3. Jeśli response.tool_calls → wywołaj lokalny handler → dodaj wynik do messages
+        4. Powtarzaj do max_iterations lub finish_reason=stop
+        5. Zwróć AgentLoopResult z evidence i final_answer
+    """
+
+    def __init__(
+        self,
+        model: str = _DEFAULT_MODEL,
+        ollama_url: str = _DEFAULT_OLLAMA_URL,
+        max_iterations: int = _DEFAULT_MAX_ITERATIONS,
+        timeout: int = _DEFAULT_TIMEOUT,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        tool_handlers: Optional[Dict[str, ToolHandler]] = None,
+        system_prompt: Optional[str] = None,
+    ):
+        self.model = model
+        self.ollama_url = ollama_url
+        self.max_iterations = max_iterations
+        self.timeout = timeout
+        self.tools: List[Dict[str, Any]] = tools or []
+        self.tool_handlers: Dict[str, ToolHandler] = tool_handlers or {}
+        self.system_prompt = system_prompt or self._default_system_prompt()
+
+    @staticmethod
+    def _default_system_prompt() -> str:
+        return (
+            "Jesteś lokalnym agentem Venom. Odpowiadasz na pytania operatora na podstawie "
+            "realnych wyników narzędzi. Zawsze wywołuj narzędzia zamiast zgadywać. "
+            "Jeśli narzędzie zwróci wynik, użyj go jako podstawy odpowiedzi. "
+            "Nie generuj listy komend jako finalnej odpowiedzi – wywołaj narzędzie i zwróć evidence."
+        )
+
+    def register_tool(
+        self,
+        name: str,
+        description: str,
+        parameters: Dict[str, Any],
+        handler: ToolHandler,
+    ) -> None:
+        """Rejestruje narzędzie dostępne dla LLM."""
+        self.tools.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "description": description,
+                    "parameters": parameters,
+                },
+            }
+        )
+        self.tool_handlers[name] = handler
+
+    def _call_ollama(self, messages: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Wywołuje Ollama /api/chat i zwraca sparsowany JSON."""
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "stream": False,
+        }
+        if self.tools:
+            payload["tools"] = self.tools
+
+        body = json.dumps(payload)
+        result = subprocess.run(
+            [
+                "curl",
+                "-s",
+                "--max-time",
+                str(self.timeout),
+                "-X",
+                "POST",
+                self.ollama_url,
+                "-H",
+                "Content-Type: application/json",
+                "-d",
+                body,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=self.timeout + 5,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"curl błąd {result.returncode}: {result.stderr[:200]}")
+        if not result.stdout.strip():
+            raise RuntimeError("Pusta odpowiedź Ollama")
+        return json.loads(result.stdout)
+
+    def _dispatch_tool(
+        self, name: str, arguments: Dict[str, Any]
+    ) -> tuple[str, Optional[str]]:
+        """Wywołuje handler narzędzia. Zwraca (result, error)."""
+        handler = self.tool_handlers.get(name)
+        if handler is None:
+            return "", f"Brak handlera dla narzędzia: {name}"
+        try:
+            result = handler(name, arguments)
+            return str(result), None
+        except Exception as e:
+            return "", f"Błąd wywołania {name}: {e}"
+
+    def _extract_tool_calls(
+        self, response_message: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
+        """Ekstrahuje tool_calls z odpowiedzi modelu (format Ollama/OpenAI)."""
+        return response_message.get("tool_calls") or []
+
+    def run(self, user_intent: str) -> AgentLoopResult:
+        """
+        Uruchamia pętlę agentową dla podanego intentu.
+
+        Args:
+            user_intent: Treść zapytania użytkownika.
+
+        Returns:
+            AgentLoopResult z finalną odpowiedzią i dowodem wykonania.
+        """
+        messages: List[Dict[str, Any]] = [
+            {"role": "system", "content": self.system_prompt},
+            {"role": "user", "content": user_intent},
+        ]
+
+        all_tool_calls: List[ToolCall] = []
+        evidence: List[str] = []
+        iterations = 0
+        stopped_by = "finish"
+
+        logger.info(
+            f"OllamaAgentLoop start: model={self.model}, intent={user_intent[:80]!r}"
+        )
+
+        while iterations < self.max_iterations:
+            iterations += 1
+            logger.debug(f"Iteracja {iterations}/{self.max_iterations}")
+
+            try:
+                response = self._call_ollama(messages)
+            except Exception as e:
+                logger.error(f"Błąd Ollama: {e}")
+                return AgentLoopResult(
+                    final_answer=f"❌ Błąd komunikacji z Ollama: {e}",
+                    tool_calls=all_tool_calls,
+                    iterations=iterations,
+                    stopped_by="error",
+                    evidence=evidence,
+                )
+
+            message = response.get("message", {})
+            finish_reason = response.get("done_reason", "")
+            raw_tool_calls = self._extract_tool_calls(message)
+
+            if not raw_tool_calls:
+                final_answer = message.get("content", "")
+                logger.info(f"Odpowiedź finalna po {iterations} iteracjach")
+                return AgentLoopResult(
+                    final_answer=final_answer,
+                    tool_calls=all_tool_calls,
+                    iterations=iterations,
+                    stopped_by="finish" if finish_reason != "max_iter" else "max_iter",
+                    evidence=evidence,
+                )
+
+            # Dodaj odpowiedź asystenta z tool_calls do historii
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": message.get("content") or "",
+                    "tool_calls": raw_tool_calls,
+                }
+            )
+
+            # Wywołaj każde narzędzie i dodaj wyniki do messages
+            for tc_raw in raw_tool_calls:
+                fn = tc_raw.get("function", {})
+                tc_name = fn.get("name", "")
+                tc_args_raw = fn.get("arguments", {})
+                if isinstance(tc_args_raw, str):
+                    try:
+                        tc_args = json.loads(tc_args_raw)
+                    except json.JSONDecodeError:
+                        tc_args = {"raw": tc_args_raw}
+                else:
+                    tc_args = tc_args_raw
+
+                call_id = tc_raw.get("id") or f"call_{iterations}_{tc_name}"
+
+                t0 = time.monotonic()
+                result_str, error = self._dispatch_tool(tc_name, tc_args)
+                elapsed_ms = int((time.monotonic() - t0) * 1000)
+
+                tc = ToolCall(
+                    call_id=call_id,
+                    name=tc_name,
+                    arguments=tc_args,
+                    result=result_str if not error else None,
+                    error=error,
+                    elapsed_ms=elapsed_ms,
+                )
+                all_tool_calls.append(tc)
+                logger.info(
+                    f"Tool {tc_name} [{elapsed_ms}ms]: {(result_str or error or '')[:100]}"
+                )
+
+                if result_str:
+                    evidence.append(f"{tc_name}: {result_str}")
+
+                tool_result_content = result_str if not error else f"Błąd: {error}"
+                messages.append(
+                    {
+                        "role": "tool",
+                        "content": tool_result_content,
+                        "tool_call_id": call_id,
+                    }
+                )
+
+        # Przekroczono max_iterations – wymuś ostatnią odpowiedź
+        stopped_by = "max_iter"
+        logger.warning(f"max_iterations={self.max_iterations} osiągnięte")
+        try:
+            messages.append(
+                {
+                    "role": "user",
+                    "content": "Podsumuj dotychczasowe wyniki narzędzi w jednej krótkiej odpowiedzi.",
+                }
+            )
+            response = self._call_ollama(messages)
+            final_answer = response.get("message", {}).get("content", "")
+        except Exception as e:
+            final_answer = f"⚠️ Przekroczono limit iteracji. Ostatni błąd: {e}"
+
+        return AgentLoopResult(
+            final_answer=final_answer,
+            tool_calls=all_tool_calls,
+            iterations=iterations,
+            stopped_by=stopped_by,
+            evidence=evidence,
+        )
+
+
+def build_tool_spec(
+    name: str,
+    description: str,
+    properties: Dict[str, Dict[str, Any]],
+    required: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Helper do budowania spec narzędzia w formacie OpenAI/Ollama."""
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": {
+                "type": "object",
+                "properties": properties,
+                "required": required or [],
+            },
+        },
+    }

--- a/venom_core/execution/skills/code_index_skill.py
+++ b/venom_core/execution/skills/code_index_skill.py
@@ -1,0 +1,394 @@
+"""Moduł: code_index_skill - przeszukiwanie kodu projektu przez ripgrep i AST."""
+
+import ast
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Annotated, List, Optional
+
+from semantic_kernel.functions import kernel_function
+
+from venom_core.execution.skills.base_skill import BaseSkill, async_safe_action
+
+
+@dataclass
+class CodeMatch:
+    """Pojedyncze trafienie w kodzie."""
+
+    file: str
+    line: int
+    text: str
+    context_before: List[str]
+    context_after: List[str]
+
+    def to_dict(self) -> dict:
+        return {
+            "file": self.file,
+            "line": self.line,
+            "text": self.text,
+            "context_before": self.context_before,
+            "context_after": self.context_after,
+        }
+
+    def format_snippet(self) -> str:
+        lines = []
+        start = self.line - len(self.context_before)
+        for i, c in enumerate(self.context_before):
+            lines.append(f"  {start + i}: {c}")
+        lines.append(f"→ {self.line}: {self.text}")
+        for i, c in enumerate(self.context_after):
+            lines.append(f"  {self.line + 1 + i}: {c}")
+        return "\n".join(lines)
+
+
+@dataclass
+class FileSymbols:
+    """Symbole wyekstrahowane z pliku Python."""
+
+    file: str
+    classes: List[str]
+    functions: List[str]
+    imports: List[str]
+
+    def format_summary(self) -> str:
+        parts = [f"Plik: {self.file}"]
+        if self.classes:
+            parts.append(f"Klasy: {', '.join(self.classes)}")
+        if self.functions:
+            parts.append(f"Funkcje: {', '.join(self.functions[:20])}")
+        if self.imports:
+            parts.append(f"Importy: {', '.join(self.imports[:10])}")
+        return "\n".join(parts)
+
+
+class CodeIndexSkill(BaseSkill):
+    """
+    Skill do przeszukiwania kodu projektu.
+
+    Używa ripgrep do szybkiego przeszukiwania wzorców i Python AST do
+    ekstrakcji symboli z plików .py. Nie wymaga wcześniejszego zbudowania
+    indeksu – działa na żywo na workspace.
+    """
+
+    _RG_BINARY = "rg"
+    _DEFAULT_GLOBS = ["*.py", "*.ts", "*.tsx", "*.md", "*.json", "*.yaml", "*.yml"]
+    _SKIP_DIRS = [
+        ".git",
+        ".venv",
+        "node_modules",
+        "__pycache__",
+        ".pytest_cache",
+        "out",
+        "dist",
+        ".mypy_cache",
+        "models_cache",
+        "models",
+    ]
+
+    def __init__(self, workspace_root: Optional[str] = None):
+        super().__init__(workspace_root)
+        self._rg_available = self._check_rg()
+
+    def _check_rg(self) -> bool:
+        try:
+            result = subprocess.run(
+                [self._RG_BINARY, "--version"],
+                capture_output=True,
+                timeout=3,
+            )
+            return result.returncode == 0
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return False
+
+    def _build_skip_args(self) -> List[str]:
+        args = []
+        for d in self._SKIP_DIRS:
+            args += ["--glob", f"!{d}"]
+            args += ["--glob", f"!**/{d}/**"]
+        return args
+
+    def _parse_rg_json_output(self, raw: str, context_lines: int) -> List[CodeMatch]:
+        matches: List[CodeMatch] = []
+        context_before_buf: List[str] = []
+
+        for line in raw.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            entry_type = entry.get("type")
+            if entry_type == "context":
+                text = entry["data"]["lines"]["text"].rstrip("\n")
+                context_before_buf.append(text)
+                if len(context_before_buf) > context_lines:
+                    context_before_buf.pop(0)
+            elif entry_type == "match":
+                data = entry["data"]
+                file_path = data["path"]["text"]
+                line_no = data["line_number"]
+                match_text = data["lines"]["text"].rstrip("\n")
+                matches.append(
+                    CodeMatch(
+                        file=file_path,
+                        line=line_no,
+                        text=match_text,
+                        context_before=list(context_before_buf),
+                        context_after=[],
+                    )
+                )
+                context_before_buf = []
+            elif entry_type == "end":
+                context_before_buf = []
+
+        return matches
+
+    def _attach_context_after(
+        self, matches: List[CodeMatch], raw: str, context_lines: int
+    ) -> None:
+        """Uzupełnia context_after przez drugi pass przez output."""
+        lines_by_file: dict = {}
+        for line in raw.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if entry.get("type") not in ("match", "context"):
+                continue
+            data = entry["data"]
+            fp = data["path"]["text"]
+            ln = data["line_number"]
+            text = data["lines"]["text"].rstrip("\n")
+            lines_by_file.setdefault(fp, {})[ln] = text
+
+        for m in matches:
+            file_lines = lines_by_file.get(m.file, {})
+            after = []
+            for offset in range(1, context_lines + 1):
+                t = file_lines.get(m.line + offset)
+                if t is not None:
+                    after.append(t)
+            m.context_after = after
+
+    def search_code(
+        self,
+        query: str,
+        path_glob: Optional[str] = None,
+        max_results: int = 10,
+        context_lines: int = 2,
+        case_sensitive: bool = False,
+    ) -> List[CodeMatch]:
+        """
+        Przeszukuje kod projektu wzorcem (regex lub dosłowny tekst).
+
+        Args:
+            query: Wzorzec do wyszukania.
+            path_glob: Glob filtrujący pliki, np. "*.py" (opcjonalny).
+            max_results: Maksymalna liczba trafień.
+            context_lines: Liczba linii kontekstu wokół trafienia.
+            case_sensitive: Czy rozróżniać wielkość liter.
+
+        Returns:
+            Lista obiektów CodeMatch.
+        """
+        if not self._rg_available:
+            self.logger.warning("ripgrep niedostępny, zwracam pustą listę")
+            return []
+
+        cmd = [
+            self._RG_BINARY,
+            "--json",
+            f"--context={context_lines}",
+            f"--max-count={max_results}",
+        ]
+        if not case_sensitive:
+            cmd.append("--ignore-case")
+        cmd += self._build_skip_args()
+        if path_glob:
+            cmd += ["--glob", path_glob]
+        cmd += [query, str(self.workspace_root)]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            matches = self._parse_rg_json_output(result.stdout, context_lines)
+            self._attach_context_after(matches, result.stdout, context_lines)
+            return matches[:max_results]
+        except subprocess.TimeoutExpired:
+            self.logger.error("ripgrep timeout")
+            return []
+        except Exception as e:
+            self.logger.error(f"Błąd ripgrep: {e}")
+            return []
+
+    def get_file_symbols(self, file_path: str) -> FileSymbols:
+        """
+        Ekstrahuje klasy, funkcje i importy z pliku Python przez AST.
+
+        Args:
+            file_path: Ścieżka do pliku .py (absolutna lub względem workspace).
+
+        Returns:
+            FileSymbols z listami klas, funkcji i importów.
+        """
+        path = Path(file_path)
+        if not path.is_absolute():
+            path = self.workspace_root / file_path
+
+        classes: List[str] = []
+        functions: List[str] = []
+        imports: List[str] = []
+
+        if not path.exists() or path.suffix != ".py":
+            return FileSymbols(
+                file=str(path), classes=classes, functions=functions, imports=imports
+            )
+
+        try:
+            source = path.read_text(encoding="utf-8", errors="replace")
+            tree = ast.parse(source, filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ClassDef):
+                    classes.append(node.name)
+                elif isinstance(node, ast.FunctionDef):
+                    functions.append(node.name)
+                elif isinstance(node, ast.AsyncFunctionDef):
+                    functions.append(node.name)
+                elif isinstance(node, ast.Import):
+                    for alias in node.names:
+                        imports.append(alias.name)
+                elif isinstance(node, ast.ImportFrom):
+                    module = node.module or ""
+                    imports.append(module)
+        except SyntaxError as e:
+            self.logger.debug(f"SyntaxError w {path}: {e}")
+        except Exception as e:
+            self.logger.error(f"Błąd AST {path}: {e}")
+
+        return FileSymbols(
+            file=str(path),
+            classes=list(dict.fromkeys(classes)),
+            functions=list(dict.fromkeys(functions)),
+            imports=list(dict.fromkeys(imports)),
+        )
+
+    def read_context(
+        self,
+        file_path: str,
+        line: int,
+        context_lines: int = 5,
+    ) -> str:
+        """
+        Zwraca fragment pliku wokół wskazanej linii.
+
+        Args:
+            file_path: Ścieżka do pliku.
+            line: Numer linii (1-indexed).
+            context_lines: Liczba linii kontekstu w każdym kierunku.
+
+        Returns:
+            Fragment pliku jako tekst z numerami linii.
+        """
+        path = Path(file_path)
+        if not path.is_absolute():
+            path = self.workspace_root / file_path
+
+        if not path.exists():
+            return f"❌ Plik nie istnieje: {file_path}"
+
+        try:
+            all_lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        except Exception as e:
+            return f"❌ Błąd odczytu: {e}"
+
+        total = len(all_lines)
+        start = max(0, line - context_lines - 1)
+        end = min(total, line + context_lines)
+
+        result_lines = []
+        for i, text in enumerate(all_lines[start:end], start=start + 1):
+            marker = "→" if i == line else " "
+            result_lines.append(f"{marker} {i:4d}: {text}")
+
+        return "\n".join(result_lines)
+
+    def format_matches_for_llm(
+        self, matches: List[CodeMatch], max_chars: int = 3000
+    ) -> str:
+        """Formatuje wyniki wyszukiwania do wstawienia w kontekst LLM."""
+        if not matches:
+            return "Brak wyników."
+        parts = []
+        total = 0
+        for m in matches:
+            snippet = f"[{m.file}:{m.line}]\n{m.format_snippet()}"
+            if total + len(snippet) > max_chars:
+                break
+            parts.append(snippet)
+            total += len(snippet)
+        return "\n\n".join(parts)
+
+    @kernel_function(
+        name="search_code",
+        description=(
+            "Przeszukuje kod projektu wzorcem tekstowym lub regex. "
+            "Zwraca trafienia z kontekstem linii i ścieżkami plików."
+        ),
+    )
+    @async_safe_action
+    async def search_code_tool(
+        self,
+        query: Annotated[str, "Wzorzec do wyszukania (tekst lub regex)"],
+        path_glob: Annotated[
+            Optional[str], "Glob filtrujący pliki, np. '*.py' (opcjonalny)"
+        ] = None,
+        max_results: Annotated[int, "Maksymalna liczba wyników (domyślnie 10)"] = 10,
+    ) -> str:
+        matches = self.search_code(
+            query=query, path_glob=path_glob, max_results=max_results
+        )
+        return self.format_matches_for_llm(matches)
+
+    @kernel_function(
+        name="get_file_symbols",
+        description=(
+            "Ekstrahuje symbole (klasy, funkcje, importy) z pliku Python. "
+            "Przydatne do szybkiego przeglądu struktury modułu."
+        ),
+    )
+    @async_safe_action
+    async def get_file_symbols_tool(
+        self,
+        file_path: Annotated[str, "Ścieżka do pliku .py"],
+    ) -> str:
+        symbols = self.get_file_symbols(file_path)
+        return symbols.format_summary()
+
+    @kernel_function(
+        name="read_file_context",
+        description=(
+            "Zwraca fragment pliku wokół wskazanej linii z numerami linii. "
+            "Używaj po search_code aby zobaczyć pełny kontekst trafienia."
+        ),
+    )
+    @async_safe_action
+    async def read_context_tool(
+        self,
+        file_path: Annotated[str, "Ścieżka do pliku"],
+        line: Annotated[int, "Numer linii (1-indexed)"],
+        context_lines: Annotated[int, "Liczba linii kontekstu (domyślnie 5)"] = 5,
+    ) -> str:
+        return self.read_context(
+            file_path=file_path, line=line, context_lines=context_lines
+        )

--- a/venom_core/execution/skills/code_index_skill.py
+++ b/venom_core/execution/skills/code_index_skill.py
@@ -63,6 +63,28 @@ class FileSymbols:
 
 
 @dataclass
+class _PythonSymbolCollector:
+    """Zbiera symbole z drzewa AST bez rozbudowanej logiki w funkcji wywołującej."""
+
+    classes: List[str] = field(default_factory=list)
+    functions: List[str] = field(default_factory=list)
+    imports: List[str] = field(default_factory=list)
+
+    def add_node(self, node: ast.AST) -> None:
+        if isinstance(node, ast.ClassDef):
+            self.classes.append(node.name)
+            return
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            self.functions.append(node.name)
+            return
+        if isinstance(node, ast.Import):
+            self.imports.extend(alias.name for alias in node.names)
+            return
+        if isinstance(node, ast.ImportFrom):
+            self.imports.append(node.module or "")
+
+
+@dataclass
 class _RgJsonStreamReducer:
     """Stanowy reduktor liniowego JSON outputu ripgrep."""
 
@@ -326,43 +348,45 @@ class CodeIndexSkill(BaseSkill):
             path = self._resolve_workspace_path(file_path)
         except ValueError as e:
             self.logger.warning(str(e))
-            return FileSymbols(file=file_path, classes=[], functions=[], imports=[])
+            return self._empty_file_symbols(file_path)
 
-        classes: List[str] = []
-        functions: List[str] = []
-        imports: List[str] = []
+        if not self._is_python_source_file(path):
+            return self._empty_file_symbols(str(path))
 
-        if not path.exists() or path.suffix != ".py":
-            return FileSymbols(
-                file=str(path), classes=classes, functions=functions, imports=imports
-            )
+        return self._extract_file_symbols(path)
 
+    @staticmethod
+    def _empty_file_symbols(file_path: str) -> FileSymbols:
+        return FileSymbols(file=file_path, classes=[], functions=[], imports=[])
+
+    @staticmethod
+    def _is_python_source_file(path: Path) -> bool:
+        return path.exists() and path.suffix == ".py"
+
+    @staticmethod
+    def _dedupe(values: List[str]) -> List[str]:
+        return list(dict.fromkeys(values))
+
+    def _extract_file_symbols(self, path: Path) -> FileSymbols:
         try:
             source = path.read_text(encoding="utf-8", errors="replace")
             tree = ast.parse(source, filename=str(path))
-            for node in ast.walk(tree):
-                if isinstance(node, ast.ClassDef):
-                    classes.append(node.name)
-                elif isinstance(node, ast.FunctionDef):
-                    functions.append(node.name)
-                elif isinstance(node, ast.AsyncFunctionDef):
-                    functions.append(node.name)
-                elif isinstance(node, ast.Import):
-                    for alias in node.names:
-                        imports.append(alias.name)
-                elif isinstance(node, ast.ImportFrom):
-                    module = node.module or ""
-                    imports.append(module)
         except SyntaxError as e:
             self.logger.debug(f"SyntaxError w {path}: {e}")
+            return self._empty_file_symbols(str(path))
         except Exception as e:
             self.logger.error(f"Błąd AST {path}: {e}")
+            return self._empty_file_symbols(str(path))
+
+        collector = _PythonSymbolCollector()
+        for node in ast.walk(tree):
+            collector.add_node(node)
 
         return FileSymbols(
             file=str(path),
-            classes=list(dict.fromkeys(classes)),
-            functions=list(dict.fromkeys(functions)),
-            imports=list(dict.fromkeys(imports)),
+            classes=self._dedupe(collector.classes),
+            functions=self._dedupe(collector.functions),
+            imports=self._dedupe(collector.imports),
         )
 
     def read_context(

--- a/venom_core/execution/skills/code_index_skill.py
+++ b/venom_core/execution/skills/code_index_skill.py
@@ -5,7 +5,7 @@ import json
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated, List, Optional
+from typing import Annotated, Dict, List, Optional
 
 from semantic_kernel.functions import kernel_function
 
@@ -110,7 +110,8 @@ class CodeIndexSkill(BaseSkill):
 
     def _parse_rg_json_output(self, raw: str, context_lines: int) -> List[CodeMatch]:
         matches: List[CodeMatch] = []
-        context_before_buf: List[str] = []
+        context_before_by_file: Dict[str, List[str]] = {}
+        active_matches_by_file: Dict[str, List[CodeMatch]] = {}
 
         for line in raw.splitlines():
             line = line.strip()
@@ -122,60 +123,59 @@ class CodeIndexSkill(BaseSkill):
                 continue
 
             entry_type = entry.get("type")
-            if entry_type == "context":
-                text = entry["data"]["lines"]["text"].rstrip("\n")
-                context_before_buf.append(text)
-                if len(context_before_buf) > context_lines:
-                    context_before_buf.pop(0)
-            elif entry_type == "match":
-                data = entry["data"]
-                file_path = data["path"]["text"]
-                line_no = data["line_number"]
-                match_text = data["lines"]["text"].rstrip("\n")
+            data = entry.get("data", {})
+            file_path = data.get("path", {}).get("text")
+            line_no = data.get("line_number")
+            text = data.get("lines", {}).get("text", "").rstrip("\n")
+
+            if (
+                entry_type in ("context", "match")
+                and file_path
+                and isinstance(line_no, int)
+            ):
+                active = active_matches_by_file.get(file_path, [])
+                if active and entry_type == "context":
+                    updated_active: List[CodeMatch] = []
+                    for m in active:
+                        if m.line < line_no <= m.line + context_lines:
+                            if len(m.context_after) < context_lines:
+                                m.context_after.append(text)
+                        if line_no < m.line + context_lines:
+                            updated_active.append(m)
+                    active_matches_by_file[file_path] = updated_active
+
+            if entry_type == "context" and file_path:
+                before = context_before_by_file.setdefault(file_path, [])
+                before.append(text)
+                if len(before) > context_lines:
+                    before.pop(0)
+            elif entry_type == "match" and file_path and isinstance(line_no, int):
+                before = context_before_by_file.get(file_path, [])
                 matches.append(
                     CodeMatch(
                         file=file_path,
                         line=line_no,
-                        text=match_text,
-                        context_before=list(context_before_buf),
+                        text=text,
+                        context_before=list(before),
                         context_after=[],
                     )
                 )
-                context_before_buf = []
+                active_matches_by_file.setdefault(file_path, []).append(matches[-1])
+                context_before_by_file[file_path] = []
             elif entry_type == "end":
-                context_before_buf = []
+                context_before_by_file.clear()
+                active_matches_by_file.clear()
 
         return matches
 
-    def _attach_context_after(
-        self, matches: List[CodeMatch], raw: str, context_lines: int
-    ) -> None:
-        """Uzupełnia context_after przez drugi pass przez output."""
-        lines_by_file: dict = {}
-        for line in raw.splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                entry = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if entry.get("type") not in ("match", "context"):
-                continue
-            data = entry["data"]
-            fp = data["path"]["text"]
-            ln = data["line_number"]
-            text = data["lines"]["text"].rstrip("\n")
-            lines_by_file.setdefault(fp, {})[ln] = text
-
-        for m in matches:
-            file_lines = lines_by_file.get(m.file, {})
-            after = []
-            for offset in range(1, context_lines + 1):
-                t = file_lines.get(m.line + offset)
-                if t is not None:
-                    after.append(t)
-            m.context_after = after
+    def _resolve_workspace_path(self, file_path: str) -> Path:
+        candidate = (self.workspace_root / file_path).resolve()
+        root = self.workspace_root.resolve()
+        try:
+            candidate.relative_to(root)
+        except ValueError as e:
+            raise ValueError(f"Ścieżka poza workspace: {file_path}") from e
+        return candidate
 
     def search_code(
         self,
@@ -222,8 +222,12 @@ class CodeIndexSkill(BaseSkill):
                 text=True,
                 timeout=15,
             )
+            if result.returncode > 1:
+                self.logger.error(
+                    f"ripgrep błąd (code={result.returncode}): {result.stderr.strip()[:200]}"
+                )
+                return []
             matches = self._parse_rg_json_output(result.stdout, context_lines)
-            self._attach_context_after(matches, result.stdout, context_lines)
             return matches[:max_results]
         except subprocess.TimeoutExpired:
             self.logger.error("ripgrep timeout")
@@ -242,9 +246,11 @@ class CodeIndexSkill(BaseSkill):
         Returns:
             FileSymbols z listami klas, funkcji i importów.
         """
-        path = Path(file_path)
-        if not path.is_absolute():
-            path = self.workspace_root / file_path
+        try:
+            path = self._resolve_workspace_path(file_path)
+        except ValueError as e:
+            self.logger.warning(str(e))
+            return FileSymbols(file=file_path, classes=[], functions=[], imports=[])
 
         classes: List[str] = []
         functions: List[str] = []
@@ -300,9 +306,10 @@ class CodeIndexSkill(BaseSkill):
         Returns:
             Fragment pliku jako tekst z numerami linii.
         """
-        path = Path(file_path)
-        if not path.is_absolute():
-            path = self.workspace_root / file_path
+        try:
+            path = self._resolve_workspace_path(file_path)
+        except ValueError as e:
+            return f"❌ {e}"
 
         if not path.exists():
             return f"❌ Plik nie istnieje: {file_path}"

--- a/venom_core/execution/skills/code_index_skill.py
+++ b/venom_core/execution/skills/code_index_skill.py
@@ -3,7 +3,7 @@
 import ast
 import json
 import subprocess
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Annotated, Dict, List, Optional
 
@@ -62,6 +62,109 @@ class FileSymbols:
         return "\n".join(parts)
 
 
+@dataclass
+class _RgJsonStreamReducer:
+    """Stanowy reduktor liniowego JSON outputu ripgrep."""
+
+    context_lines: int
+    matches: List[CodeMatch] = field(default_factory=list)
+    context_before_by_file: Dict[str, List[str]] = field(default_factory=dict)
+    active_matches_by_file: Dict[str, List[CodeMatch]] = field(default_factory=dict)
+
+    def feed_line(self, raw_line: str) -> None:
+        line = raw_line.strip()
+        if not line:
+            return
+
+        entry = self._parse_entry(line)
+        if entry is None:
+            return
+
+        entry_type, file_path, line_no, text = self._extract_entry_fields(entry)
+        if entry_type == "end":
+            self._reset_state()
+            return
+        if not file_path or not isinstance(line_no, int):
+            return
+
+        if entry_type in ("context", "match"):
+            self._update_active_matches(file_path, line_no, text)
+        if entry_type == "context":
+            self._append_context_before(file_path, text)
+        elif entry_type == "match":
+            self._append_match(file_path, line_no, text)
+
+    def _parse_entry(self, line: str) -> Optional[dict]:
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(entry, dict):
+            return None
+        return entry
+
+    @staticmethod
+    def _extract_entry_fields(
+        entry: dict,
+    ) -> tuple[str, Optional[str], Optional[int], str]:
+        entry_type = str(entry.get("type", ""))
+        data = entry.get("data", {})
+        if not isinstance(data, dict):
+            data = {}
+        path_data = data.get("path", {})
+        if not isinstance(path_data, dict):
+            path_data = {}
+        lines_data = data.get("lines", {})
+        if not isinstance(lines_data, dict):
+            lines_data = {}
+        file_path = path_data.get("text")
+        line_no = data.get("line_number")
+        text = str(lines_data.get("text", "")).rstrip("\n")
+        return (
+            entry_type,
+            file_path if isinstance(file_path, str) else None,
+            line_no if isinstance(line_no, int) else None,
+            text,
+        )
+
+    def _update_active_matches(self, file_path: str, line_no: int, text: str) -> None:
+        active = self.active_matches_by_file.get(file_path, [])
+        if not active:
+            return
+
+        updated_active: List[CodeMatch] = []
+        for match in active:
+            if match.line < line_no <= match.line + self.context_lines:
+                if len(match.context_after) < self.context_lines:
+                    match.context_after.append(text)
+            if line_no < match.line + self.context_lines:
+                updated_active.append(match)
+        self.active_matches_by_file[file_path] = updated_active
+
+    def _append_context_before(self, file_path: str, text: str) -> None:
+        before = self.context_before_by_file.setdefault(file_path, [])
+        before.append(text)
+        if len(before) > self.context_lines:
+            before.pop(0)
+
+    def _append_match(self, file_path: str, line_no: int, text: str) -> None:
+        before = self.context_before_by_file.get(file_path, [])
+        match = CodeMatch(
+            file=file_path,
+            line=line_no,
+            text=text,
+            context_before=list(before),
+            context_after=[],
+        )
+        self.matches.append(match)
+        self.active_matches_by_file.setdefault(file_path, []).append(match)
+        self.context_before_by_file[file_path] = []
+
+    def _reset_state(self) -> None:
+        self.context_before_by_file.clear()
+        self.active_matches_by_file.clear()
+
+
 class CodeIndexSkill(BaseSkill):
     """
     Skill do przeszukiwania kodu projektu.
@@ -109,64 +212,10 @@ class CodeIndexSkill(BaseSkill):
         return args
 
     def _parse_rg_json_output(self, raw: str, context_lines: int) -> List[CodeMatch]:
-        matches: List[CodeMatch] = []
-        context_before_by_file: Dict[str, List[str]] = {}
-        active_matches_by_file: Dict[str, List[CodeMatch]] = {}
-
+        reducer = _RgJsonStreamReducer(context_lines=context_lines)
         for line in raw.splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                entry = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-
-            entry_type = entry.get("type")
-            data = entry.get("data", {})
-            file_path = data.get("path", {}).get("text")
-            line_no = data.get("line_number")
-            text = data.get("lines", {}).get("text", "").rstrip("\n")
-
-            if (
-                entry_type in ("context", "match")
-                and file_path
-                and isinstance(line_no, int)
-            ):
-                active = active_matches_by_file.get(file_path, [])
-                if active and entry_type == "context":
-                    updated_active: List[CodeMatch] = []
-                    for m in active:
-                        if m.line < line_no <= m.line + context_lines:
-                            if len(m.context_after) < context_lines:
-                                m.context_after.append(text)
-                        if line_no < m.line + context_lines:
-                            updated_active.append(m)
-                    active_matches_by_file[file_path] = updated_active
-
-            if entry_type == "context" and file_path:
-                before = context_before_by_file.setdefault(file_path, [])
-                before.append(text)
-                if len(before) > context_lines:
-                    before.pop(0)
-            elif entry_type == "match" and file_path and isinstance(line_no, int):
-                before = context_before_by_file.get(file_path, [])
-                matches.append(
-                    CodeMatch(
-                        file=file_path,
-                        line=line_no,
-                        text=text,
-                        context_before=list(before),
-                        context_after=[],
-                    )
-                )
-                active_matches_by_file.setdefault(file_path, []).append(matches[-1])
-                context_before_by_file[file_path] = []
-            elif entry_type == "end":
-                context_before_by_file.clear()
-                active_matches_by_file.clear()
-
-        return matches
+            reducer.feed_line(line)
+        return reducer.matches
 
     def _resolve_workspace_path(self, file_path: str) -> Path:
         candidate = (self.workspace_root / file_path).resolve()
@@ -176,6 +225,50 @@ class CodeIndexSkill(BaseSkill):
         except ValueError as e:
             raise ValueError(f"Ścieżka poza workspace: {file_path}") from e
         return candidate
+
+    def _build_search_command(
+        self,
+        query: str,
+        path_glob: Optional[str],
+        max_results: int,
+        context_lines: int,
+        case_sensitive: bool,
+    ) -> List[str]:
+        cmd = [
+            self._RG_BINARY,
+            "--json",
+            f"--context={context_lines}",
+            f"--max-count={max_results}",
+        ]
+        if not case_sensitive:
+            cmd.append("--ignore-case")
+        cmd += self._build_skip_args()
+        if path_glob:
+            cmd += ["--glob", path_glob]
+        cmd += [query, str(self.workspace_root)]
+        return cmd
+
+    def _run_search_command(self, cmd: List[str]) -> Optional[str]:
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+        except subprocess.TimeoutExpired:
+            self.logger.error("ripgrep timeout")
+            return None
+        except Exception as e:
+            self.logger.error(f"Błąd ripgrep: {e}")
+            return None
+
+        if result.returncode > 1:
+            self.logger.error(
+                f"ripgrep błąd (code={result.returncode}): {result.stderr.strip()[:200]}"
+            )
+            return None
+        return result.stdout
 
     def search_code(
         self,
@@ -202,41 +295,24 @@ class CodeIndexSkill(BaseSkill):
             self.logger.warning("ripgrep niedostępny, zwracam pustą listę")
             return []
 
-        cmd = [
-            self._RG_BINARY,
-            "--json",
-            f"--context={context_lines}",
-            f"--max-count={max_results}",
-        ]
-        if not case_sensitive:
-            cmd.append("--ignore-case")
-        cmd += self._build_skip_args()
-        if path_glob:
-            cmd += ["--glob", path_glob]
-        cmd += [query, str(self.workspace_root)]
+        cmd = self._build_search_command(
+            query=query,
+            path_glob=path_glob,
+            max_results=max_results,
+            context_lines=context_lines,
+            case_sensitive=case_sensitive,
+        )
+        raw_output = self._run_search_command(cmd)
+        if raw_output is None:
+            return []
 
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=15,
-            )
-            if result.returncode > 1:
-                self.logger.error(
-                    f"ripgrep błąd (code={result.returncode}): {result.stderr.strip()[:200]}"
-                )
-                return []
-            matches = self._parse_rg_json_output(result.stdout, context_lines)
-            return matches[:max_results]
-        except subprocess.TimeoutExpired:
-            self.logger.error("ripgrep timeout")
-            return []
-        except Exception as e:
-            self.logger.error(f"Błąd ripgrep: {e}")
-            return []
+        matches = self._parse_rg_json_output(raw_output, context_lines)
+        return matches[:max_results]
 
     def get_file_symbols(self, file_path: str) -> FileSymbols:
+        return self._collect_file_symbols(file_path)
+
+    def _collect_file_symbols(self, file_path: str) -> FileSymbols:
         """
         Ekstrahuje klasy, funkcje i importy z pliku Python przez AST.
 


### PR DESCRIPTION
## Summary

PR241 dostarcza dwie niezależne, ale powiązane zmiany:

### PR241A – LocalAgentCLI (Python)
Samodzielny lokalny agent CLI działający bez VS Code i bez Copilot, z indeksacją kodu i wykonywaniem komend.

- **`venom_core/execution/skills/code_index_skill.py`** — `CodeIndexSkill`: wyszukiwanie kodu przez ripgrep (`--json`), ekstrakcja symboli przez `ast.parse()`, odczyt fragmentów pliku z kontekstem linii
- **`venom_core/execution/ollama_agent_loop.py`** — `OllamaAgentLoop`: pętla agentowa przez Ollama `/api/chat` z narzędziami (OpenAI tools format), guard `max_iterations=5`, śledzenie wywołań narzędzi i evidence
- **`venom_core/agents/local_agent_cli.py`** — `LocalAgent` + `IntentRouter`: klasyfikacja intencji (GIT_STATUS / CODE_SEARCH / SHELL_EXEC / FILE_OP / GENERAL), fast path dla git status, opt-in shell exec z blokadą komend destrukcyjnych

### PR241B – VS Code extension: agentic loop + full tool suite (TypeScript)
Przebudowa rozszerzenia `tools/vscode-chat-executor` z pojedynczej komendy na pełną pętlę agentową.

**Problem (AS IS):** dwa participanty (`@venom-exec` + `@venom-agent`) robiące to samo — tylko `git status`, bez pętli agentowej, wyniki narzędzi nie wracały do modelu.

**Rozwiązanie (TO BE):** jeden `@venom-agent` z pętlą `sendRequest → LanguageModelToolCallPart → invoke → LanguageModelToolResultPart → repeat`.

Nowe narzędzia LM:
- `venom_git_status` — 12 komend git na allowliście (było 5)
- `venom_search_code` — ripgrep `--json` wrapper, skip dirs, timeout 10s
- `venom_read_file` — fragment pliku z kontekstem linii
- `venom_exec_safe` — opt-in przez `venom.execution.allowExec` (pytest, ruff, mypy, make test-*)
- `run_git_status` — zachowany jako backward-compat alias

## Pliki zmienione

| Plik | Zmiana |
|---|---|
| `venom_core/agents/local_agent_cli.py` | Nowy — 507 linii |
| `venom_core/execution/ollama_agent_loop.py` | Nowy — 328 linii |
| `venom_core/execution/skills/code_index_skill.py` | Nowy — 394 linii |
| `tools/vscode-chat-executor/src/extension.ts` | Przepisany — +572/-207 linii |
| `tools/vscode-chat-executor/package.json` | Zaktualizowany — 1 participant, 5 tools, 3 settings |
| `tests/test_code_index_skill.py` | Nowy — 25 testów |
| `tests/test_ollama_agent_loop.py` | Nowy — 21 testów |
| `tests/test_local_agent_cli.py` | Nowy — 48 testów |
| `scripts/dev/241_local_agent_selftest.py` | Nowy — 6 sond (selftest bez VS Code) |
| `scripts/dev/241b_vscode_extension_probe.py` | Nowy — 8 sond (artefakty extension) |
| `config/testing/test_catalog.json` | +3 wpisy (domain: skills/runtime/agents) |
| `config/pytest-groups/sonar-new-code.txt` | +3 pliki testowe |
| `config/pytest-groups/fast.txt` | +3 pliki testowe |
| `make/runtime.mk` | +4 targety (pr241-selftest, pr241b-probe i ich JSON warianty) |
| `Makefile` | +2 wpisy PHONY |

## Test plan

- [x] `pytest tests/test_code_index_skill.py tests/test_ollama_agent_loop.py tests/test_local_agent_cli.py` → **94/94 PASS**
- [x] `make local-first-pr241-selftest` → **6/6 PASS** (import, intent_router, code_index, git_fast_path, search_via_agent, shell_blocked)
- [x] `make local-first-pr241b-probe` → **8/8 PASS** (build_ok, single_participant, 4 tools, 2 settings, agentic_loop, rg, legacy_alias)
- [x] `make test-catalog-check` → repo=476, catalog=476
- [x] `make test-groups-check` → synced
- [x] `make test-lane-contracts-check` → 2 groups, 364 tests
- [x] `make pr-fast` → **2547 passed, 3 skipped**, coverage 87.28% ≥ 80%, 14 floor checks OK
- [x] `npm run build` (extension) → czysta kompilacja TypeScript bez błędów

## Kryteria akceptacji (z docs_dev)

- [x] `@venom-agent gdzie jest klasa IntegratorAgent` → narzędzie `venom_search_code` zwraca ścieżkę i numer linii
- [x] `@venom-agent sprawdz status git` → `REPO_ROOT=` + blok `## branch`
- [x] `@venom-agent pokaż ostatnie 5 commitów` → `git log --oneline -5` na allowliście
- [x] Brak participanta `@venom-exec` (usunięty z extension.ts i package.json)
- [x] `npm run build` przechodzi bez błędów
- [x] `make pr-fast` przechodzi


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Nowe funkcjonalności

* **Venom Agent dla VS Code** — Nowy asystent z pętlą agentic, obsługą tool-calling oraz integracją z modelem Ollama. Umożliwia wyszukiwanie kodu, czytanie plików, bezpieczne wykonanie komend oraz status Git.
* **Agent CLI** — Samodzielne narzędzie linii poleceń do uruchamiania agenta bez VS Code, z obsługą trybu interaktywnego oraz JSON.
* **Wyszukiwanie kodu i symboli** — Integracja z ripgrep do szybkiego przeszukiwania repozytorium i wyodrębniania struktur kodu.

## Testy i certyfikacja

* **Testy jednostkowe** — Kompletne pokrycie dla nowych komponentów agenta, pętli wykonawczej i umiejętności indeksowania kodu.
* **Probe weryfikacyjne** — Narzędzia do walidacji artefaktów rozszerzenia VS Code i zachowania lokalnego agenta.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpieniak01/Venom/pull/505?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->