### PR TITLE
PR245: complete runtime unification phases (F1-F5)

### DIFF
--- a/services/multi_runtime/components.py
+++ b/services/multi_runtime/components.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import importlib.util
-import os
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
+
+from .runtime_config import read_config_str
 
 
 @dataclass(slots=True)
@@ -35,7 +36,7 @@ def _module_available(module_name: str) -> bool:
 
 
 def _resolve_tts_status() -> tuple[bool, str, str | None]:
-    configured_path = str(os.getenv("TTS_MODEL_PATH", "")).strip()
+    configured_path = read_config_str("TTS_MODEL_PATH", "")
     if configured_path:
         path = Path(configured_path)
         if path.exists():

--- a/services/multi_runtime/main.py
+++ b/services/multi_runtime/main.py
@@ -77,10 +77,69 @@ from .schemas import (
 logger = logging.getLogger(__name__)
 
 
-def _read_positive_int_env(*names: str, default: int) -> int:
+_BOOTSTRAP_CONFIG_SNAPSHOT: dict[str, str] = {}
+
+
+def _bootstrap_config_snapshot_value(name: str) -> str:
+    raw = getattr(SETTINGS, name, None)
+    if raw is None or str(raw).strip() == "":
+        raw = os.environ.get(name)
+    if raw is None:
+        return ""
+    return str(raw).strip()
+
+
+def _refresh_bootstrap_config_snapshot() -> None:
+    tracked_names = (
+        "GEMMA4_AUDIO_PROBE_TIMEOUT_SECONDS",
+        "GEMMA4_AUDIO_PROBE_MAX_PROMPT_TOKENS",
+        "GEMMA4_AUDIO_PROBE_MAX_LAYERS",
+        "GEMMA4_AUDIO_PROBE_MAX_TOP_K",
+        "GEMMA4_AUDIO_PROBE_HIDDEN_SLICE",
+        "GEMMA4_AUDIO_PROBE_ENABLED",
+        "VENOM_INTROSPECTION_PROBE_MAX_CONCURRENCY",
+        "GEMMA4_AUDIO_PROBE_MAX_CONCURRENCY",
+        "VENOM_INTROSPECTION_PROBE_EXECUTOR_WORKERS",
+        "GEMMA4_AUDIO_PROBE_EXECUTOR_WORKERS",
+        "GEMMA4_AUDIO_PRECISION",
+        "GEMMA4_AUDIO_QUANTIZATION_BACKEND",
+        "GEMMA4_AUDIO_DEVICE_TARGET",
+        "GEMMA4_AUDIO_CACHE_IMPLEMENTATION",
+        "GEMMA4_AUDIO_STARTUP_PROFILE",
+        "GEMMA4_AUDIO_MODEL_ID",
+        "GEMMA4_AUDIO_CACHE_DIR",
+        "GEMMA4_AUDIO_DEVICE",
+        "GEMMA4_AUDIO_MAX_NEW_TOKENS",
+        "GEMMA4_AUDIO_IMAGE_ALLOWED_HOSTS",
+        "GEMMA4_AUDIO_IMAGE_INPUT_DIR",
+        "GEMMA4_CORS_ORIGINS",
+        "GEMMA4_AUDIO_HOST",
+        "GEMMA4_AUDIO_PORT",
+        "GEMMA4_AUDIO_LOG_PATH",
+    )
+    for name in tracked_names:
+        _BOOTSTRAP_CONFIG_SNAPSHOT[name] = _bootstrap_config_snapshot_value(name)
+
+
+_refresh_bootstrap_config_snapshot()
+
+
+def _read_config_str(name: str, default: str = "") -> str:
+    text = _BOOTSTRAP_CONFIG_SNAPSHOT.get(name, "")
+    if not text:
+        text = str(os.environ.get(name, "")).strip()
+    return text or default
+
+
+def _read_config_bool(name: str, default: bool = False) -> bool:
+    raw = _read_config_str(name, "1" if default else "0").lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _read_positive_int_config(*names: str, default: int) -> int:
     for name in names:
-        raw = os.getenv(name)
-        if raw is None:
+        raw = _read_config_str(name, "")
+        if not raw:
             continue
         try:
             parsed = int(raw)
@@ -91,10 +150,10 @@ def _read_positive_int_env(*names: str, default: int) -> int:
     return default
 
 
-def _read_positive_float_env(*names: str, default: float) -> float:
+def _read_positive_float_config(*names: str, default: float) -> float:
     for name in names:
-        raw = os.getenv(name)
-        if raw is None:
+        raw = _read_config_str(name, "")
+        if not raw:
             continue
         try:
             parsed = float(raw)
@@ -105,38 +164,33 @@ def _read_positive_float_env(*names: str, default: float) -> float:
     return default
 
 
-_PROBE_TIMEOUT_SECONDS = _read_positive_float_env(
+_PROBE_TIMEOUT_SECONDS = _read_positive_float_config(
     "GEMMA4_AUDIO_PROBE_TIMEOUT_SECONDS",
     default=20.0,
 )
-_PROBE_MAX_PROMPT_TOKENS = _read_positive_int_env(
+_PROBE_MAX_PROMPT_TOKENS = _read_positive_int_config(
     "GEMMA4_AUDIO_PROBE_MAX_PROMPT_TOKENS",
     default=1024,
 )
-_PROBE_MAX_LAYERS = _read_positive_int_env(
+_PROBE_MAX_LAYERS = _read_positive_int_config(
     "GEMMA4_AUDIO_PROBE_MAX_LAYERS",
     default=8,
 )
-_PROBE_MAX_TOP_K = _read_positive_int_env(
+_PROBE_MAX_TOP_K = _read_positive_int_config(
     "GEMMA4_AUDIO_PROBE_MAX_TOP_K",
     default=32,
 )
-_PROBE_HIDDEN_SLICE = _read_positive_int_env(
+_PROBE_HIDDEN_SLICE = _read_positive_int_config(
     "GEMMA4_AUDIO_PROBE_HIDDEN_SLICE",
     default=16,
 )
-_PROBE_ENABLED = str(os.getenv("GEMMA4_AUDIO_PROBE_ENABLED", "0")).strip().lower() in {
-    "1",
-    "true",
-    "yes",
-    "on",
-}
-_PROBE_MAX_CONCURRENCY = _read_positive_int_env(
+_PROBE_ENABLED = _read_config_bool("GEMMA4_AUDIO_PROBE_ENABLED", default=False)
+_PROBE_MAX_CONCURRENCY = _read_positive_int_config(
     "VENOM_INTROSPECTION_PROBE_MAX_CONCURRENCY",
     "GEMMA4_AUDIO_PROBE_MAX_CONCURRENCY",
     default=2,
 )
-_PROBE_EXECUTOR_WORKERS = _read_positive_int_env(
+_PROBE_EXECUTOR_WORKERS = _read_positive_int_config(
     "VENOM_INTROSPECTION_PROBE_EXECUTOR_WORKERS",
     "GEMMA4_AUDIO_PROBE_EXECUTOR_WORKERS",
     default=_PROBE_MAX_CONCURRENCY,
@@ -189,12 +243,12 @@ def _resolve_startup_runtime_params() -> dict[str, object]:
     2. Optional startup profile override (safe_int4) when explicitly enabled.
     3. Defaults (auto/no quant/auto).
     """
-    precision = str(os.getenv("GEMMA4_AUDIO_PRECISION", "")).strip().lower()
-    quantization_backend = (
-        str(os.getenv("GEMMA4_AUDIO_QUANTIZATION_BACKEND", "")).strip().lower()
-    )
-    device_target = str(os.getenv("GEMMA4_AUDIO_DEVICE_TARGET", "")).strip().lower()
-    cache_impl = str(os.getenv("GEMMA4_AUDIO_CACHE_IMPLEMENTATION", "")).strip().lower()
+    precision = _read_config_str("GEMMA4_AUDIO_PRECISION", "").lower()
+    quantization_backend = _read_config_str(
+        "GEMMA4_AUDIO_QUANTIZATION_BACKEND", ""
+    ).lower()
+    device_target = _read_config_str("GEMMA4_AUDIO_DEVICE_TARGET", "").lower()
+    cache_impl = _read_config_str("GEMMA4_AUDIO_CACHE_IMPLEMENTATION", "").lower()
 
     if not precision:
         precision = "auto"
@@ -209,9 +263,9 @@ def _resolve_startup_runtime_params() -> dict[str, object]:
         cache_impl = ""
 
     # Optional startup profile: explicitly opt-in, does not redefine "auto".
-    startup_profile = (
-        str(os.getenv("GEMMA4_AUDIO_STARTUP_PROFILE", "default")).strip().lower()
-    )
+    startup_profile = _read_config_str(
+        "GEMMA4_AUDIO_STARTUP_PROFILE", "default"
+    ).lower()
     if (
         startup_profile == "safe_int4"
         and precision == "auto"
@@ -309,10 +363,10 @@ async def initialize_daemon(
 
 
 async def _startup_model_loader() -> None:
-    model_id = os.getenv("GEMMA4_AUDIO_MODEL_ID", "google/gemma-4-E2B-it")
-    cache_dir = os.getenv("GEMMA4_AUDIO_CACHE_DIR", "models_cache/hf")
-    device = os.getenv("GEMMA4_AUDIO_DEVICE", "auto")
-    max_tokens = int(os.getenv("GEMMA4_AUDIO_MAX_NEW_TOKENS", "128"))
+    model_id = _read_config_str("GEMMA4_AUDIO_MODEL_ID", "google/gemma-4-E2B-it")
+    cache_dir = _read_config_str("GEMMA4_AUDIO_CACHE_DIR", "models_cache/hf")
+    device = _read_config_str("GEMMA4_AUDIO_DEVICE", "auto")
+    max_tokens = _read_positive_int_config("GEMMA4_AUDIO_MAX_NEW_TOKENS", default=128)
     await initialize_daemon(model_id, cache_dir, device, max_tokens)
 
 
@@ -392,7 +446,7 @@ def _validate_image_url(url: str) -> None:
     if _is_private_or_local_host(parsed.hostname):
         raise ValueError("Local/private hosts are not allowed for image URLs")
 
-    raw_allowed_hosts = os.getenv("GEMMA4_AUDIO_IMAGE_ALLOWED_HOSTS", "").strip()
+    raw_allowed_hosts = _read_config_str("GEMMA4_AUDIO_IMAGE_ALLOWED_HOSTS", "")
     if not raw_allowed_hosts:
         return
 
@@ -416,7 +470,7 @@ async def _image_from_url(url: str) -> Image.Image:
 
 
 def _image_from_path(path: str) -> Image.Image:
-    raw_allowed_dir = os.getenv("GEMMA4_AUDIO_IMAGE_INPUT_DIR", "").strip()
+    raw_allowed_dir = _read_config_str("GEMMA4_AUDIO_IMAGE_INPUT_DIR", "")
     if not raw_allowed_dir:
         raise ValueError("Local image path loading is disabled by policy")
     allowed_root = Path(raw_allowed_dir).resolve()
@@ -443,7 +497,13 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=os.getenv("GEMMA4_CORS_ORIGINS", "http://localhost:3000").split(","),
+    allow_origins=[
+        origin.strip()
+        for origin in _read_config_str(
+            "GEMMA4_CORS_ORIGINS", "http://localhost:3000"
+        ).split(",")
+        if origin.strip()
+    ],
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -1839,7 +1899,9 @@ def run_server(
 
 
 if __name__ == "__main__":
-    host = os.getenv("GEMMA4_AUDIO_HOST", "127.0.0.1")
-    port = int(os.getenv("GEMMA4_AUDIO_PORT", "8014"))
-    log_file = os.getenv("GEMMA4_AUDIO_LOG_PATH", "logs/gemma4_audio_service.log")
+    host = _read_config_str("GEMMA4_AUDIO_HOST", "127.0.0.1")
+    port = _read_positive_int_config("GEMMA4_AUDIO_PORT", default=8014)
+    log_file = _read_config_str(
+        "GEMMA4_AUDIO_LOG_PATH", "logs/gemma4_audio_service.log"
+    )
     run_server(host, port, log_file)

--- a/services/multi_runtime/policies.py
+++ b/services/multi_runtime/policies.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from typing import Any, Literal
+
+from .runtime_config import read_config_int
 
 ExecutionMode = Literal["balanced", "vision_priority", "voice_priority"]
 ImageStrategy = Literal["vlm_only", "ocr_first", "hybrid"]
@@ -17,15 +18,10 @@ _ECONOMY_VRAM_THRESHOLD_DEFAULT = 2048
 
 
 def _economy_vram_threshold() -> int:
-    try:
-        return int(
-            os.getenv(
-                "MULTI_RUNTIME_ECONOMY_VRAM_THRESHOLD_MB",
-                _ECONOMY_VRAM_THRESHOLD_DEFAULT,
-            )
-        )
-    except (ValueError, TypeError):
-        return _ECONOMY_VRAM_THRESHOLD_DEFAULT
+    return read_config_int(
+        "MULTI_RUNTIME_ECONOMY_VRAM_THRESHOLD_MB",
+        _ECONOMY_VRAM_THRESHOLD_DEFAULT,
+    )
 
 
 @dataclass(slots=True)

--- a/services/multi_runtime/policies.py
+++ b/services/multi_runtime/policies.py
@@ -18,10 +18,13 @@ _ECONOMY_VRAM_THRESHOLD_DEFAULT = 2048
 
 
 def _economy_vram_threshold() -> int:
-    return read_config_int(
+    threshold = read_config_int(
         "MULTI_RUNTIME_ECONOMY_VRAM_THRESHOLD_MB",
         _ECONOMY_VRAM_THRESHOLD_DEFAULT,
     )
+    if threshold <= 0:
+        return _ECONOMY_VRAM_THRESHOLD_DEFAULT
+    return threshold
 
 
 @dataclass(slots=True)

--- a/services/multi_runtime/runtime_config.py
+++ b/services/multi_runtime/runtime_config.py
@@ -1,0 +1,27 @@
+"""Shared runtime config reads for multi_runtime service modules."""
+
+from __future__ import annotations
+
+import os
+
+from venom_core.config import SETTINGS
+
+
+def read_config_str(name: str, default: str = "") -> str:
+    raw = getattr(SETTINGS, name, None)
+    if raw is None or str(raw).strip() == "":
+        raw = os.environ.get(name)
+    if raw is None:
+        return default
+    text = str(raw).strip()
+    return text or default
+
+
+def read_config_int(name: str, default: int) -> int:
+    raw = read_config_str(name, "")
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default

--- a/services/multi_runtime/stages/audio_output.py
+++ b/services/multi_runtime/stages/audio_output.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import base64
 import io
-import os
 import re
 import wave
 from pathlib import Path
 from time import perf_counter
 from typing import Any
+
+from services.multi_runtime.runtime_config import read_config_str
 
 from .base import StageContext
 
@@ -19,7 +20,7 @@ _PIPER_VOICE_CACHE: dict[str, Any] = {}
 
 
 def _find_tts_model_path() -> Path | None:
-    configured = str(os.getenv("TTS_MODEL_PATH", "")).strip()
+    configured = read_config_str("TTS_MODEL_PATH", "")
     if configured:
         p = Path(configured)
         return p if p.exists() else None

--- a/services/multi_runtime/stages/image_preprocessor.py
+++ b/services/multi_runtime/stages/image_preprocessor.py
@@ -14,7 +14,10 @@ _MAX_DIM_DEFAULT = 1024
 
 
 def _max_image_dim() -> int:
-    return read_config_int("MULTI_RUNTIME_IMAGE_MAX_DIM", _MAX_DIM_DEFAULT)
+    max_dim = read_config_int("MULTI_RUNTIME_IMAGE_MAX_DIM", _MAX_DIM_DEFAULT)
+    if max_dim <= 0:
+        return _MAX_DIM_DEFAULT
+    return max_dim
 
 
 def _normalize_image(img: Image.Image, max_dim: int) -> tuple[Image.Image, str]:

--- a/services/multi_runtime/stages/image_preprocessor.py
+++ b/services/multi_runtime/stages/image_preprocessor.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-import os
 from time import perf_counter
 
 from PIL import Image, ImageOps
+
+from services.multi_runtime.runtime_config import read_config_int
 
 from .base import StageContext
 
@@ -13,10 +14,7 @@ _MAX_DIM_DEFAULT = 1024
 
 
 def _max_image_dim() -> int:
-    try:
-        return int(os.getenv("MULTI_RUNTIME_IMAGE_MAX_DIM", _MAX_DIM_DEFAULT))
-    except (ValueError, TypeError):
-        return _MAX_DIM_DEFAULT
+    return read_config_int("MULTI_RUNTIME_IMAGE_MAX_DIM", _MAX_DIM_DEFAULT)
 
 
 def _normalize_image(img: Image.Image, max_dim: int) -> tuple[Image.Image, str]:

--- a/tests/test_audio_stream_handler_roi.py
+++ b/tests/test_audio_stream_handler_roi.py
@@ -10,6 +10,11 @@ import pytest
 
 import venom_core.api.audio_stream as audio_stream_mod
 from venom_core.api.audio_stream import AudioStreamHandler, get_audio_stream_handler
+from venom_core.utils.mode_contracts import (
+    MODE_CONTRACTS,
+    VOICE_EXECUTION_CONTEXT,
+    VOICE_HISTORY_SCOPE,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -79,6 +84,7 @@ def test_get_status_reports_basic_state():
     assert status["stt_backend"] is None
     assert status["tts_backend"] is None
     assert "dependencies" in status
+    assert status["mode_contracts"] == MODE_CONTRACTS
 
 
 def test_get_status_reports_loaded_backends_and_dependencies(monkeypatch):
@@ -131,7 +137,7 @@ def test_coerce_str_returns_default_for_non_string_or_blank():
     assert audio_stream_mod._coerce_str(" value ", "fallback") == "value"
 
 
-def test_gemma4_audio_voice_flags_reflect_settings(monkeypatch):
+def test_multi_runtime_voice_flags_reflect_settings(monkeypatch):
     monkeypatch.setattr(
         audio_stream_mod.SETTINGS,
         "GEMMA4_AUDIO_REASONING_SUMMARY_ENABLED",
@@ -151,7 +157,7 @@ def test_gemma4_audio_voice_flags_reflect_settings(monkeypatch):
         raising=False,
     )
 
-    flags = audio_stream_mod._gemma4_audio_voice_flags()
+    flags = audio_stream_mod._multi_runtime_voice_flags()
 
     assert flags == {
         "reasoning_summary_enabled": True,
@@ -854,14 +860,14 @@ def test_build_voice_session_record_includes_runtime_fields(tmp_path):
             "mime_type": "audio/webm",
             "voice_mode": "summary",
             "timings_ms": {"stt_ms": 12.0},
-            "runtime": {"provider": "gemma4_audio"},
-            "pipeline_id": "gemma4_audio_piper",
-            "audio_runtime_provider": "gemma4_audio",
+            "runtime": {"provider": "multi_runtime"},
+            "pipeline_id": "multi_runtime_piper",
+            "audio_runtime_provider": "multi_runtime",
             "audio_runtime_model": "google/gemma-4-E2B-it",
             "audio_input_status": "verified",
             "fallback_reason": None,
             "native_audio_ms": 111.0,
-            "runtime_log_path": "logs/gemma4_audio_service.log",
+            "runtime_log_path": "logs/multi_runtime_service.log",
             "transcription": "piec razy piec",
             "response_text": "25",
         },
@@ -869,12 +875,12 @@ def test_build_voice_session_record_includes_runtime_fields(tmp_path):
 
     assert record["session_id"] == "session-a"
     assert record["voice_mode"] == "summary"
-    assert record["runtime"] == {"provider": "gemma4_audio"}
-    assert record["pipeline_id"] == "gemma4_audio_piper"
-    assert record["audio_runtime_provider"] == "gemma4_audio"
+    assert record["runtime"] == {"provider": "multi_runtime"}
+    assert record["pipeline_id"] == "multi_runtime_piper"
+    assert record["audio_runtime_provider"] == "multi_runtime"
     assert record["audio_runtime_model"] == "google/gemma-4-E2B-it"
     assert record["audio_input_status"] == "verified"
-    assert record["runtime_log_path"] == "logs/gemma4_audio_service.log"
+    assert record["runtime_log_path"] == "logs/multi_runtime_service.log"
     assert record["transcription"] == "piec razy piec"
 
 
@@ -895,7 +901,7 @@ def test_build_voice_session_insights_payload_delegates_to_voice_metadata(monkey
         transcript="ile to jest dwa razy dwa",
         response="dwa razy dwa to cztery",
         voice_mode="summary",
-        pipeline_id="gemma4_audio_piper",
+        pipeline_id="multi_runtime_piper",
         reasoning_summary_enabled=True,
         emotion_detection_enabled=True,
         emotion_response_style_enabled=False,
@@ -907,7 +913,7 @@ def test_build_voice_session_insights_payload_delegates_to_voice_metadata(monkey
         "transcript": "ile to jest dwa razy dwa",
         "response": "dwa razy dwa to cztery",
         "voice_mode": "summary",
-        "pipeline_id": "gemma4_audio_piper",
+        "pipeline_id": "multi_runtime_piper",
         "reasoning_summary_enabled": True,
         "emotion_detection_enabled": True,
         "emotion_response_style_enabled": False,
@@ -1007,7 +1013,7 @@ def test_build_runtime_metadata_and_tts_sample_rate(monkeypatch):
     assert handler._get_tts_sample_rate() == 22050
 
 
-def test_gemma4_audio_helper_urls_and_selection(monkeypatch):
+def test_multi_runtime_helper_urls_and_selection(monkeypatch):
     """Gemma4 helper URLs should normalize /v1 origin and selected state."""
     handler = _make_handler()
 
@@ -1024,23 +1030,23 @@ def test_gemma4_audio_helper_urls_and_selection(monkeypatch):
         audio_stream_mod.SETTINGS, "ACTIVE_LLM_SERVER", "gemma4_audio", raising=False
     )
 
-    assert handler._gemma4_audio_service_origin() == "http://localhost:8014"
-    assert handler._gemma4_audio_respond_url() == "http://localhost:8014/v1/respond"
-    assert handler._gemma4_audio_health_url() == "http://localhost:8014/health"
-    assert handler._gemma4_audio_runtime_selected() is True
+    assert handler._multi_runtime_service_origin() == "http://localhost:8014"
+    assert handler._multi_runtime_respond_url() == "http://localhost:8014/v1/respond"
+    assert handler._multi_runtime_health_url() == "http://localhost:8014/health"
+    assert handler._multi_runtime_runtime_selected() is True
 
     monkeypatch.setattr(
         audio_stream_mod.SETTINGS, "ACTIVE_LLM_SERVER", "ollama", raising=False
     )
-    assert handler._gemma4_audio_runtime_selected() is False
+    assert handler._multi_runtime_runtime_selected() is False
 
 
 @pytest.mark.asyncio
-async def test_gemma4_audio_health_ok_handles_success_and_failures(monkeypatch):
+async def test_multi_runtime_health_ok_handles_success_and_failures(monkeypatch):
     """Health check should accept ok/warming and reject invalid responses."""
     handler = _make_handler()
     monkeypatch.setattr(
-        handler, "_gemma4_audio_health_url", lambda: "http://runtime/health"
+        handler, "_multi_runtime_health_url", lambda: "http://runtime/health"
     )
 
     responses = iter(
@@ -1065,15 +1071,15 @@ async def test_gemma4_audio_health_ok_handles_success_and_failures(monkeypatch):
 
     monkeypatch.setattr(audio_stream_mod.httpx, "AsyncClient", _AsyncClient)
 
-    assert await handler._gemma4_audio_health_ok() is True
-    assert await handler._gemma4_audio_health_ok() is False
+    assert await handler._multi_runtime_health_ok() is True
+    assert await handler._multi_runtime_health_ok() is False
 
-    monkeypatch.setattr(handler, "_gemma4_audio_health_url", lambda: "")
-    assert await handler._gemma4_audio_health_ok() is False
+    monkeypatch.setattr(handler, "_multi_runtime_health_url", lambda: "")
+    assert await handler._multi_runtime_health_ok() is False
 
 
 @pytest.mark.asyncio
-async def test_invoke_gemma4_audio_runtime_builds_request_and_validates_response(
+async def test_invoke_multi_runtime_builds_request_and_validates_response(
     monkeypatch, tmp_path
 ):
     """Gemma4 runtime request should send multipart payload and parse text result."""
@@ -1100,7 +1106,7 @@ async def test_invoke_gemma4_audio_runtime_builds_request_and_validates_response
         raising=False,
     )
     monkeypatch.setattr(
-        handler, "_gemma4_audio_respond_url", lambda: "http://runtime/v1/respond"
+        handler, "_multi_runtime_respond_url", lambda: "http://runtime/v1/respond"
     )
     monkeypatch.setattr(
         audio_stream_mod.Path,
@@ -1163,7 +1169,7 @@ async def test_invoke_gemma4_audio_runtime_builds_request_and_validates_response
 
     monkeypatch.setattr(audio_stream_mod.httpx, "AsyncClient", _AsyncClient)
 
-    result = await handler._invoke_gemma4_audio_runtime(wav_path, 17)
+    result = await handler._invoke_multi_runtime(wav_path, 17)
 
     assert result["text"] == "25"
     assert result["response_text"] == "25"
@@ -1183,7 +1189,7 @@ async def test_invoke_gemma4_audio_runtime_builds_request_and_validates_response
 
 
 @pytest.mark.asyncio
-async def test_invoke_gemma4_audio_runtime_prefers_alternate_text_fields(
+async def test_invoke_multi_runtime_prefers_alternate_text_fields(
     monkeypatch, tmp_path
 ):
     """Gemma4 runtime should accept alternate response text fields."""
@@ -1191,7 +1197,7 @@ async def test_invoke_gemma4_audio_runtime_prefers_alternate_text_fields(
     wav_path = tmp_path / "recording.wav"
     wav_path.write_bytes(b"RIFF....WAVEfmt ")
     monkeypatch.setattr(
-        handler, "_gemma4_audio_respond_url", lambda: "http://runtime/v1/respond"
+        handler, "_multi_runtime_respond_url", lambda: "http://runtime/v1/respond"
     )
 
     class _AsyncBinaryFile:
@@ -1233,14 +1239,14 @@ async def test_invoke_gemma4_audio_runtime_prefers_alternate_text_fields(
 
     monkeypatch.setattr(audio_stream_mod.httpx, "AsyncClient", _AsyncClient)
 
-    result = await handler._invoke_gemma4_audio_runtime(wav_path, 17)
+    result = await handler._invoke_multi_runtime(wav_path, 17)
 
     assert result["text"] == "42"
     assert result["response_text"] == "42"
 
 
 @pytest.mark.asyncio
-async def test_invoke_gemma4_audio_runtime_uses_generated_text_when_response_empty(
+async def test_invoke_multi_runtime_uses_generated_text_when_response_empty(
     monkeypatch, tmp_path
 ):
     """Fallback to generated_text when response_text is blank."""
@@ -1248,7 +1254,7 @@ async def test_invoke_gemma4_audio_runtime_uses_generated_text_when_response_emp
     wav_path = tmp_path / "recording.wav"
     wav_path.write_bytes(b"RIFF....WAVEfmt ")
     monkeypatch.setattr(
-        handler, "_gemma4_audio_respond_url", lambda: "http://runtime/v1/respond"
+        handler, "_multi_runtime_respond_url", lambda: "http://runtime/v1/respond"
     )
 
     class _AsyncBinaryFile:
@@ -1286,12 +1292,12 @@ async def test_invoke_gemma4_audio_runtime_uses_generated_text_when_response_emp
 
     monkeypatch.setattr(audio_stream_mod.httpx, "AsyncClient", _AsyncClient)
 
-    result = await handler._invoke_gemma4_audio_runtime(wav_path, 17)
+    result = await handler._invoke_multi_runtime(wav_path, 17)
     assert result["text"] == "41"
 
 
 @pytest.mark.asyncio
-async def test_invoke_gemma4_audio_runtime_uses_message_content_when_other_fields_empty(
+async def test_invoke_multi_runtime_uses_message_content_when_other_fields_empty(
     monkeypatch, tmp_path
 ):
     """Fallback to message.content when text/response_text/generated_text are blank."""
@@ -1299,7 +1305,7 @@ async def test_invoke_gemma4_audio_runtime_uses_message_content_when_other_field
     wav_path = tmp_path / "recording.wav"
     wav_path.write_bytes(b"RIFF....WAVEfmt ")
     monkeypatch.setattr(
-        handler, "_gemma4_audio_respond_url", lambda: "http://runtime/v1/respond"
+        handler, "_multi_runtime_respond_url", lambda: "http://runtime/v1/respond"
     )
 
     class _AsyncBinaryFile:
@@ -1342,12 +1348,12 @@ async def test_invoke_gemma4_audio_runtime_uses_message_content_when_other_field
 
     monkeypatch.setattr(audio_stream_mod.httpx, "AsyncClient", _AsyncClient)
 
-    result = await handler._invoke_gemma4_audio_runtime(wav_path, 17)
+    result = await handler._invoke_multi_runtime(wav_path, 17)
     assert result["text"] == "40"
 
 
 @pytest.mark.asyncio
-async def test_invoke_gemma4_audio_runtime_raises_for_http_and_empty_text(
+async def test_invoke_multi_runtime_raises_for_http_and_empty_text(
     monkeypatch, tmp_path
 ):
     """Gemma4 runtime should reject HTTP errors and empty text payloads."""
@@ -1355,7 +1361,7 @@ async def test_invoke_gemma4_audio_runtime_raises_for_http_and_empty_text(
     wav_path = tmp_path / "recording.wav"
     wav_path.write_bytes(b"RIFF....WAVEfmt ")
     monkeypatch.setattr(
-        handler, "_gemma4_audio_respond_url", lambda: "http://runtime/v1/respond"
+        handler, "_multi_runtime_respond_url", lambda: "http://runtime/v1/respond"
     )
 
     class _HttpErrorClient:
@@ -1374,7 +1380,7 @@ async def test_invoke_gemma4_audio_runtime_raises_for_http_and_empty_text(
     monkeypatch.setattr(audio_stream_mod.httpx, "AsyncClient", _HttpErrorClient)
 
     with pytest.raises(RuntimeError, match="Gemma4 audio runtime HTTP 503: down"):
-        await handler._invoke_gemma4_audio_runtime(wav_path, 7)
+        await handler._invoke_multi_runtime(wav_path, 7)
 
     class _EmptyTextClient(_HttpErrorClient):
         async def post(self, url, data=None, files=None):
@@ -1383,11 +1389,11 @@ async def test_invoke_gemma4_audio_runtime_raises_for_http_and_empty_text(
     monkeypatch.setattr(audio_stream_mod.httpx, "AsyncClient", _EmptyTextClient)
 
     with pytest.raises(RuntimeError, match="returned an empty response"):
-        await handler._invoke_gemma4_audio_runtime(wav_path, 8)
+        await handler._invoke_multi_runtime(wav_path, 8)
 
 
 @pytest.mark.asyncio
-async def test_process_native_gemma4_audio_pipeline_handles_selection_and_fallbacks(
+async def test_process_native_multi_runtime_pipeline_handles_selection_and_fallbacks(
     monkeypatch, tmp_path
 ):
     """Native pipeline should short-circuit cleanly before whisper fallback."""
@@ -1398,23 +1404,23 @@ async def test_process_native_gemma4_audio_pipeline_handles_selection_and_fallba
     wav_path.write_bytes(b"wav")
     timings_ms = {}
 
-    monkeypatch.setattr(handler, "_gemma4_audio_runtime_selected", lambda: False)
+    monkeypatch.setattr(handler, "_multi_runtime_runtime_selected", lambda: False)
     assert (
-        await handler._process_native_gemma4_audio_pipeline(
+        await handler._process_native_multi_runtime_pipeline(
             1, session_dir, wav_path, timings_ms, 0.0, MagicMock()
         )
         is False
     )
 
     handler.audio_engine = MagicMock()
-    monkeypatch.setattr(handler, "_gemma4_audio_runtime_selected", lambda: True)
+    monkeypatch.setattr(handler, "_multi_runtime_runtime_selected", lambda: True)
     monkeypatch.setattr(
         handler,
-        "_gemma4_audio_runtime_snapshot",
-        lambda: {"audio_runtime_provider": "gemma4_audio"},
+        "_multi_runtime_runtime_snapshot",
+        lambda: {"audio_runtime_provider": "multi_runtime"},
     )
     monkeypatch.setattr(
-        handler, "_gemma4_audio_health_ok", AsyncMock(return_value=False)
+        handler, "_multi_runtime_health_ok", AsyncMock(return_value=False)
     )
     update_calls = []
     monkeypatch.setattr(
@@ -1426,7 +1432,7 @@ async def test_process_native_gemma4_audio_pipeline_handles_selection_and_fallba
     monkeypatch.setattr(handler, "_connection_voice_mode", lambda _cid: "standard")
 
     assert (
-        await handler._process_native_gemma4_audio_pipeline(
+        await handler._process_native_multi_runtime_pipeline(
             2, session_dir, wav_path, timings_ms, 0.0, MagicMock()
         )
         is False
@@ -1436,7 +1442,7 @@ async def test_process_native_gemma4_audio_pipeline_handles_selection_and_fallba
 
 
 @pytest.mark.asyncio
-async def test_process_native_gemma4_audio_pipeline_success(monkeypatch, tmp_path):
+async def test_process_native_multi_runtime_pipeline_success(monkeypatch, tmp_path):
     """Native pipeline success should update metadata and send TTS response."""
     handler = _make_handler()
     handler.audio_engine = MagicMock()
@@ -1452,18 +1458,18 @@ async def test_process_native_gemma4_audio_pipeline_success(monkeypatch, tmp_pat
     sent_audio = []
     update_calls = []
 
-    monkeypatch.setattr(handler, "_gemma4_audio_runtime_selected", lambda: True)
+    monkeypatch.setattr(handler, "_multi_runtime_runtime_selected", lambda: True)
     monkeypatch.setattr(
         handler,
-        "_gemma4_audio_runtime_snapshot",
-        lambda: {"audio_runtime_provider": "gemma4_audio"},
+        "_multi_runtime_runtime_snapshot",
+        lambda: {"audio_runtime_provider": "multi_runtime"},
     )
     monkeypatch.setattr(
-        handler, "_gemma4_audio_health_ok", AsyncMock(return_value=True)
+        handler, "_multi_runtime_health_ok", AsyncMock(return_value=True)
     )
     monkeypatch.setattr(
         handler,
-        "_invoke_gemma4_audio_runtime",
+        "_invoke_multi_runtime",
         AsyncMock(return_value={"text": "piec razy piec", "response_text": "25"}),
     )
     monkeypatch.setattr(
@@ -1485,7 +1491,7 @@ async def test_process_native_gemma4_audio_pipeline_success(monkeypatch, tmp_pat
     )
     monkeypatch.setattr(handler, "_elapsed_ms", lambda _started: 12.5)
 
-    result = await handler._process_native_gemma4_audio_pipeline(
+    result = await handler._process_native_multi_runtime_pipeline(
         3, session_dir, wav_path, timings_ms, 0.0, MagicMock()
     )
 
@@ -1498,6 +1504,8 @@ async def test_process_native_gemma4_audio_pipeline_success(monkeypatch, tmp_pat
     assert len(sent_audio) == 1
     assert update_calls[0]["pipeline_id"] == "multi_runtime_piper"
     assert update_calls[0]["transcription"] == "piec razy piec"
+    assert update_calls[0]["execution_context"] == VOICE_EXECUTION_CONTEXT
+    assert update_calls[0]["history_scope"] == VOICE_HISTORY_SCOPE
     assert update_calls[1]["pipeline_id"] == "multi_runtime_piper"
 
 

--- a/tests/test_llm_runtime_activation_api.py
+++ b/tests/test_llm_runtime_activation_api.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from venom_core.api.routes import system_llm
+from venom_core.utils.mode_contracts import MODE_CONTRACTS
 
 
 @pytest.fixture
@@ -185,6 +186,7 @@ class TestLlmRuntimeActivationAPI:
                 payload["runtime_switch_policy"]["ownership_token_configured"] is True
             )
             assert payload["last_runtime_switch"]["runtime"] == "multi_runtime"
+            assert payload["mode_contracts"] == MODE_CONTRACTS
 
     def test_get_active_runtime_info_includes_switch_policy_and_last_event(
         self, client
@@ -218,6 +220,7 @@ class TestLlmRuntimeActivationAPI:
 
             response = client.get("/api/v1/system/llm-runtime/active")
             assert response.status_code == 200
+            assert response.json()["mode_contracts"] == MODE_CONTRACTS
             payload = response.json()
             assert payload["runtime_switch_policy"]["allowed_sources"] == [
                 "make_start",

--- a/tests/test_llm_runtime_options_api.py
+++ b/tests/test_llm_runtime_options_api.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from venom_core.api.routes import system_llm
+from venom_core.utils.mode_contracts import MODE_CONTRACTS
 
 
 def _client() -> TestClient:
@@ -195,6 +196,7 @@ def test_resolve_runtime_options_payload_mixed_modes() -> None:
     assert (
         payload["feedback_loop"]["requested_alias"] == "OpenCodeInterpreter-Qwen2.5-7B"
     )
+    assert payload["active"]["mode_contracts"] == MODE_CONTRACTS
 
 
 def test_runtime_options_returns_503_when_llm_controller_missing() -> None:
@@ -444,7 +446,7 @@ async def test_local_models_by_runtime_skips_non_runtime_vllm_entries(
         patch.object(system_llm, "get_active_llm_runtime", return_value=active_runtime),
         patch.object(
             system_llm,
-            "gemma4_audio_available_models",
+            "multi_runtime_available_models",
             side_effect=lambda role="target", settings_obj=None: (
                 ["google/gemma-4-E2B-it"]
                 if role == "target"
@@ -487,7 +489,7 @@ async def test_local_models_by_runtime_reports_unknown_provider_issue(
         patch.object(system_llm, "get_active_llm_runtime", return_value=active_runtime),
         patch.object(
             system_llm,
-            "gemma4_audio_available_models",
+            "multi_runtime_available_models",
             side_effect=lambda role="target", settings_obj=None: (
                 ["google/gemma-4-E2B-it"]
                 if role == "target"
@@ -516,18 +518,18 @@ async def test_local_models_by_runtime_reports_unknown_provider_issue(
     ]
 
 
-def test_gemma4_audio_static_models_returns_target_models() -> None:
+def test_multi_runtime_static_models_returns_target_models() -> None:
     with patch.object(
         system_llm,
-        "gemma4_audio_available_models",
+        "multi_runtime_available_models",
         side_effect=lambda role="target", settings_obj=None: (
             ["google/gemma-4-E2B-it"]
             if role == "target"
             else ["google/gemma-4-E2B-it-assistant"]
         ),
     ):
-        models = system_llm._gemma4_audio_static_models(  # noqa: SLF001
-            active_provider="gemma4_audio",
+        models = system_llm._multi_runtime_static_models(  # noqa: SLF001
+            active_provider="multi_runtime",
             active_model="google/gemma-4-E2B-it",
         )
     ids = [m["id"] for m in models]
@@ -535,53 +537,53 @@ def test_gemma4_audio_static_models_returns_target_models() -> None:
     assert len(models) == 1
 
 
-def test_gemma4_audio_static_models_active_flag() -> None:
+def test_multi_runtime_static_models_active_flag() -> None:
     with patch.object(
         system_llm,
-        "gemma4_audio_available_models",
+        "multi_runtime_available_models",
         side_effect=lambda role="target", settings_obj=None: (
             ["google/gemma-4-E2B-it"]
             if role == "target"
             else ["google/gemma-4-E2B-it-assistant"]
         ),
     ):
-        models = system_llm._gemma4_audio_static_models(  # noqa: SLF001
-            active_provider="gemma4_audio",
+        models = system_llm._multi_runtime_static_models(  # noqa: SLF001
+            active_provider="multi_runtime",
             active_model="google/gemma-4-E2B-it",
         )
     by_id = {m["id"]: m for m in models}
     assert by_id["google/gemma-4-E2B-it"]["active"] is True
 
 
-def test_gemma4_audio_static_models_inactive_when_different_provider() -> None:
+def test_multi_runtime_static_models_inactive_when_different_provider() -> None:
     with patch.object(
         system_llm,
-        "gemma4_audio_available_models",
+        "multi_runtime_available_models",
         side_effect=lambda role="target", settings_obj=None: (
             ["google/gemma-4-E2B-it"]
             if role == "target"
             else ["google/gemma-4-E2B-it-assistant"]
         ),
     ):
-        models = system_llm._gemma4_audio_static_models(  # noqa: SLF001
+        models = system_llm._multi_runtime_static_models(  # noqa: SLF001
             active_provider="ollama",
             active_model="google/gemma-4-E2B-it",
         )
     assert all(not m["active"] for m in models)
 
 
-def test_gemma4_audio_static_models_capabilities() -> None:
+def test_multi_runtime_static_models_capabilities() -> None:
     with patch.object(
         system_llm,
-        "gemma4_audio_available_models",
+        "multi_runtime_available_models",
         side_effect=lambda role="target", settings_obj=None: (
             ["google/gemma-4-E2B-it"]
             if role == "target"
             else ["google/gemma-4-E2B-it-assistant"]
         ),
     ):
-        models = system_llm._gemma4_audio_static_models(  # noqa: SLF001
-            active_provider="gemma4_audio",
+        models = system_llm._multi_runtime_static_models(  # noqa: SLF001
+            active_provider="multi_runtime",
             active_model="",
         )
     for model in models:
@@ -594,17 +596,17 @@ def test_gemma4_audio_static_models_capabilities() -> None:
 
 
 @pytest.mark.asyncio
-async def test_local_models_by_runtime_injects_gemma4_audio_static_models() -> None:
+async def test_local_models_by_runtime_injects_multi_runtime_static_models() -> None:
     from unittest.mock import patch
 
     active_runtime = SimpleNamespace(
-        provider="gemma4_audio", model_name="google/gemma-4-E2B-it"
+        provider="multi_runtime", model_name="google/gemma-4-E2B-it"
     )
     with (
         patch.object(system_llm, "get_active_llm_runtime", return_value=active_runtime),
         patch.object(
             system_llm,
-            "gemma4_audio_available_models",
+            "multi_runtime_available_models",
             side_effect=lambda role="target", settings_obj=None: (
                 ["google/gemma-4-E2B-it"]
                 if role == "target"
@@ -624,17 +626,17 @@ async def test_local_models_by_runtime_injects_gemma4_audio_static_models() -> N
     assert audit == []
 
 
-def test_gemma4_audio_runtime_input_capabilities_present() -> None:
+def test_multi_runtime_input_capabilities_present() -> None:
     with patch.object(
         system_llm,
-        "gemma4_audio_available_models",
+        "multi_runtime_available_models",
         side_effect=lambda role="target", settings_obj=None: (
             ["google/gemma-4-E2B-it"]
             if role == "target"
             else ["google/gemma-4-E2B-it-assistant"]
         ),
     ):
-        info = system_llm._gemma4_audio_runtime_input_capabilities("gemma4_audio")  # noqa: SLF001
+        info = system_llm._multi_runtime_input_capabilities("multi_runtime")  # noqa: SLF001
     assert info["supports_text_input"] is True
     assert info["supports_audio_input"] is True
     assert info["supports_text_output"] is True
@@ -646,17 +648,17 @@ def test_gemma4_audio_runtime_input_capabilities_present() -> None:
     assert "pid_path" in info
 
 
-def test_gemma4_audio_runtime_input_capabilities_empty_for_other_runtimes() -> None:
+def test_multi_runtime_input_capabilities_empty_for_other_runtimes() -> None:
     for runtime in ("ollama", "vllm", "onnx", "openai"):
-        result = system_llm._gemma4_audio_runtime_input_capabilities(runtime)  # noqa: SLF001
+        result = system_llm._multi_runtime_input_capabilities(runtime)  # noqa: SLF001
         assert result == {}, f"Expected empty dict for runtime={runtime}"
 
 
-def test_runtime_target_payload_includes_gemma4_audio_capabilities() -> None:
+def test_runtime_target_payload_includes_multi_runtime_capabilities() -> None:
     from unittest.mock import patch
 
     active_runtime = SimpleNamespace(
-        provider="gemma4_audio", model_name="google/gemma-4-E2B-it"
+        provider="multi_runtime", model_name="google/gemma-4-E2B-it"
     )
     with (
         patch.object(
@@ -669,7 +671,7 @@ def test_runtime_target_payload_includes_gemma4_audio_capabilities() -> None:
         ),
         patch.object(
             system_llm,
-            "gemma4_audio_available_models",
+            "multi_runtime_available_models",
             side_effect=lambda role="target", settings_obj=None: (
                 ["google/gemma-4-E2B-it"]
                 if role == "target"
@@ -678,7 +680,7 @@ def test_runtime_target_payload_includes_gemma4_audio_capabilities() -> None:
         ),
     ):
         payload = system_llm._runtime_target_payload(  # noqa: SLF001
-            runtime_id="gemma4_audio",
+            runtime_id="multi_runtime",
             source_type="local-runtime",
             configured=True,
             available=True,
@@ -715,11 +717,11 @@ def test_runtime_target_payload_no_gemma4_fields_for_other_runtimes() -> None:
     assert "supported_models" not in payload
 
 
-def test_resolve_selected_model_for_switch_gemma4_audio_prefers_request() -> None:
+def test_resolve_selected_model_for_switch_multi_runtime_prefers_request() -> None:
     request = SimpleNamespace(model="google/gemma-4-E2B-it", model_alias="")
     with patch.object(
         system_llm,
-        "gemma4_audio_available_models",
+        "multi_runtime_available_models",
         side_effect=lambda role="target", settings_obj=None: (
             ["google/gemma-4-E2B-it"]
             if role == "target"
@@ -728,7 +730,7 @@ def test_resolve_selected_model_for_switch_gemma4_audio_prefers_request() -> Non
     ):
         selected, key = system_llm._resolve_selected_model_for_switch(  # noqa: SLF001
             request=request,
-            server_name="gemma4_audio",
+            server_name="multi_runtime",
             config={"LAST_MODEL_GEMMA4_AUDIO": "google/gemma-4-E2B-it"},
             models=[],
         )
@@ -736,12 +738,12 @@ def test_resolve_selected_model_for_switch_gemma4_audio_prefers_request() -> Non
     assert key == "LAST_MODEL_GEMMA4_AUDIO"
 
 
-def test_resolve_selected_model_for_switch_gemma4_audio_invalid_request() -> None:
+def test_resolve_selected_model_for_switch_multi_runtime_invalid_request() -> None:
     request = SimpleNamespace(model="google/gemma-4-unknown", model_alias="")
     with (
         patch.object(
             system_llm,
-            "gemma4_audio_available_models",
+            "multi_runtime_available_models",
             side_effect=lambda role="target", settings_obj=None: (
                 ["google/gemma-4-E2B-it"]
                 if role == "target"
@@ -752,7 +754,7 @@ def test_resolve_selected_model_for_switch_gemma4_audio_invalid_request() -> Non
     ):  # noqa: PT011
         system_llm._resolve_selected_model_for_switch(  # noqa: SLF001
             request=request,
-            server_name="gemma4_audio",
+            server_name="multi_runtime",
             config={},
             models=[],
         )

--- a/venom_core/api/audio_stream.py
+++ b/venom_core/api/audio_stream.py
@@ -715,8 +715,9 @@ class AudioStreamHandler:
             "audio_runtime_supports_image": True,
             "audio_runtime_supports_unified_multimodal_respond": True,
             "audio_runtime_runtime_mode": "processor_model",
-            "audio_runtime_image_token_budget": int(
-                _multi_runtime_setting("GEMMA4_AUDIO_IMAGE_TOKEN_BUDGET", 280)
+            "audio_runtime_image_token_budget": _coerce_int(
+                _multi_runtime_setting("GEMMA4_AUDIO_IMAGE_TOKEN_BUDGET", 280),
+                280,
             ),
             "assistant_models": multi_runtime_available_models(role="assistant"),
             "audio_runtime_log_path": log_path,

--- a/venom_core/api/audio_stream.py
+++ b/venom_core/api/audio_stream.py
@@ -21,10 +21,15 @@ from fastapi import WebSocket, WebSocketDisconnect
 
 from venom_core.config import SETTINGS
 from venom_core.perception.audio_engine import AudioEngine
-from venom_core.services.gemma4_audio_models import gemma4_audio_available_models
+from venom_core.services.multi_runtime_models import multi_runtime_available_models
 from venom_core.utils.llm_runtime import get_active_llm_runtime
 from venom_core.utils.logger import get_logger
-from venom_core.utils.runtime_names import is_multi_runtime
+from venom_core.utils.mode_contracts import (
+    VOICE_EXECUTION_CONTEXT,
+    VOICE_HISTORY_SCOPE,
+    mode_contracts_payload,
+)
+from venom_core.utils.runtime_names import MULTI_RUNTIME_ID, is_multi_runtime
 from venom_core.utils.voice_metadata import build_voice_session_insights
 
 logger = get_logger(__name__)
@@ -126,6 +131,8 @@ def _build_voice_session_record(
         "economy_mode_activated": metadata.get("economy_mode_activated"),
         "degradation_reasons": metadata.get("degradation_reasons") or [],
         "component_snapshot": metadata.get("component_snapshot") or [],
+        "execution_context": metadata.get("execution_context"),
+        "history_scope": metadata.get("history_scope"),
     }
 
 
@@ -143,20 +150,20 @@ def _coerce_str(value: Any, default: str) -> str:
     return text or default
 
 
-def _gemma4_audio_setting(name: str, default: Any) -> Any:
+def _multi_runtime_setting(name: str, default: Any) -> Any:
     return getattr(SETTINGS, name, default)
 
 
-def _gemma4_audio_voice_flags() -> dict[str, bool]:
+def _multi_runtime_voice_flags() -> dict[str, bool]:
     return {
         "reasoning_summary_enabled": bool(
-            _gemma4_audio_setting("GEMMA4_AUDIO_REASONING_SUMMARY_ENABLED", False)
+            _multi_runtime_setting("GEMMA4_AUDIO_REASONING_SUMMARY_ENABLED", False)
         ),
         "emotion_detection_enabled": bool(
-            _gemma4_audio_setting("GEMMA4_AUDIO_EMOTION_DETECTION_ENABLED", False)
+            _multi_runtime_setting("GEMMA4_AUDIO_EMOTION_DETECTION_ENABLED", False)
         ),
         "emotion_response_style_enabled": bool(
-            _gemma4_audio_setting(
+            _multi_runtime_setting(
                 "GEMMA4_AUDIO_EMOTION_RESPONSE_STYLE_ENABLED",
                 False,
             )
@@ -347,7 +354,8 @@ class AudioStreamHandler:
             "tts_model_path": getattr(voice, "model_path", None),
             "tts_fallback": getattr(voice, "is_fallback_mode", None),
             "dependencies": dependencies,
-            **self._gemma4_audio_runtime_snapshot(),
+            "mode_contracts": mode_contracts_payload(),
+            **self._multi_runtime_runtime_snapshot(),
         }
 
     def get_latest_voice_session(self) -> dict[str, object] | None:
@@ -677,39 +685,46 @@ class AudioStreamHandler:
         voice_mode = conn["voice_mode"]
         return str(voice_mode).strip() or "standard"
 
-    def _gemma4_audio_runtime_snapshot(self) -> dict[str, Any]:
-        endpoint = _coerce_str(_gemma4_audio_setting("GEMMA4_AUDIO_ENDPOINT", ""), "")
-        log_path = _coerce_str(_gemma4_audio_setting("GEMMA4_AUDIO_LOG_PATH", ""), "")
-        pid_path = _coerce_str(_gemma4_audio_setting("GEMMA4_AUDIO_PID_PATH", ""), "")
+    def _voice_contract_payload(self, connection_id: int) -> dict[str, str]:
         return {
-            "audio_runtime_provider": "multi_runtime",
+            "execution_context": VOICE_EXECUTION_CONTEXT,
+            "history_scope": VOICE_HISTORY_SCOPE,
+            "voice_mode": self._connection_voice_mode(connection_id),
+        }
+
+    def _multi_runtime_runtime_snapshot(self) -> dict[str, Any]:
+        endpoint = _coerce_str(_multi_runtime_setting("GEMMA4_AUDIO_ENDPOINT", ""), "")
+        log_path = _coerce_str(_multi_runtime_setting("GEMMA4_AUDIO_LOG_PATH", ""), "")
+        pid_path = _coerce_str(_multi_runtime_setting("GEMMA4_AUDIO_PID_PATH", ""), "")
+        return {
+            "audio_runtime_provider": MULTI_RUNTIME_ID,
             "audio_runtime_model": _coerce_str(
-                _gemma4_audio_setting("GEMMA4_AUDIO_MODEL_ID", ""), ""
+                _multi_runtime_setting("GEMMA4_AUDIO_MODEL_ID", ""), ""
             ),
             "audio_runtime_endpoint": endpoint,
             "audio_runtime_enabled": bool(
-                _gemma4_audio_setting("GEMMA4_AUDIO_ENABLED", False)
+                _multi_runtime_setting("GEMMA4_AUDIO_ENABLED", False)
             ),
-            "audio_runtime_selected": self._gemma4_audio_runtime_selected(),
+            "audio_runtime_selected": self._multi_runtime_runtime_selected(),
             "audio_runtime_supports_audio": bool(
-                _gemma4_audio_setting("GEMMA4_AUDIO_SUPPORTS_AUDIO", True)
+                _multi_runtime_setting("GEMMA4_AUDIO_SUPPORTS_AUDIO", True)
             ),
             "audio_runtime_supports_text": bool(
-                _gemma4_audio_setting("GEMMA4_AUDIO_SUPPORTS_TEXT", True)
+                _multi_runtime_setting("GEMMA4_AUDIO_SUPPORTS_TEXT", True)
             ),
             "audio_runtime_supports_image": True,
             "audio_runtime_supports_unified_multimodal_respond": True,
             "audio_runtime_runtime_mode": "processor_model",
             "audio_runtime_image_token_budget": int(
-                _gemma4_audio_setting("GEMMA4_AUDIO_IMAGE_TOKEN_BUDGET", 280)
+                _multi_runtime_setting("GEMMA4_AUDIO_IMAGE_TOKEN_BUDGET", 280)
             ),
-            "assistant_models": gemma4_audio_available_models(role="assistant"),
+            "assistant_models": multi_runtime_available_models(role="assistant"),
             "audio_runtime_log_path": log_path,
             "audio_runtime_pid_path": pid_path,
         }
 
-    def _gemma4_audio_service_origin(self) -> str:
-        endpoint = _coerce_str(_gemma4_audio_setting("GEMMA4_AUDIO_ENDPOINT", ""), "")
+    def _multi_runtime_service_origin(self) -> str:
+        endpoint = _coerce_str(_multi_runtime_setting("GEMMA4_AUDIO_ENDPOINT", ""), "")
         if not endpoint:
             return ""
         endpoint = endpoint.rstrip("/")
@@ -717,21 +732,28 @@ class AudioStreamHandler:
             return endpoint[:-3].rstrip("/")
         return endpoint
 
-    def _gemma4_audio_respond_url(self) -> str:
-        origin = self._gemma4_audio_service_origin()
+    def _multi_runtime_respond_url(self) -> str:
+        origin = self._multi_runtime_service_origin()
         return f"{origin}/v1/respond" if origin else ""
 
-    def _gemma4_audio_health_url(self) -> str:
-        origin = self._gemma4_audio_service_origin()
+    def _multi_runtime_health_url(self) -> str:
+        origin = self._multi_runtime_service_origin()
         return f"{origin}/health" if origin else ""
 
-    def _gemma4_audio_runtime_enabled(self) -> bool:
-        return bool(_gemma4_audio_setting("GEMMA4_AUDIO_ENABLED", False))
+    def _multi_runtime_runtime_enabled(self) -> bool:
+        return bool(_multi_runtime_setting("GEMMA4_AUDIO_ENABLED", False))
 
-    def _gemma4_audio_runtime_selected(self) -> bool:
-        if not self._gemma4_audio_runtime_enabled():
+    def _multi_runtime_runtime_selected(self) -> bool:
+        if not self._multi_runtime_runtime_enabled():
             return False
-        active_server = _coerce_str(_gemma4_audio_setting("ACTIVE_LLM_SERVER", ""), "")
+        try:
+            runtime = get_active_llm_runtime()
+            if is_multi_runtime(getattr(runtime, "provider", "")):
+                return True
+        except Exception:
+            # Compatibility fallback for early bootstrap and partial runtime init.
+            pass
+        active_server = _coerce_str(_multi_runtime_setting("ACTIVE_LLM_SERVER", ""), "")
         return is_multi_runtime(active_server)
 
     def _voice_pipeline_mode(self) -> str:
@@ -743,18 +765,25 @@ class AudioStreamHandler:
         """
         return (
             "native_multi_runtime"
-            if self._gemma4_audio_runtime_selected()
+            if self._multi_runtime_runtime_selected()
             else "intermediary_local_stt"
         )
 
     def _voice_pipeline_fallback_reason(self) -> str:
-        active_server = _coerce_str(_gemma4_audio_setting("ACTIVE_LLM_SERVER", ""), "")
+        active_server = ""
+        try:
+            runtime = get_active_llm_runtime()
+            active_server = _coerce_str(getattr(runtime, "provider", ""), "")
+        except Exception:
+            active_server = _coerce_str(
+                _multi_runtime_setting("ACTIVE_LLM_SERVER", ""), ""
+            )
         if not active_server:
             return "native voice disabled: ACTIVE_LLM_SERVER is empty"
         return f"native voice disabled for active runtime: {active_server}"
 
-    async def _gemma4_audio_health_ok(self) -> bool:
-        health_url = self._gemma4_audio_health_url()
+    async def _multi_runtime_health_ok(self) -> bool:
+        health_url = self._multi_runtime_health_url()
         if not health_url:
             return False
         try:
@@ -769,12 +798,12 @@ class AudioStreamHandler:
         except Exception:
             return False
 
-    async def _invoke_gemma4_audio_runtime(
+    async def _invoke_multi_runtime(
         self,
         wav_path: Path,
         connection_id: int,
     ) -> dict[str, Any]:
-        respond_url = self._gemma4_audio_respond_url()
+        respond_url = self._multi_runtime_respond_url()
         if not respond_url:
             raise RuntimeError("Gemma4 audio endpoint is not configured")
 
@@ -795,10 +824,10 @@ class AudioStreamHandler:
             "task": "question",
             "question": prompt,
             "system_prompt": _coerce_str(
-                _gemma4_audio_setting("SIMPLE_MODE_SYSTEM_PROMPT", ""), ""
+                _multi_runtime_setting("SIMPLE_MODE_SYSTEM_PROMPT", ""), ""
             ),
             "max_new_tokens": _coerce_int(
-                _gemma4_audio_setting("GEMMA4_AUDIO_MAX_NEW_TOKENS", 128), 128
+                _multi_runtime_setting("GEMMA4_AUDIO_MAX_NEW_TOKENS", 128), 128
             ),
             "release_after_response": True,
         }
@@ -837,7 +866,8 @@ class AudioStreamHandler:
             "text": text,
             "response_text": text,
             "model": _coerce_str(
-                data.get("model") or _gemma4_audio_setting("GEMMA4_AUDIO_MODEL_ID", ""),
+                data.get("model")
+                or _multi_runtime_setting("GEMMA4_AUDIO_MODEL_ID", ""),
                 "",
             ),
             "duration_ms": data.get("duration_ms"),
@@ -860,7 +890,7 @@ class AudioStreamHandler:
             "component_snapshot": data.get("component_snapshot") or [],
         }
 
-    async def _process_native_gemma4_audio_pipeline(
+    async def _process_native_multi_runtime_pipeline(
         self,
         connection_id: int,
         session_dir: Path,
@@ -869,13 +899,13 @@ class AudioStreamHandler:
         total_started_at: float,
         operator_agent,
     ) -> bool:
-        if not self._gemma4_audio_runtime_selected():
+        if not self._multi_runtime_runtime_selected():
             return False
         if not self.audio_engine:
             return False
 
-        snapshot = self._gemma4_audio_runtime_snapshot()
-        if not await self._gemma4_audio_health_ok():
+        snapshot = self._multi_runtime_runtime_snapshot()
+        if not await self._multi_runtime_health_ok():
             self._update_voice_session_metadata(
                 session_dir,
                 {
@@ -889,12 +919,12 @@ class AudioStreamHandler:
                         response="",
                         voice_mode=self._connection_voice_mode(connection_id),
                         pipeline_id="whisper_llm_piper",
-                        **_gemma4_audio_voice_flags(),
+                        **_multi_runtime_voice_flags(),
                         raw_thinking_available=False,
                     ),
                     "timings_ms": timings_ms,
                     "runtime": self._build_runtime_metadata(operator_agent),
-                    "voice_mode": self._connection_voice_mode(connection_id),
+                    **self._voice_contract_payload(connection_id),
                 },
             )
             return False
@@ -905,9 +935,7 @@ class AudioStreamHandler:
 
         native_started_at = time.perf_counter()
         try:
-            runtime_result = await self._invoke_gemma4_audio_runtime(
-                wav_path, connection_id
-            )
+            runtime_result = await self._invoke_multi_runtime(wav_path, connection_id)
         except Exception as exc:
             timings_ms["native_audio_ms"] = self._elapsed_ms(native_started_at)
             self._update_voice_session_metadata(
@@ -924,12 +952,12 @@ class AudioStreamHandler:
                         response="",
                         voice_mode=self._connection_voice_mode(connection_id),
                         pipeline_id="whisper_llm_piper",
-                        **_gemma4_audio_voice_flags(),
+                        **_multi_runtime_voice_flags(),
                         raw_thinking_available=False,
                     ),
                     "timings_ms": timings_ms,
                     "runtime": self._build_runtime_metadata(operator_agent),
-                    "voice_mode": self._connection_voice_mode(connection_id),
+                    **self._voice_contract_payload(connection_id),
                 },
             )
             logger.warning(
@@ -947,7 +975,7 @@ class AudioStreamHandler:
             response=response_text,
             voice_mode=self._connection_voice_mode(connection_id),
             pipeline_id="multi_runtime_piper",
-            **_gemma4_audio_voice_flags(),
+            **_multi_runtime_voice_flags(),
             raw_thinking_available=bool(
                 runtime_result.get("raw_thinking_available", False)
             ),
@@ -983,7 +1011,7 @@ class AudioStreamHandler:
                 **insights,
                 "timings_ms": timings_ms,
                 "runtime": self._build_runtime_metadata(operator_agent),
-                "voice_mode": self._connection_voice_mode(connection_id),
+                **self._voice_contract_payload(connection_id),
             },
         )
 
@@ -1056,7 +1084,7 @@ class AudioStreamHandler:
             )
             logger.info(f"Zapisano sesję audio: {session_dir}")
 
-            if not self._gemma4_audio_runtime_selected():
+            if not self._multi_runtime_runtime_selected():
                 self._update_voice_session_metadata(
                     session_dir,
                     {
@@ -1067,7 +1095,7 @@ class AudioStreamHandler:
                     },
                 )
 
-            if await self._process_native_gemma4_audio_pipeline(
+            if await self._process_native_multi_runtime_pipeline(
                 connection_id,
                 session_dir,
                 session_dir / VOICE_SESSION_WAV_FILENAME,
@@ -1107,7 +1135,7 @@ class AudioStreamHandler:
                     "audio_input_status": "verified",
                     "decoder_source": "faster_whisper",
                     "runtime_log_path": _coerce_str(
-                        _gemma4_audio_setting("GEMMA4_AUDIO_LOG_PATH", ""), ""
+                        _multi_runtime_setting("GEMMA4_AUDIO_LOG_PATH", ""), ""
                     ),
                 },
             )
@@ -1171,7 +1199,7 @@ class AudioStreamHandler:
             )
             logger.info(f"Zapisano sesję audio MediaRecorder: {session_dir}")
 
-            if not self._gemma4_audio_runtime_selected():
+            if not self._multi_runtime_runtime_selected():
                 self._update_voice_session_metadata(
                     session_dir,
                     {
@@ -1182,7 +1210,7 @@ class AudioStreamHandler:
                     },
                 )
 
-            if await self._process_native_gemma4_audio_pipeline(
+            if await self._process_native_multi_runtime_pipeline(
                 connection_id,
                 session_dir,
                 wav_path,
@@ -1220,7 +1248,7 @@ class AudioStreamHandler:
                     "audio_input_status": "verified",
                     "decoder_source": "faster_whisper",
                     "runtime_log_path": _coerce_str(
-                        _gemma4_audio_setting("GEMMA4_AUDIO_LOG_PATH", ""), ""
+                        _multi_runtime_setting("GEMMA4_AUDIO_LOG_PATH", ""), ""
                     ),
                 },
             )
@@ -1274,8 +1302,14 @@ class AudioStreamHandler:
             response="",
             voice_mode=self._connection_voice_mode(connection_id),
             pipeline_id="whisper_llm_piper",
-            **_gemma4_audio_voice_flags(),
+            **_multi_runtime_voice_flags(),
             raw_thinking_available=False,
+        )
+        voice_context.update(
+            {
+                "execution_context": VOICE_EXECUTION_CONTEXT,
+                "history_scope": VOICE_HISTORY_SCOPE,
+            }
         )
         response_text = await _invoke_operator_agent(
             operator_agent,
@@ -1295,10 +1329,11 @@ class AudioStreamHandler:
                     response=response_text,
                     voice_mode=self._connection_voice_mode(connection_id),
                     pipeline_id="whisper_llm_piper",
-                    **_gemma4_audio_voice_flags(),
+                    **_multi_runtime_voice_flags(),
                     raw_thinking_available=False,
                 ),
                 "timings_ms": timings_ms,
+                **self._voice_contract_payload(connection_id),
             },
         )
         if not response_text:
@@ -1547,7 +1582,7 @@ class AudioStreamHandler:
             "tts_model_path": getattr(voice, "model_path", None),
             "tts_fallback": getattr(voice, "is_fallback_mode", None),
             "tts_sample_rate": self._get_tts_sample_rate(),
-            **self._gemma4_audio_runtime_snapshot(),
+            **self._multi_runtime_runtime_snapshot(),
         }
 
     def _update_voice_session_metadata(

--- a/venom_core/api/routes/system_llm.py
+++ b/venom_core/api/routes/system_llm.py
@@ -42,7 +42,7 @@ from venom_core.services.feedback_loop_policy import (
     is_feedback_loop_ready,
     resolve_feedback_loop_model,
 )
-from venom_core.services.gemma4_audio_models import gemma4_audio_available_models
+from venom_core.services.multi_runtime_models import multi_runtime_available_models
 from venom_core.services.runtime_switch_service import (
     RuntimeSwitchOrchestrator,
     probe_health_ready,
@@ -63,6 +63,7 @@ from venom_core.utils.llm_runtime import (
     infer_local_provider,
 )
 from venom_core.utils.logger import get_logger
+from venom_core.utils.mode_contracts import mode_contracts_payload
 from venom_core.utils.runtime_names import (
     MULTI_RUNTIME_ID,
     is_multi_runtime,
@@ -1292,19 +1293,19 @@ async def _local_models_by_runtime(
             runtime_id = str(payload.get("runtime_id") or "").strip().lower()
             if runtime_id in grouped:
                 grouped[runtime_id].append(payload)
-    grouped[MULTI_RUNTIME_ID] = _gemma4_audio_static_models(
+    grouped[MULTI_RUNTIME_ID] = _multi_runtime_static_models(
         active_provider=active_provider,
         active_model=active_model,
     )
     return grouped, audit_issues
 
 
-def _gemma4_audio_static_models(
+def _multi_runtime_static_models(
     *,
     active_provider: str,
     active_model: str,
 ) -> list[dict[str, Any]]:
-    target_models = gemma4_audio_available_models(role="target")
+    target_models = multi_runtime_available_models(role="target")
     return [
         _runtime_model_payload(
             runtime_id=MULTI_RUNTIME_ID,
@@ -1455,15 +1456,15 @@ def _runtime_target_payload(
         "supports_adapter_runtime_apply": runtime_capabilities[
             "supports_adapter_runtime_apply"
         ],
-        **_gemma4_audio_runtime_input_capabilities(runtime_id),
+        **_multi_runtime_input_capabilities(runtime_id),
     }
 
 
-def _gemma4_audio_runtime_input_capabilities(runtime_id: str) -> dict[str, Any]:
+def _multi_runtime_input_capabilities(runtime_id: str) -> dict[str, Any]:
     if not is_multi_runtime(runtime_id):
         return {}
-    target_models = gemma4_audio_available_models(role="target")
-    assistant_models = gemma4_audio_available_models(role="assistant")
+    target_models = multi_runtime_available_models(role="target")
+    assistant_models = multi_runtime_available_models(role="assistant")
     return {
         "supports_text_input": True,
         "supports_audio_input": True,
@@ -1866,6 +1867,7 @@ async def _resolve_runtime_options_payload() -> dict[str, Any]:
             "active_endpoint": active_runtime.endpoint,
             "config_hash": active_runtime.config_hash,
             "source_type": _runtime_source_type(active_runtime.provider),
+            "mode_contracts": mode_contracts_payload(),
             "requested_model_alias": active_feedback_resolution[
                 "requested_model_alias"
             ],
@@ -2099,6 +2101,7 @@ def get_active_llm_server():
         },
         "runtime_switch_policy": get_runtime_switch_guard_status(),
         "last_runtime_switch": get_last_runtime_switch_event(),
+        "mode_contracts": mode_contracts_payload(),
     }
 
 
@@ -2113,6 +2116,7 @@ def get_active_llm_runtime_info():
         "drift": drift,
         "runtime_switch_policy": get_runtime_switch_guard_status(),
         "last_runtime_switch": get_last_runtime_switch_event(),
+        "mode_contracts": mode_contracts_payload(),
     }
 
 
@@ -2286,7 +2290,7 @@ def _resolve_selected_model_for_switch(
     models: list[dict[str, Any]],
 ) -> tuple[str, str]:
     if is_multi_runtime(server_name):
-        return _resolve_gemma4_audio_selected_model_for_switch(
+        return _resolve_multi_runtime_selected_model_for_switch(
             request=request,
             server_name=server_name,
             config=config,
@@ -2325,7 +2329,7 @@ def _resolve_selected_model_for_switch(
         return fallback
 
 
-def _resolve_gemma4_audio_selected_model_for_switch(
+def _resolve_multi_runtime_selected_model_for_switch(
     *,
     request: ActiveLlmServerRequest,
     server_name: str,
@@ -2335,19 +2339,19 @@ def _resolve_gemma4_audio_selected_model_for_switch(
     requested_model = str(request.model or "").strip()
 
     if requested_model:
-        _validate_gemma4_audio_requested_model(
+        _validate_multi_runtime_requested_model(
             requested_model=requested_model, server_name=server_name
         )
         return requested_model, requested_last_model_key
 
-    selected = _resolve_gemma4_audio_fallback_model(config=config)
+    selected = _resolve_multi_runtime_fallback_model(config=config)
     return selected, requested_last_model_key
 
 
-def _validate_gemma4_audio_requested_model(
+def _validate_multi_runtime_requested_model(
     *, requested_model: str, server_name: str
 ) -> None:
-    available_models = gemma4_audio_available_models(role="target")
+    available_models = multi_runtime_available_models(role="target")
     if not available_models:
         logger.warning(
             "Brak katalogu modeli multi_runtime; akceptuję requested_model='{}' dla {}.",
@@ -2366,8 +2370,8 @@ def _validate_gemma4_audio_requested_model(
     )
 
 
-def _resolve_gemma4_audio_fallback_model(*, config: dict[str, Any]) -> str:
-    available_models = gemma4_audio_available_models(role="target")
+def _resolve_multi_runtime_fallback_model(*, config: dict[str, Any]) -> str:
+    available_models = multi_runtime_available_models(role="target")
     previous_choice = str(config.get("LAST_MODEL_GEMMA4_AUDIO") or "").strip()
     if previous_choice in available_models:
         return previous_choice

--- a/venom_core/utils/mode_contracts.py
+++ b/venom_core/utils/mode_contracts.py
@@ -1,0 +1,38 @@
+"""Canonical mode contracts for voice, text chat, and Venom agent flows."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+VOICE_EXECUTION_CONTEXT = "voice_command"
+VOICE_HISTORY_SCOPE = "ephemeral_no_text_chat_inheritance"
+
+TEXT_CHAT_EXECUTION_CONTEXT = "text_chat_session"
+TEXT_CHAT_HISTORY_SCOPE = "persistent_until_stack_restart"
+
+VENOM_AGENT_EXECUTION_CONTEXT = "operator_execution_context"
+VENOM_AGENT_HISTORY_SCOPE = "operator_task_context"
+
+MODE_CONTRACTS: dict[str, dict[str, str]] = {
+    "voice": {
+        "execution_context": VOICE_EXECUTION_CONTEXT,
+        "history_scope": VOICE_HISTORY_SCOPE,
+        "session_memory_policy": "ephemeral",
+    },
+    "text_chat": {
+        "execution_context": TEXT_CHAT_EXECUTION_CONTEXT,
+        "history_scope": TEXT_CHAT_HISTORY_SCOPE,
+        "session_memory_policy": "persistent",
+    },
+    "venom_agent": {
+        "execution_context": VENOM_AGENT_EXECUTION_CONTEXT,
+        "history_scope": VENOM_AGENT_HISTORY_SCOPE,
+        "session_memory_policy": "task_scoped",
+    },
+}
+
+
+def mode_contracts_payload() -> dict[str, dict[str, Any]]:
+    """Return a defensive copy for API payloads."""
+    return deepcopy(MODE_CONTRACTS)

--- a/web-next/components/gemma4/gemma4-runtime-control.tsx
+++ b/web-next/components/gemma4/gemma4-runtime-control.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/ui/confirm-dialog";
 import { Switch } from "@/components/ui/switch";
 import { useTranslation } from "@/lib/i18n";
+import { isMultiRuntime } from "@/lib/runtime-id";
 import type {
   DaemonConfigRequest,
   DaemonRespondResponse,
@@ -1690,17 +1691,9 @@ function resolveRuntimeSnapshotModel(
   const fallbackModel = snapshot?.model_name ?? "—";
   if (!targetModelOverride) return fallbackModel;
 
-  const runtimeId = String(snapshot?.runtime_id ?? "").trim().toLowerCase();
-  const provider = String(snapshot?.provider ?? "").trim().toLowerCase();
-  const isMultiRuntimeSnapshot =
-    runtimeId === "multi_runtime" ||
-    runtimeId === "gemma4_audio" ||
-    runtimeId.startsWith("multi_runtime@") ||
-    runtimeId.startsWith("gemma4_audio@") ||
-    provider === "multi_runtime" ||
-    provider === "gemma4_audio" ||
-    provider.startsWith("multi_runtime@") ||
-    provider.startsWith("gemma4_audio@");
+  const runtimeId = String(snapshot?.runtime_id ?? "").trim();
+  const provider = String(snapshot?.provider ?? "").trim();
+  const isMultiRuntimeSnapshot = isMultiRuntime(runtimeId) || isMultiRuntime(provider);
   return isMultiRuntimeSnapshot ? targetModelOverride : fallbackModel;
 }
 

--- a/web-next/components/layout/mobile-nav.tsx
+++ b/web-next/components/layout/mobile-nav.tsx
@@ -25,6 +25,7 @@ import {
 import { useTelemetryFeed } from "@/hooks/use-telemetry";
 import { LanguageSwitcher } from "./language-switcher";
 import { useLanguage, useTranslation } from "@/lib/i18n";
+import { canonicalRuntimeId } from "@/lib/runtime-id";
 import { getNavigationItems } from "./sidebar-helpers";
 import { ModelIntrospectionMechanismControl } from "@/components/inspector/model-introspection-mechanism";
 import {
@@ -67,6 +68,7 @@ export function MobileNav() {
     tasks: t("mobileNav.telemetry.tasks"),
     ws: t("mobileNav.telemetry.ws"),
   };
+  const canonicalCostProvider = canonicalRuntimeId(costMode?.provider ?? "");
 
   const handleCostToggle = async () => {
     setCostLoading(true);
@@ -248,7 +250,7 @@ export function MobileNav() {
                   <p className="text-lg font-semibold text-[color:var(--text-heading)]">
                     {costMode?.enabled ? t("sidebar.cost.pro") : t("sidebar.cost.eco")}
                   </p>
-                  <p className="text-xs text-[color:var(--text-secondary)]">{t("mobileNav.telemetry.provider")}: {costMode?.provider ?? t("mobileNav.telemetry.noneProvider")}</p>
+                  <p className="text-xs text-[color:var(--text-secondary)]">{t("mobileNav.telemetry.provider")}: {canonicalCostProvider || t("mobileNav.telemetry.noneProvider")}</p>
                 </div>
                 <Sparkles className="h-5 w-5 text-emerald-200" />
               </div>

--- a/web-next/components/layout/sidebar-sections.tsx
+++ b/web-next/components/layout/sidebar-sections.tsx
@@ -151,7 +151,7 @@ export function CostModeSection({
                         {costMode?.enabled ? t("sidebar.cost.pro") : t("sidebar.cost.eco")}
                     </p>
                     <p className="text-xs text-[color:var(--ui-muted)]">
-                        {t("common.provider")}: {canonicalProvider || "brak"}
+                        {t("common.provider")}: {canonicalProvider || t("common.unknown")}
                     </p>
                 </div>
                 <Sparkles className="h-5 w-5 text-emerald-200" />

--- a/web-next/components/layout/sidebar-sections.tsx
+++ b/web-next/components/layout/sidebar-sections.tsx
@@ -8,6 +8,7 @@ import {
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { useAppMeta } from "@/lib/app-meta";
+import { canonicalRuntimeId } from "@/lib/runtime-id";
 import { getNavigationItems, AUTONOMY_LEVELS, AutonomySnapshot } from "./sidebar-helpers";
 import type { LanguageCode } from "@/lib/i18n";
 
@@ -134,6 +135,7 @@ export function CostModeSection({
     onToggle: () => void;
     t: (key: string) => string;
 }>) {
+    const canonicalProvider = canonicalRuntimeId(costMode?.provider ?? "");
     let toggleLabel = t("sidebar.cost.switchToPro");
     if (costLoading) {
         toggleLabel = t("sidebar.cost.switching");
@@ -149,7 +151,7 @@ export function CostModeSection({
                         {costMode?.enabled ? t("sidebar.cost.pro") : t("sidebar.cost.eco")}
                     </p>
                     <p className="text-xs text-[color:var(--ui-muted)]">
-                        {t("common.provider")}: {costMode?.provider ?? "brak"}
+                        {t("common.provider")}: {canonicalProvider || "brak"}
                     </p>
                 </div>
                 <Sparkles className="h-5 w-5 text-emerald-200" />

--- a/web-next/components/layout/system-status-panel.tsx
+++ b/web-next/components/layout/system-status-panel.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import { useActiveLlmServer, useQueueStatus } from "@/hooks/use-api";
 import { useTranslation } from "@/lib/i18n";
+import { canonicalRuntimeId } from "@/lib/runtime-id";
 
 type StatusTone = "success" | "warning" | "danger" | "neutral";
 
@@ -33,6 +34,7 @@ export function SystemStatusPanel() {
     }
 
     const hasLlm = Boolean(llmActive?.active_server || llmActive?.active_model);
+    const activeServer = canonicalRuntimeId(llmActive?.active_server ?? "");
     let llmTone: StatusTone = "warning";
     if (hasLlm) {
       llmTone = "success";
@@ -41,7 +43,7 @@ export function SystemStatusPanel() {
     }
     const llmHint = hasLlm
       ? t("systemStatus.hints.llmDetails", {
-        server: llmActive?.active_server ?? t("systemStatus.hints.unknown"),
+        server: activeServer || t("systemStatus.hints.unknown"),
         model: llmActive?.active_model ?? t("systemStatus.hints.unknown"),
       })
       : "";

--- a/web-next/components/models/hooks/use-runtime.ts
+++ b/web-next/components/models/hooks/use-runtime.ts
@@ -2,6 +2,7 @@ import { useState, useMemo, useEffect, useCallback } from "react";
 import { useToast } from "@/components/ui/toast";
 import { useLanguage } from "@/lib/i18n";
 import { ApiError } from "@/lib/api-client";
+import { canonicalRuntimeId, isMultiRuntime } from "@/lib/runtime-id";
 import type {
     ActiveLlmServerResponse,
     LlmRuntimeModelOption,
@@ -24,7 +25,7 @@ const isCloudRuntime = (runtime: string): runtime is "openai" | "google" =>
     runtime === "openai" || runtime === "google";
 
 const isServerWithInlineModelActivation = (runtime: string): boolean =>
-    runtime === "multi_runtime" || runtime === "gemma4_audio";
+    isMultiRuntime(runtime);
 
 const ERROR_DETAIL_KEYS = ["detail", "message", "error", "reason"] as const;
 
@@ -276,15 +277,17 @@ export function useRuntime() {
     const activateRuntimeSelection = useCallback(
         async (server: string, model: string | null): Promise<ActiveLlmServerResponse | void> => {
             if (!server) return;
-            const resolvedModel = resolveSelectedModelForServer(server, model);
+            const canonicalServer = canonicalRuntimeId(server);
+            const targetServer = canonicalServer || server;
+            const resolvedModel = resolveSelectedModelForServer(targetServer, model);
             let response: ActiveLlmServerResponse | void = undefined;
-            if (isCloudRuntime(server)) {
-                response = await setActiveLlmRuntime(server, resolvedModel ?? model ?? undefined);
-            } else if (isServerWithInlineModelActivation(server)) {
-                response = await setActiveLlmServer(server, resolvedModel ?? model ?? undefined);
+            if (isCloudRuntime(targetServer)) {
+                response = await setActiveLlmRuntime(targetServer, resolvedModel ?? model ?? undefined);
+            } else if (isServerWithInlineModelActivation(targetServer)) {
+                response = await setActiveLlmServer(targetServer, resolvedModel ?? model ?? undefined);
             } else {
-                if (server !== activeServer.data?.active_server) {
-                    response = await setActiveLlmServer(server, resolvedModel ?? undefined);
+                if (targetServer !== activeServer.data?.active_server) {
+                    response = await setActiveLlmServer(targetServer, resolvedModel ?? undefined);
                 }
                 if (resolvedModel) {
                     await switchModel(resolvedModel);

--- a/web-next/components/voice/dev-diagnostics-drawer.tsx
+++ b/web-next/components/voice/dev-diagnostics-drawer.tsx
@@ -11,6 +11,7 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { useTranslation } from "@/lib/i18n";
+import { canonicalRuntimeId, isMultiRuntime } from "@/lib/runtime-id";
 
 type AudioStatus = {
   enabled: boolean;
@@ -173,6 +174,7 @@ export function DevDiagnosticsDrawerContent({
   const latestVoiceSession = audioStatus?.latest_voice_session ?? null;
   const runtimeSnapshot = audioStatus?.runtime_snapshot ?? null;
   const wsState = audioStatus?.enabled ? "online" : "offline";
+  const displayedRuntimeProvider = canonicalRuntimeId(runtimeSnapshot?.provider ?? runtimeSnapshot?.runtime_id ?? "");
 
   const copyJson = async (value: unknown) => {
     if (!navigator?.clipboard) return;
@@ -194,9 +196,9 @@ export function DevDiagnosticsDrawerContent({
         {renderDiagnosticMode && renderDiagnosticMode !== "off" && (
           <Badge tone="neutral">render: {renderDiagnosticMode}</Badge>
         )}
-        {runtimeSnapshot?.provider && (
+        {displayedRuntimeProvider && (
           <Badge tone="neutral">
-            {t("runtime.snapshot.provider")}: {runtimeSnapshot.provider}
+            {t("runtime.snapshot.provider")}: {displayedRuntimeProvider}
           </Badge>
         )}
         {latestVoiceSession?.session_id && (
@@ -309,6 +311,8 @@ function LatestRecordingSection({
 
   const timings = latestVoiceSession.timings_ms;
   const runtime = latestVoiceSession.runtime;
+  const displayedLlmRuntime = canonicalRuntimeId(runtime?.llm_service_id ?? "");
+  const audioRuntimeProvider = canonicalRuntimeId(latestVoiceSession.audio_runtime_provider ?? "");
 
   return (
     <div className="rounded-2xl border border-white/10 bg-white/[0.03] p-4">
@@ -349,7 +353,7 @@ function LatestRecordingSection({
         {runtime && (
           <p>
             {joinParts([
-              runtime.llm_model && `LLM ${runtime.llm_service_id}:${runtime.llm_model}`,
+              runtime.llm_model && `LLM ${(displayedLlmRuntime || runtime.llm_service_id || "unknown")}:${runtime.llm_model}`,
               runtime.stt_model && `STT ${runtime.stt_model}/${runtime.stt_device}`,
               formatTtsSampleRateLabel(runtime.tts_sample_rate),
             ])}
@@ -359,10 +363,10 @@ function LatestRecordingSection({
         {latestVoiceSession.pipeline_id && (
           <p>Pipeline: {latestVoiceSession.pipeline_id}</p>
         )}
-        {latestVoiceSession.audio_runtime_provider && (
+        {audioRuntimeProvider && (
           <p>
             STT backend:{" "}
-            {latestVoiceSession.audio_runtime_provider === "multi_runtime"
+            {isMultiRuntime(audioRuntimeProvider)
               ? "multi_runtime"
               : "faster-whisper"}
             {latestVoiceSession.audio_runtime_model
@@ -397,6 +401,9 @@ function RuntimeSnapshotSection({
 }>) {
   const t = useTranslation();
   if (!runtimeSnapshot) return null;
+  const displayedRuntimeProvider = canonicalRuntimeId(
+    runtimeSnapshot.provider ?? runtimeSnapshot.runtime_id ?? "",
+  );
   const capabilities = runtimeSnapshot.runtime_capabilities;
   const pipeline = runtimeSnapshot.voice_pipeline;
   const probeStatus = capabilities?.probe_status ?? t("runtime.snapshot.unknown");
@@ -427,7 +434,7 @@ function RuntimeSnapshotSection({
       <div className="mb-3 grid gap-2 text-xs sm:grid-cols-3">
         <div className="rounded-xl border border-white/10 bg-black/20 p-3">
           <p className="text-caption">{t("runtime.snapshot.provider")}</p>
-          <p className="mt-1 text-white">{runtimeSnapshot.provider ?? runtimeSnapshot.runtime_id ?? "—"}</p>
+          <p className="mt-1 text-white">{displayedRuntimeProvider || "—"}</p>
         </div>
         <div className="rounded-xl border border-white/10 bg-black/20 p-3">
           <p className="text-caption">{t("runtime.snapshot.endpoint")}</p>

--- a/web-next/components/voice/voice-chat-screen.tsx
+++ b/web-next/components/voice/voice-chat-screen.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { SectionHeading } from "@/components/ui/section-heading";
 import { useTranslation } from "@/lib/i18n";
+import { isMultiRuntime } from "@/lib/runtime-id";
 import {
   VoiceCommandCenter,
   type VoiceModePreset,
@@ -49,7 +50,6 @@ const VOICE_MODES: VoiceModeCard[] = [
     icon: ListTodo,
   },
 ];
-const NATIVE_VOICE_RUNTIME_PREFIXES = ["multi_runtime", "gemma4_audio"] as const;
 
 type VoiceChatScreenProps = Readonly<{
   isDevMode?: boolean;
@@ -149,13 +149,10 @@ function VoiceSystemStatusBar({ status }: Readonly<{ status: VoiceStatusUpdate |
   const sttOk = status.stt_ready === true;
   const ttsOk = status.tts_ready === true;
   const runtimeProvider = String(status.runtime_snapshot?.provider ?? "").trim();
-  const runtimeProviderNormalized = runtimeProvider.toLowerCase();
   const runtimeModel = String(status.runtime_snapshot?.model_name ?? "").trim();
   const probeStatus = status.runtime_snapshot?.runtime_capabilities?.probe_status ?? null;
   const llmOk = runtimeProvider.length > 0 && runtimeModel.length > 0;
-  const isNativeVoiceRuntime = NATIVE_VOICE_RUNTIME_PREFIXES.some((prefix) =>
-    runtimeProviderNormalized.startsWith(prefix),
-  );
+  const isNativeVoiceRuntime = isMultiRuntime(runtimeProvider);
   const voiceProbeFailed = probeStatus === "failed";
   const voiceProbeBlocking = voiceProbeFailed && isNativeVoiceRuntime;
   const allOk = sttOk && ttsOk && llmOk && !voiceProbeBlocking;

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -3015,10 +3015,10 @@ function VoiceCommandCenterPanel({
                   {
                     label: t("voice.controls.selectedRuntime"),
                     value: formatRuntimeSummaryLabel(
-                      viewState.effectiveAudioStatus.latest_voice_session.runtime?.llm_service_id
+                      viewState.effectiveAudioStatus.latest_voice_session?.runtime?.llm_service_id
                         ?? viewState.effectiveAudioStatus.runtime_snapshot?.provider
                         ?? viewState.effectiveAudioStatus.runtime_snapshot?.runtime_id,
-                      viewState.effectiveAudioStatus.latest_voice_session.runtime?.llm_model
+                      viewState.effectiveAudioStatus.latest_voice_session?.runtime?.llm_model
                         ?? viewState.effectiveAudioStatus.runtime_snapshot?.model_name,
                     ),
                     tone: "neutral",
@@ -3035,8 +3035,8 @@ function VoiceCommandCenterPanel({
                   {
                     label: t("voice.controls.responseRuntime"),
                     value: formatRuntimeSummaryLabel(
-                      viewState.effectiveAudioStatus.latest_voice_session.audio_runtime_provider,
-                      viewState.effectiveAudioStatus.latest_voice_session.audio_runtime_model,
+                      viewState.effectiveAudioStatus.latest_voice_session?.audio_runtime_provider,
+                      viewState.effectiveAudioStatus.latest_voice_session?.audio_runtime_model,
                     ),
                     tone: "neutral",
                   },

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -43,6 +43,7 @@ import {
   RuntimeDiagnosticsPanel,
   type RuntimeSummaryItem,
 } from "@/components/runtime/runtime-diagnostics-panel";
+import { canonicalRuntimeId } from "@/lib/runtime-id";
 
 export type AudioStatus = {
   enabled: boolean;
@@ -182,6 +183,14 @@ const nextSecureRandomFallbackInt = () => {
   const perfNow = typeof performance === "undefined" ? 0 : Math.floor(performance.now());
   return Date.now() + perfNow + secureRandomFallbackCounter;
 };
+
+function formatRuntimeSummaryLabel(
+  provider: string | null | undefined,
+  model: string | null | undefined,
+): string {
+  const normalizedProvider = canonicalRuntimeId(provider ?? "") || "—";
+  return `${normalizedProvider} / ${model ?? "—"}`;
+}
 
 const secureRandomInt = (maxExclusive: number): number => {
   if (maxExclusive <= 0) return 0;
@@ -3003,6 +3012,34 @@ function VoiceCommandCenterPanel({
               description={t("runtime.diagnostics.description")}
               summaryItems={
                 [
+                  {
+                    label: t("voice.controls.selectedRuntime"),
+                    value: formatRuntimeSummaryLabel(
+                      viewState.effectiveAudioStatus.latest_voice_session.runtime?.llm_service_id
+                        ?? viewState.effectiveAudioStatus.runtime_snapshot?.provider
+                        ?? viewState.effectiveAudioStatus.runtime_snapshot?.runtime_id,
+                      viewState.effectiveAudioStatus.latest_voice_session.runtime?.llm_model
+                        ?? viewState.effectiveAudioStatus.runtime_snapshot?.model_name,
+                    ),
+                    tone: "neutral",
+                  },
+                  {
+                    label: t("voice.controls.systemVoiceRuntime"),
+                    value: formatRuntimeSummaryLabel(
+                      viewState.effectiveAudioStatus.runtime_snapshot?.provider
+                        ?? viewState.effectiveAudioStatus.runtime_snapshot?.runtime_id,
+                      viewState.effectiveAudioStatus.runtime_snapshot?.model_name,
+                    ),
+                    tone: "neutral",
+                  },
+                  {
+                    label: t("voice.controls.responseRuntime"),
+                    value: formatRuntimeSummaryLabel(
+                      viewState.effectiveAudioStatus.latest_voice_session.audio_runtime_provider,
+                      viewState.effectiveAudioStatus.latest_voice_session.audio_runtime_model,
+                    ),
+                    tone: "neutral",
+                  },
                   {
                     label: t("runtime.diagnostics.policy"),
                     value: viewState.effectiveAudioStatus.latest_voice_session.selected_policy ?? "—",

--- a/web-next/components/voice/voice-status-sidebar.tsx
+++ b/web-next/components/voice/voice-status-sidebar.tsx
@@ -7,6 +7,7 @@ import { SelectMenu } from "@/components/ui/select-menu";
 import { Gemma4RuntimeControl } from "@/components/gemma4/gemma4-runtime-control";
 import type { VoiceStatusUpdate } from "@/components/voice/voice-command-center";
 import { useTranslation } from "@/lib/i18n";
+import { canonicalRuntimeId, isMultiRuntime } from "@/lib/runtime-id";
 import { resolveRuntimeActivationErrorMessage, useRuntime } from "@/components/models/hooks/use-runtime";
 
 type VoiceStatusSidebarProps = Readonly<{
@@ -39,6 +40,11 @@ function formatConfidence(value?: number | null): string | null {
   return `${Math.round(Math.max(0, Math.min(1, value)) * 100)}%`;
 }
 
+function formatRuntimeTuple(provider: string | null | undefined, model: string | null | undefined): string {
+  const normalizedProvider = canonicalRuntimeId(provider ?? "") || "—";
+  return `${normalizedProvider} / ${model ?? "—"}`;
+}
+
 function isGenericFailureResponse(text: string): boolean {
   const normalized = text.trim().toLowerCase();
   if (!normalized) return false;
@@ -56,17 +62,9 @@ export function VoiceStatusSidebar({ status, isDevMode = false, onRuntimeApplied
   const t = useTranslation();
   const runtime = status?.runtime_snapshot ?? null;
   const latestVoiceSession = status?.latest_voice_session ?? runtime?.latest_voice_session ?? null;
-  const runtimeProvider = (runtime?.provider ?? "").trim().toLowerCase();
-  const runtimeId = (runtime?.runtime_id ?? "").trim().toLowerCase();
-  const isGemma4AudioRuntime =
-    runtimeProvider === "multi_runtime" ||
-    runtimeProvider === "gemma4_audio" ||
-    runtimeProvider.startsWith("multi_runtime@") ||
-    runtimeProvider.startsWith("gemma4_audio@") ||
-    runtimeId === "multi_runtime" ||
-    runtimeId === "gemma4_audio" ||
-    runtimeId.startsWith("multi_runtime@") ||
-    runtimeId.startsWith("gemma4_audio@");
+  const runtimeProvider = runtime?.provider ?? "";
+  const runtimeId = runtime?.runtime_id ?? "";
+  const isGemma4AudioRuntime = isMultiRuntime(runtimeProvider) || isMultiRuntime(runtimeId);
 
   if (!status) {
     return (
@@ -187,9 +185,14 @@ function RuntimeSwitchCard({
   const [activationError, setActivationError] = useState<string | null>(null);
   const appliedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const didAutoSelectPreferredRuntime = useRef(false);
-  const nativeVoiceRuntimeIds = useMemo(() => new Set(["multi_runtime", "gemma4_audio"]), []);
+  const nativeVoiceRuntimeIds = useMemo(() => new Set(["multi_runtime"]), []);
   const selectedRuntime = runtime.selectedServer ?? "";
   const selectedModel = runtime.selectedModel ?? "";
+  const selectedRuntimeSummary = formatRuntimeTuple(selectedRuntime, selectedModel);
+  const activeRuntimeSummary = formatRuntimeTuple(
+    runtime.activeServer.data?.active_server ?? null,
+    runtime.activeServer.data?.active_model ?? null,
+  );
   const applyDisabled = pending || !selectedRuntime || !selectedModel;
   const runtimeError = runtime.activeServer.error ?? runtime.llmServers.error;
   const serversLoading = runtime.llmServers.loading ?? false;
@@ -211,7 +214,7 @@ function RuntimeSwitchCard({
 
   const preferredNativeRuntime = useMemo(
     () =>
-      serverOptions.find((option) => nativeVoiceRuntimeIds.has(String(option.value).trim().toLowerCase())) ??
+      serverOptions.find((option) => nativeVoiceRuntimeIds.has(canonicalRuntimeId(String(option.value)))) ??
       null,
     [nativeVoiceRuntimeIds, serverOptions],
   );
@@ -223,8 +226,8 @@ function RuntimeSwitchCard({
     if (!preferredNativeRuntime) {
       return;
     }
-    const normalizedSelectedRuntime = selectedRuntime.trim().toLowerCase();
-    const normalizedPreferredRuntime = String(preferredNativeRuntime.value).trim().toLowerCase();
+    const normalizedSelectedRuntime = canonicalRuntimeId(selectedRuntime);
+    const normalizedPreferredRuntime = canonicalRuntimeId(String(preferredNativeRuntime.value));
     if (normalizedSelectedRuntime === normalizedPreferredRuntime) {
       didAutoSelectPreferredRuntime.current = true;
       return;
@@ -337,6 +340,8 @@ function RuntimeSwitchCard({
         >
           {pending ? t("voice.controls.refreshing") : t("voice.controls.refresh")}
         </Button>
+        <Row label={t("voice.controls.selectedRuntime")} value={selectedRuntimeSummary} />
+        <Row label={t("voice.controls.systemVoiceRuntime")} value={activeRuntimeSummary} />
 
         {applied && (
           <p className="text-[11px] text-emerald-400">{t("voice.controls.runtimeApplied")}</p>
@@ -368,15 +373,14 @@ function RuntimeOverviewCard({
   loadingLabel?: string;
 }>) {
   const profile = runtime?.runtime_capabilities?.compatibility_profile ?? runtime?.voice_pipeline?.profile ?? null;
-  const provider = runtime?.provider ?? null;
+  const provider = canonicalRuntimeId(runtime?.provider ?? runtime?.runtime_id ?? "");
   const model = runtime?.model_name ?? null;
   const endpoint = runtime?.endpoint ?? null;
   const probeStatus = runtime?.runtime_capabilities?.probe_status ?? null;
-  const activeVoiceRuntime = provider || model ? `${provider ?? "—"} / ${model ?? "—"}` : null;
+  const activeVoiceRuntime = provider || model ? formatRuntimeTuple(provider, model) : null;
   const runtimeProvider = String(provider ?? "").trim().toLowerCase();
   const isNativeVoiceRuntime =
-    runtimeProvider.startsWith("multi_runtime") ||
-    runtimeProvider.startsWith("gemma4_audio");
+    isMultiRuntime(runtimeProvider);
   const probeTone = (() => {
     if (!probeStatus) return "neutral" as const;
     if (probeStatus === "verified") return "success" as const;
@@ -394,7 +398,7 @@ function RuntimeOverviewCard({
         <>
           <div className="flex items-center justify-between gap-2 mb-2">
             <span className="text-sm font-semibold text-white truncate">
-              {provider ?? "—"} / {model ?? t("voice.controls.unknownModel")}
+              {formatRuntimeTuple(provider, model ?? t("voice.controls.unknownModel"))}
             </span>
             {probeStatus && (
               <Badge tone={probeTone} className="shrink-0 text-[10px]">
@@ -461,7 +465,7 @@ function VoiceSessionCard({
       {(session.audio_runtime_provider || session.audio_runtime_model) && (
         <Row
           label={t("voice.controls.responseRuntime")}
-          value={`${session.audio_runtime_provider ?? "—"} / ${session.audio_runtime_model ?? "—"}`}
+          value={formatRuntimeTuple(session.audio_runtime_provider, session.audio_runtime_model)}
         />
       )}
       {session.reasoning_summary_status && (

--- a/web-next/lib/i18n/locales/voice/de.ts
+++ b/web-next/lib/i18n/locales/voice/de.ts
@@ -20,6 +20,7 @@ export const voice = {
     systemStatus: "Systemstatus",
     runtimeApplied: "Runtime angewendet ✓",
     systemVoiceRuntime: "System-Voice-Runtime",
+    selectedRuntime: "Ausgewählte Runtime",
     responseRuntime: "Antwort-Runtime",
     voiceRuntimePriority: "Runtime {{runtime}} hat Priorität für Voice.",
     diagnostics: "Dev-Diagnose",

--- a/web-next/lib/i18n/locales/voice/en.ts
+++ b/web-next/lib/i18n/locales/voice/en.ts
@@ -20,6 +20,7 @@ export const voice = {
     systemStatus: "System status",
     runtimeApplied: "Runtime applied ✓",
     systemVoiceRuntime: "System voice runtime",
+    selectedRuntime: "Selected runtime",
     responseRuntime: "Response runtime",
     voiceRuntimePriority: "Runtime {{runtime}} is preferred for voice.",
     diagnostics: "Dev diagnostics",

--- a/web-next/lib/i18n/locales/voice/pl.ts
+++ b/web-next/lib/i18n/locales/voice/pl.ts
@@ -20,6 +20,7 @@ export const voice = {
     systemStatus: "Status systemu",
     runtimeApplied: "Runtime przełączony ✓",
     systemVoiceRuntime: "Runtime systemowy voice",
+    selectedRuntime: "Wybrany runtime",
     responseRuntime: "Runtime odpowiedzi",
     voiceRuntimePriority: "Runtime {{runtime}} ma pierwszeństwo dla voice.",
     diagnostics: "Diagnostyka dev",

--- a/web-next/lib/runtime-id.ts
+++ b/web-next/lib/runtime-id.ts
@@ -1,0 +1,25 @@
+const MULTI_RUNTIME_ID = "multi_runtime";
+const LEGACY_MULTI_RUNTIME_ID = "gemma4_audio";
+
+export function normalizeRuntimeId(value: string | null | undefined): string {
+  const candidate = (value || "").trim().toLowerCase();
+  if (!candidate) return "";
+  const atIndex = candidate.indexOf("@");
+  const base = atIndex >= 0 ? candidate.slice(0, atIndex) : candidate;
+  if (base === LEGACY_MULTI_RUNTIME_ID) {
+    return atIndex >= 0 ? `${MULTI_RUNTIME_ID}${candidate.slice(atIndex)}` : MULTI_RUNTIME_ID;
+  }
+  return candidate;
+}
+
+export function canonicalRuntimeId(value: string | null | undefined): string {
+  const normalized = normalizeRuntimeId(value);
+  const atIndex = normalized.indexOf("@");
+  if (atIndex < 0) return normalized;
+  return normalized.slice(0, atIndex);
+}
+
+export function isMultiRuntime(value: string | null | undefined): boolean {
+  const normalized = canonicalRuntimeId(value);
+  return normalized === MULTI_RUNTIME_ID;
+}

--- a/web-next/tests/component-test-setup.ts
+++ b/web-next/tests/component-test-setup.ts
@@ -50,3 +50,15 @@ if (!("cancelAnimationFrame" in globalThis)) {
 }
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const originalConsoleError = console.error.bind(console);
+console.error = (...args: unknown[]) => {
+  const first = args[0];
+  if (
+    typeof first === "string"
+    && first.includes("not wrapped in act")
+  ) {
+    return;
+  }
+  originalConsoleError(...args);
+};

--- a/web-next/tests/component-test-setup.ts
+++ b/web-next/tests/component-test-setup.ts
@@ -50,15 +50,3 @@ if (!("cancelAnimationFrame" in globalThis)) {
 }
 
 (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-
-const originalConsoleError = console.error.bind(console);
-console.error = (...args: unknown[]) => {
-  const first = args[0];
-  if (
-    typeof first === "string"
-    && first.includes("not wrapped in act")
-  ) {
-    return;
-  }
-  originalConsoleError(...args);
-};

--- a/web-next/tests/dev-diagnostics-drawer.component.test.tsx
+++ b/web-next/tests/dev-diagnostics-drawer.component.test.tsx
@@ -39,34 +39,34 @@ function makeAudioStatus() {
       runtime: {
         stt_model: "medium",
         stt_device: "cuda",
-        llm_service_id: "gemma4_audio",
+        llm_service_id: "multi_runtime",
         llm_model: "google/gemma-4-E2B-it",
         tts_sample_rate: 24000,
       },
-      pipeline_id: "gemma4_audio_piper",
-      audio_runtime_provider: "gemma4_audio",
+      pipeline_id: "multi_runtime_piper",
+      audio_runtime_provider: "multi_runtime",
       audio_runtime_model: "google/gemma-4-E2B-it",
       audio_input_status: "verified",
-      decoder_source: "gemma4_audio",
+      decoder_source: "multi_runtime",
       fallback_reason: null,
       native_audio_ms: 1200,
-      runtime_log_path: "/var/log/venom/gemma4_audio.log",
+      runtime_log_path: "/var/log/venom/multi_runtime.log",
     },
     runtime_snapshot: {
-      runtime_id: "gemma4_audio@http://localhost:8014/v1",
-      provider: "gemma4_audio",
+      runtime_id: "multi_runtime://localhost:8014/v1",
+      provider: "multi_runtime",
       model_name: "google/gemma-4-E2B-it",
       endpoint: "http://localhost:8014/v1",
       config_hash: "cfg123",
       runtime_capabilities: {
-        compatibility_profile: "gemma4_audio_native",
+        compatibility_profile: "multi_runtime_native",
         probe_status: "verified",
         probes: {
           health: { status: "verified" },
         },
       },
       voice_pipeline: {
-        profile: "gemma4_audio_native",
+        profile: "multi_runtime_native",
         stt: "native_audio",
         reasoning: "native_audio_model",
         tools: "disabled",
@@ -123,10 +123,12 @@ describe("DevDiagnosticsDrawer", () => {
     assert.ok(screen.getByText("Sygnał: ws:open"));
     assert.ok(screen.getByText("Chunki: 2"));
     assert.ok(screen.getByText("render: debug"));
-    assert.ok(screen.getByText("Dostawca: gemma4_audio"));
+    assert.ok(screen.getByText("Dostawca: multi_runtime"));
     assert.ok(screen.getAllByText("ID sesji: session-123").length >= 2);
     assert.ok(screen.getByText("Hash konfiguracji"));
     assert.ok(screen.getByText("Pipeline głosu"));
+    assert.ok(screen.getByText(/LLM multi_runtime:google\/gemma-4-E2B-it/));
+    assert.ok(screen.getByText(/STT backend:\s+multi_runtime \(google\/gemma-4-E2B-it\)/));
     assert.ok(screen.getAllByText("Kanał gotowy").length >= 2);
     assert.ok(screen.getByText("Kopiuj runtime JSON"));
     assert.ok(screen.getByText("Kopiuj sesję JSON"));

--- a/web-next/tests/use-runtime-gemma4-audio.test.tsx
+++ b/web-next/tests/use-runtime-gemma4-audio.test.tsx
@@ -100,7 +100,7 @@ beforeEach(() => {
     if (url.endsWith("/api/v1/system/llm-servers/active")) {
       if (init?.method === "POST") {
         const body = JSON.parse(String(init.body ?? "{}")) as Record<string, string>;
-        assert.equal(body.server_name, "gemma4_audio");
+        assert.equal(body.server_name, "multi_runtime");
         assert.equal(body.model, "google/gemma-4-E2B-it");
         return new Response(JSON.stringify(payloads.activeServer), { status: 200 });
       }
@@ -136,7 +136,7 @@ function RuntimeHarness() {
 }
 
 describe("useRuntime gemma4_audio activation", () => {
-  it("uses inline model activation for gemma4_audio and does not switch via /models/switch", async () => {
+  it("canonicalizes gemma4_audio to multi_runtime and does not switch via /models/switch", async () => {
     render(
       <LanguageProvider>
         <ToastProvider>

--- a/web-next/tests/voice-command-center-debug.component.test.tsx
+++ b/web-next/tests/voice-command-center-debug.component.test.tsx
@@ -29,6 +29,8 @@ describe("VoiceCommandCenter debug mode", () => {
   };
 
   beforeEach(() => {
+    const rafTimers = new Map<number, ReturnType<typeof setTimeout>>();
+    let rafId = 0;
     window.history.replaceState({}, "", "http://localhost/voice?debug");
     Object.defineProperty(globalThis, "location", {
       configurable: true,
@@ -40,11 +42,22 @@ describe("VoiceCommandCenter debug mode", () => {
     });
     Object.defineProperty(globalThis, "requestAnimationFrame", {
       configurable: true,
-      value: () => 0,
+      value: (callback: FrameRequestCallback) => {
+        rafId += 1;
+        const timer = setTimeout(() => callback(Date.now()), 0);
+        rafTimers.set(rafId, timer);
+        return rafId;
+      },
     });
     Object.defineProperty(globalThis, "cancelAnimationFrame", {
       configurable: true,
-      value: () => undefined,
+      value: (id: number) => {
+        const timer = rafTimers.get(id);
+        if (timer) {
+          clearTimeout(timer);
+          rafTimers.delete(id);
+        }
+      },
     });
   });
 

--- a/web-next/tests/voice-command-center-debug.component.test.tsx
+++ b/web-next/tests/voice-command-center-debug.component.test.tsx
@@ -1,7 +1,7 @@
 import "./component-test-setup";
 import assert from "node:assert/strict";
 import { afterEach, beforeEach, describe, it, mock } from "node:test";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { VoiceCommandCenter } from "../components/voice/voice-command-center";
 import { isVoiceDevModeEnabled } from "../lib/voice-dev-mode";
 
@@ -9,11 +9,24 @@ afterEach(() => cleanup());
 
 describe("VoiceCommandCenter debug mode", () => {
   const originalFetch = globalThis.fetch;
+  const originalRaf = globalThis.requestAnimationFrame;
+  const originalCancelRaf = globalThis.cancelAnimationFrame;
   const matchMediaMock = mock.fn(() => ({
     matches: false,
     addEventListener() {},
     removeEventListener() {},
   }));
+  const renderAndFlush = async (ui: Parameters<typeof render>[0]) => {
+    await act(async () => {
+      render(ui);
+      await Promise.resolve();
+    });
+  };
+  const flushAsyncUi = async () => {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  };
 
   beforeEach(() => {
     window.history.replaceState({}, "", "http://localhost/voice?debug");
@@ -25,12 +38,28 @@ describe("VoiceCommandCenter debug mode", () => {
       configurable: true,
       value: matchMediaMock,
     });
+    Object.defineProperty(globalThis, "requestAnimationFrame", {
+      configurable: true,
+      value: () => 0,
+    });
+    Object.defineProperty(globalThis, "cancelAnimationFrame", {
+      configurable: true,
+      value: () => undefined,
+    });
   });
 
   afterEach(() => {
     window.history.replaceState({}, "", "http://localhost/");
     globalThis.fetch = originalFetch;
     matchMediaMock.mock.resetCalls();
+    Object.defineProperty(globalThis, "requestAnimationFrame", {
+      configurable: true,
+      value: originalRaf,
+    });
+    Object.defineProperty(globalThis, "cancelAnimationFrame", {
+      configurable: true,
+      value: originalCancelRaf,
+    });
   });
 
   it("shows dry-run badge and skips real fetches", async () => {
@@ -39,24 +68,26 @@ describe("VoiceCommandCenter debug mode", () => {
     });
     globalThis.fetch = fetchMock as typeof fetch;
 
-    render(<VoiceCommandCenter isDevMode />);
+    await renderAndFlush(<VoiceCommandCenter isDevMode />);
 
     await waitFor(() => {
       assert.ok(screen.getAllByText(/DEBUG DRY RUN/i).length >= 1);
     });
     assert.ok(screen.getByLabelText(/diagnostyka dev/i));
     assert.equal(fetchMock.mock.callCount(), 0);
+    await flushAsyncUi();
   });
 
   it("shows the diagnostics button even when dev mode is off", async () => {
     const fetchMock = mock.fn(async () => new Response("{}", { status: 200 }));
     globalThis.fetch = fetchMock as typeof fetch;
 
-    render(<VoiceCommandCenter />);
+    await renderAndFlush(<VoiceCommandCenter />);
 
     await waitFor(() => {
       assert.ok(screen.getByLabelText(/diagnostyka/i));
     });
+    await flushAsyncUi();
   });
 });
 

--- a/web-next/tests/voice-status-sidebar.component.test.tsx
+++ b/web-next/tests/voice-status-sidebar.component.test.tsx
@@ -45,13 +45,13 @@ const gemma4VoiceStatus = {
   ...voiceStatus,
   latest_voice_session: {
     session_id: "session-123",
-    pipeline_id: "gemma4_audio_piper",
+    pipeline_id: "multi_runtime_piper",
     voice_mode: "standard",
     audio_runtime_provider: "multi_runtime",
     audio_runtime_model: "google/gemma-4-E2B-it",
     reasoning_summary_enabled: true,
     reasoning_summary_status: "summary",
-    reasoning_summary: "pipeline=gemma4_audio_piper | mode=standard",
+    reasoning_summary: "pipeline=multi_runtime_piper | mode=standard",
     raw_thinking_available: true,
     emotion_detection_enabled: true,
     emotion_response_style_enabled: true,
@@ -63,16 +63,16 @@ const gemma4VoiceStatus = {
   },
   runtime_snapshot: {
     ...voiceStatus.runtime_snapshot,
-    runtime_id: "gemma4_audio@http://localhost:8014/v1",
-    provider: "gemma4_audio",
+    runtime_id: "multi_runtime://localhost:8014/v1",
+    provider: "multi_runtime",
     model_name: "google/gemma-4-E2B-it",
     endpoint: "http://localhost:8014/v1",
     runtime_capabilities: {
-      compatibility_profile: "gemma4_audio_native",
+      compatibility_profile: "multi_runtime_native",
       probe_status: "verified",
     },
     voice_pipeline: {
-      profile: "gemma4_audio_native",
+      profile: "multi_runtime_native",
       stt: "native_audio",
       reasoning: "native_audio_model",
       reasoning_summary: "summary",
@@ -149,10 +149,10 @@ const runtimeSelectionPayloads = {
     models: [],
     count: 0,
     providers: {
-      gemma4_audio: [
+      multi_runtime: [
         {
           name: "google/gemma-4-E2B-it",
-          provider: "gemma4_audio",
+          provider: "multi_runtime",
           source: "local-runtime",
           installed: true,
           active: true,
@@ -160,7 +160,7 @@ const runtimeSelectionPayloads = {
       ],
     },
     active: {
-      provider: "gemma4_audio",
+      provider: "multi_runtime",
       model: "google/gemma-4-E2B-it",
       endpoint: "http://localhost:8014/v1",
       status: "ready",
@@ -169,8 +169,8 @@ const runtimeSelectionPayloads = {
   runtimeOptions: {
     status: "success",
     active: {
-      runtime_id: "gemma4_audio",
-      active_server: "gemma4_audio",
+      runtime_id: "multi_runtime",
+      active_server: "multi_runtime",
       active_model: "google/gemma-4-E2B-it",
       active_endpoint: "http://localhost:8014/v1",
       config_hash: "cfg123",
@@ -178,7 +178,7 @@ const runtimeSelectionPayloads = {
     },
     runtimes: [
       {
-        runtime_id: "gemma4_audio",
+        runtime_id: "multi_runtime",
         source_type: "local-runtime",
         configured: true,
         available: true,
@@ -187,7 +187,7 @@ const runtimeSelectionPayloads = {
         models: [
           {
             name: "google/gemma-4-E2B-it",
-            provider: "gemma4_audio",
+            provider: "multi_runtime",
             source_type: "local-runtime",
             chat_compatible: true,
           },
@@ -198,11 +198,11 @@ const runtimeSelectionPayloads = {
   },
   activeServer: {
     status: "success",
-    active_server: "gemma4_audio",
+    active_server: "multi_runtime",
     active_endpoint: "http://localhost:8014/v1",
     active_model: "google/gemma-4-E2B-it",
     config_hash: "cfg123",
-    runtime_id: "gemma4_audio",
+    runtime_id: "multi_runtime",
     source_type: "local-runtime",
   },
   modelOperations: {
@@ -213,9 +213,16 @@ const runtimeSelectionPayloads = {
 } as const;
 
 describe("VoiceStatusSidebar", () => {
-  it("shows active runtime details and does not surface Gemma 4 controls for ollama", () => {
+  const renderAndFlush = async (ui: Parameters<typeof render>[0]) => {
+    await act(async () => {
+      render(ui);
+      await Promise.resolve();
+    });
+  };
+
+  it("shows active runtime details and does not surface Gemma 4 controls for ollama", async () => {
     window.history.pushState({}, "", "/voice");
-    render(
+    await renderAndFlush(
       <ToastProvider>
         <VoiceStatusSidebar status={voiceStatus as never} isDevMode={false} />
       </ToastProvider>,
@@ -228,7 +235,7 @@ describe("VoiceStatusSidebar", () => {
     assert.equal(screen.queryByText(/Gemma 4 Runtime/i), null);
   });
 
-  it("surfaces Gemma 4 runtime controls for gemma4_audio without dev gate", async () => {
+  it("surfaces Gemma 4 runtime controls for multi_runtime without dev gate", async () => {
     window.history.pushState({}, "", "/voice");
     globalThis.fetch = async (input: RequestInfo | URL) => {
       const url = String(input);
@@ -299,7 +306,7 @@ describe("VoiceStatusSidebar", () => {
       }
       throw new Error(`Unexpected fetch: ${url}`);
     };
-    render(
+    await renderAndFlush(
       <ToastProvider>
         <VoiceStatusSidebar status={gemma4VoiceStatus as never} isDevMode={false} />
       </ToastProvider>,
@@ -313,7 +320,7 @@ describe("VoiceStatusSidebar", () => {
     assert.ok(screen.getByText(/curious/i));
   });
 
-  it("normalizes generic backend apology in latest session response", () => {
+  it("normalizes generic backend apology in latest session response", async () => {
     window.history.pushState({}, "", "/voice");
     const statusWithGenericError = {
       ...gemma4VoiceStatus,
@@ -322,7 +329,7 @@ describe("VoiceStatusSidebar", () => {
         response_text: "Przepraszam, wystąpił błąd. Spróbuj ponownie.",
       },
     };
-    render(
+    await renderAndFlush(
       <ToastProvider>
         <VoiceStatusSidebar status={statusWithGenericError as never} isDevMode={false} />
       </ToastProvider>,
@@ -365,7 +372,7 @@ describe("VoiceStatusSidebar", () => {
       throw new Error(`Unexpected fetch: ${url}`);
     };
 
-    render(
+    await renderAndFlush(
       <ToastProvider>
         <VoiceStatusSidebar status={gemma4VoiceStatus as never} isDevMode={false} />
       </ToastProvider>,
@@ -378,15 +385,16 @@ describe("VoiceStatusSidebar", () => {
     assert.ok(await screen.findByText("multi_runtime health check failed"));
   });
 
-  it("keeps the active and response runtime labels distinct", () => {
+  it("keeps the active and response runtime labels distinct", async () => {
     window.history.pushState({}, "", "/voice");
-    render(
+    await renderAndFlush(
       <ToastProvider>
         <VoiceStatusSidebar status={gemma4VoiceStatus as never} isDevMode={false} />
       </ToastProvider>,
     );
 
-    assert.ok(screen.getByText("Runtime systemowy voice"));
+    assert.ok(screen.getAllByText("Runtime systemowy voice").length >= 1);
+    assert.ok(screen.getByText("Wybrany runtime"));
     assert.ok(screen.getByText("Runtime odpowiedzi"));
   });
 });


### PR DESCRIPTION
## Cel
Domknięcie PR245 end-to-end: ujednolicenie runtime truth/config, kontraktów trybów, nazewnictwa `multi_runtime`, frontendowego status truth oraz pełne evidence jakościowe.

## Zakres zmian
### 1) Faza 1 — Runtime truth i centralizacja konfiguracji
- Wprowadzono wspólny adapter odczytu konfiguracji runtime:
  - `services/multi_runtime/runtime_config.py`
- Przełączono helpery `services/multi_runtime/*` z rozproszonych odczytów env na wspólną warstwę:
  - `components.py`
  - `policies.py`
  - `stages/audio_output.py`
  - `stages/image_preprocessor.py`
- `services/multi_runtime/main.py` utrzymuje scentralizowany odczyt bootstrap config i snapshot startowy.

### 2) Faza 2 — Kontrakty trybów (`voice` / `text_chat` / `venom_agent`)
- Dodano centralny moduł kontraktów:
  - `venom_core/utils/mode_contracts.py`
- Podpięto kontrakt do statusów voice i endpointów runtime:
  - `venom_core/api/audio_stream.py`
  - `venom_core/api/routes/system_llm.py`
    - `/api/v1/system/llm-servers/active`
    - `/api/v1/system/llm-runtime/active`
    - `active` w `/api/v1/system/llm-runtime/options`

### 3) Faza 3 — Migracja nazewnictwa do `multi_runtime`
- Backend + testy: ograniczenie aliasu `gemma4_audio` do kontrolowanej kompatybilności.
- Kanonizacja runtime id oraz uporządkowanie payloadów/fixture tam, gdzie nie testujemy alias compatibility.

### 4) Faza 4 — Frontend runtime status truth
- Ujednolicona semantyka runtime/provider poza voice i w voice:
  - `web-next/lib/runtime-id.ts`
  - `web-next/components/models/hooks/use-runtime.ts`
  - `web-next/components/voice/*`
  - `web-next/components/layout/system-status-panel.tsx`
  - `web-next/components/layout/sidebar-sections.tsx`
  - `web-next/components/layout/mobile-nav.tsx`
- UI pokazuje kanoniczne `multi_runtime` zamiast historycznego aliasu tam, gdzie runtime jest prezentowany użytkownikowi.

### 5) Faza 5 — Trwałość i evidence
- Aktualizacja testów i kontraktów backend/frontend:
  - `tests/test_llm_runtime_options_api.py`
  - `tests/test_llm_runtime_activation_api.py`
  - `tests/test_audio_stream_handler_roi.py`
  - `web-next/tests/*` (status/diagnostics/runtime)

## Walidacja jakości (zielone)
Wykonane lokalnie:
1. `source .venv/bin/activate && make pr-fast` ✅
2. `source .venv/bin/activate && pytest -q tests/test_llm_runtime_options_api.py tests/test_llm_runtime_activation_api.py` ✅
3. `source .venv/bin/activate && pytest -q tests/test_217da_multi_runtime_pipeline_basics.py tests/test_217dc_pipeline_completion.py` ✅
4. `source .venv/bin/activate && pytest -q tests/test_audio_stream_handler_roi.py tests/test_llm_runtime_options_api.py` ✅
5. `cd web-next && npm run test:unit:components -- tests/voice-status-sidebar.component.test.tsx tests/dev-diagnostics-drawer.component.test.tsx` ✅

`make pr-fast` raportował:
- changed-lines coverage: `No coverable changed lines found (after exclusions).`
- coverage floors: `OK: coverage floors passed for 14 files.`

## Dla reviewerów
Proponowana kolejność review:
1. `venom_core/utils/mode_contracts.py` + użycia w `audio_stream.py` i `system_llm.py`.
2. `services/multi_runtime/runtime_config.py` + migracja helperów `services/multi_runtime/*`.
3. `web-next/lib/runtime-id.ts` + integracja w `use-runtime` i komponentach statusowych.
4. Testy kontraktowe backend (`tests/test_llm_runtime_*`, `tests/test_audio_stream_handler_roi.py`) i komponentowe frontend.

## Ryzyka / uwagi
- Alias `gemma4_audio` pozostaje tylko w kontrolowanych miejscach kompatybilności/migracji.
- Znane warningi `act(...)` w części testów komponentowych są niezależne od tego zakresu i nie blokują tej zmiany.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Multi-runtime voice support now available, replacing previous audio implementation with more flexible runtime configuration.
  * Enhanced runtime identification with canonical ID mapping for consistent display across the interface.

* **Improvements**
  * Centralized configuration management for runtime parameters (environment variables and settings consolidation).
  * Better UI labeling and identification of active runtimes in voice chat, diagnostics, and control panels.
  * Improved diagnostic tools with normalized runtime provider display.

* **Tests**
  * Updated test coverage for multi-runtime functionality and API endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpieniak01/Venom/pull/509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->