### PR TITLE
[codex] fix inspector mermaid smells

### DIFF
--- a/tests/test_model_introspection_analysis_service.py
+++ b/tests/test_model_introspection_analysis_service.py
@@ -495,6 +495,111 @@ async def test_analysis_stream_emits_failed_result_when_response_has_no_body_ite
 
 
 @pytest.mark.asyncio
+async def test_analysis_stream_emits_error_on_stream_consumption_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_snapshot(**kwargs):
+        return _build_snapshot()
+
+    async def fake_stream_simple_chat(_request):
+        return _FakeStreamingResponse(
+            [
+                "event: start\ndata: {}\n\n",
+                'event: content\ndata: {"text":"Slonce to "}\n\n',
+            ]
+        )
+
+    def _boom(**_kwargs):
+        raise RuntimeError("stream consumption exploded")
+
+    monkeypatch.setattr(
+        analysis_service,
+        "build_model_introspection_snapshot",
+        fake_snapshot,
+    )
+    monkeypatch.setattr(analysis_service, "stream_simple_chat", fake_stream_simple_chat)
+    monkeypatch.setattr(analysis_service, "_consume_sse_events", _boom)
+
+    chunks: list[str] = []
+    async for chunk in analysis_service.stream_model_introspection_analysis(
+        prompt="Co to jest slonce?",
+        live_analysis_enabled=True,
+    ):
+        chunks.append(chunk)
+
+    events: list[tuple[str, str]] = []
+    for chunk in chunks:
+        events.extend(analysis_service.parse_sse_events(chunk))
+
+    event_names = [name for name, _ in events]
+    assert event_names[-2:] == ["error", "analysis_done"]
+    done_payload = json.loads(events[-1][1])
+    assert done_payload["status"] == "failed"
+    assert "stream consumption exploded" in done_payload["analysis"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_analysis_raises_when_stream_open_fails_with_non_degraded_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_snapshot(**kwargs):
+        return _build_snapshot()
+
+    async def fake_stream_simple_chat(_request):
+        raise RuntimeError("unexpected bootstrap failure")
+
+    monkeypatch.setattr(
+        analysis_service,
+        "build_model_introspection_snapshot",
+        fake_snapshot,
+    )
+    monkeypatch.setattr(analysis_service, "stream_simple_chat", fake_stream_simple_chat)
+
+    with pytest.raises(RuntimeError, match="unexpected bootstrap failure"):
+        await analysis_service.analyze_model_with_optional_live_run(
+            prompt="Co to jest slonce?",
+            live_analysis_enabled=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_analysis_raises_when_stream_collection_fails_with_non_degraded_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_snapshot(**kwargs):
+        return _build_snapshot()
+
+    async def fake_stream_simple_chat(_request):
+        return _FakeStreamingResponse(
+            [
+                "event: start\ndata: {}\n\n",
+                'event: content\ndata: {"text":"Slonce to "}\n\n',
+            ]
+        )
+
+    async def fake_collect_streaming_response(_response):
+        raise RuntimeError("unexpected collection failure")
+
+    monkeypatch.setattr(
+        analysis_service,
+        "build_model_introspection_snapshot",
+        fake_snapshot,
+    )
+    monkeypatch.setattr(analysis_service, "stream_simple_chat", fake_stream_simple_chat)
+    monkeypatch.setattr(
+        analysis_service,
+        "_collect_streaming_response",
+        fake_collect_streaming_response,
+    )
+
+    with pytest.raises(RuntimeError, match="unexpected collection failure"):
+        await analysis_service.analyze_model_with_optional_live_run(
+            prompt="Co to jest slonce?",
+            live_analysis_enabled=True,
+        )
+
+
+@pytest.mark.asyncio
 async def test_analysis_stream_maps_traffic_control_degraded_to_skipped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/venom_core/services/model_introspection_analysis_service.py
+++ b/venom_core/services/model_introspection_analysis_service.py
@@ -2721,11 +2721,9 @@ async def stream_model_introspection_analysis(
             response_text="".join(content_parts),
         )
         if error_message is not None:
-            yield (
-                _serialize_sse_event(
-                    "error",
-                    {"code": "analysis_stream_failed", "message": error_message},
-                ),
+            yield _serialize_sse_event(
+                "error",
+                {"code": "analysis_stream_failed", "message": error_message},
             )
         yield _serialize_sse_event("analysis_done", done_payload)
         return

--- a/web-next/app/inspector/use-inspector-state.ts
+++ b/web-next/app/inspector/use-inspector-state.ts
@@ -41,7 +41,7 @@ function serializeMermaidError(error: unknown): string {
     }
     return "[Mermaid error object]";
   }
-  return "unknown Mermaid render failure";
+  return error == null ? "unknown Mermaid render failure" : String(error);
 }
 
 async function fetchFlowTraceWithTimeout(requestId: string, timeoutMs: number) {

--- a/web-next/app/inspector/use-inspector-state.ts
+++ b/web-next/app/inspector/use-inspector-state.ts
@@ -39,8 +39,9 @@ function serializeMermaidError(error: unknown): string {
     } catch {
       return "[unserializable Mermaid error object]";
     }
+    return "[Mermaid error object]";
   }
-  return String(error ?? "unknown Mermaid render failure");
+  return "unknown Mermaid render failure";
 }
 
 async function fetchFlowTraceWithTimeout(requestId: string, timeoutMs: number) {

--- a/web-next/app/inspector/use-inspector-state.ts
+++ b/web-next/app/inspector/use-inspector-state.ts
@@ -41,7 +41,20 @@ function serializeMermaidError(error: unknown): string {
     }
     return "[Mermaid error object]";
   }
-  return error == null ? "unknown Mermaid render failure" : String(error);
+  if (error == null) {
+    return "unknown Mermaid render failure";
+  }
+  switch (typeof error) {
+    case "string":
+      return error;
+    case "number":
+    case "boolean":
+    case "bigint":
+    case "symbol":
+      return String(error);
+    default:
+      return "unknown Mermaid render failure";
+  }
 }
 
 async function fetchFlowTraceWithTimeout(requestId: string, timeoutMs: number) {

--- a/web-next/hooks/use-api.ts
+++ b/web-next/hooks/use-api.ts
@@ -111,7 +111,7 @@ function ensureEntry<T>(key: string, fetcher: () => Promise<T>, interval: number
     listeners: new Set(),
     fetching: false,
   };
-  pollingRegistry.set(key, entry as PollingEntry<unknown>);
+  pollingRegistry.set(key, entry);
   triggerFetch(entry);
   return entry;
 }


### PR DESCRIPTION
## What changed
- Hardened Mermaid error serialization in `web-next/app/inspector/use-inspector-state.ts` so object-shaped failures no longer degrade into `[object Object]`.
- Removed a redundant type assertion in `web-next/hooks/use-api.ts` that Sonar flagged as unnecessary.

## Why
- Inspector error messages need to stay readable when Mermaid rendering fails, especially for debugging and support.
- The extra cast in `use-api.ts` did not add safety and only added noise.

## Impact
- Inspector fallback errors are now stable, human-readable, and easier to diagnose.
- The polling hook is simpler and cleaner for static analysis.

## Validation
- `source .venv/bin/activate && make pr-fast`
- Result: `4522 passed, 4 skipped`
- Coverage: `No coverable changed lines found (after exclusions).`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Ulepszono obsługę błędów podczas analizy modeli ze strumieniowaniem danych, zapewniając prawidłową emisję zdarzeń błędu i statusu
  * Poprawiono wyświetlanie komunikatów błędów z edytora diagramów poprzez lepsze rozpoznawanie i serializację różnych typów błędów

* **Tests**
  * Dodano zestawu testów weryfikujących obsługę błędów SSE w serwisie analizy modeli

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpieniak01/Venom/pull/507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->