### PR TITLE
PR245C: ujednolicenie semantyki runtime switch (voice + text)

### DIFF
--- a/config/pytest-groups/long.txt
+++ b/config/pytest-groups/long.txt
@@ -25,6 +25,7 @@ tests/test_policy_gate_integration.py
 tests/test_rag_boost_integration.py
 tests/test_rag_integration.py
 tests/test_routing_integration.py
+tests/test_runtime_switch_gate.py
 tests/test_sonar_change_scope_resolver.py
 tests/test_system_routes_integration_regression.py
 tests/test_test_intelligence_report.py

--- a/config/pytest-groups/sonar-new-code.txt
+++ b/config/pytest-groups/sonar-new-code.txt
@@ -253,6 +253,7 @@ tests/test_runtime_policy_regression_contracts.py
 tests/test_runtime_registry_contracts.py
 tests/test_runtime_registry_translation_contracts.py
 tests/test_runtime_service_helpers.py
+tests/test_runtime_switch_gate.py
 tests/test_runtime_switch_service_branches.py
 tests/test_runtime_switch_telemetry.py
 tests/test_scheduler.py

--- a/config/testing/test_catalog.json
+++ b/config/testing/test_catalog.json
@@ -1052,6 +1052,20 @@
       "rationale": "Changed-scope coverage reinforcement for Sonar new-code lane."
     },
     {
+      "path": "tests/test_runtime_switch_gate.py",
+      "domain": "testing_tooling",
+      "test_type": "gate",
+      "intent": "gate",
+      "primary_lane": "new-code",
+      "allowed_lanes": [
+        "new-code",
+        "ci-lite",
+        "release"
+      ],
+      "legacy_targeted": false,
+      "rationale": "Changed-scope coverage reinforcement for runtime switch gate regression."
+    },
+    {
       "path": "tests/test_audit_lite_deps.py",
       "domain": "audit",
       "test_type": "gate",

--- a/tests/test_audio_stream_handler_roi.py
+++ b/tests/test_audio_stream_handler_roi.py
@@ -7,9 +7,11 @@ from unittest.mock import AsyncMock, MagicMock
 
 import numpy as np
 import pytest
+from fastapi import HTTPException
 
 import venom_core.api.audio_stream as audio_stream_mod
 from venom_core.api.audio_stream import AudioStreamHandler, get_audio_stream_handler
+from venom_core.services import runtime_switch_gate as gate
 from venom_core.utils.mode_contracts import (
     MODE_CONTRACTS,
     VOICE_EXECUTION_CONTEXT,
@@ -260,6 +262,51 @@ def test_get_audio_stream_handler_returns_same_instance(monkeypatch):
     first = get_audio_stream_handler()
     second = get_audio_stream_handler()
     assert first is second
+
+
+@pytest.mark.asyncio
+async def test_native_voice_pipeline_rejects_during_runtime_switch(
+    monkeypatch, tmp_path
+):
+    handler = _make_handler()
+    handler.audio_engine = MagicMock()
+    monkeypatch.setattr(handler, "_multi_runtime_runtime_selected", lambda: True)
+    monkeypatch.setattr(
+        handler,
+        "_multi_runtime_health_ok",
+        AsyncMock(return_value=True),
+    )
+    monkeypatch.setattr(handler, "_send_json", AsyncMock())
+    monkeypatch.setattr(handler, "_update_voice_session_metadata", lambda *a, **k: None)
+    monkeypatch.setattr(
+        handler,
+        "_build_runtime_metadata",
+        lambda *_a, **_k: {"llm_service_id": "ollama", "llm_model": "qwen3.5:latest"},
+    )
+    invoke_multi_runtime = AsyncMock(return_value={"text": "ok"})
+    monkeypatch.setattr(handler, "_invoke_multi_runtime", invoke_multi_runtime)
+
+    snapshot = gate.begin_runtime_switch(
+        source="ui",
+        from_runtime="ollama",
+        to_runtime="multi_runtime",
+        reason="test",
+    )
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await handler._process_native_multi_runtime_pipeline(
+                connection_id=1,
+                session_dir=tmp_path,
+                wav_path=tmp_path / "recording.wav",
+                timings_ms={},
+                total_started_at=0.0,
+                operator_agent=object(),
+            )
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail["code"] == "runtime_switch_in_progress"
+        assert invoke_multi_runtime.await_count == 0
+    finally:
+        gate.finish_runtime_switch(switch_id=snapshot.switch_id)
     # Cleanup
     monkeypatch.setattr(audio_stream_mod, "audio_stream_handler", None)
 

--- a/tests/test_llm_server_selection.py
+++ b/tests/test_llm_server_selection.py
@@ -1,11 +1,14 @@
 """Unit tests for active LLM server selection (PR 069)."""
 
 import asyncio
+from datetime import UTC, datetime
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import HTTPException
 
+import venom_core.main as main_module
 from tests.helpers.url_fixtures import LOCALHOST_11434_V1
 from venom_core.api.routes import system_llm as system_routes
 from venom_core.config import SETTINGS
@@ -469,6 +472,85 @@ async def test_set_active_llm_server_waits_for_active_runtime_requests_to_drain(
         release.set()
         await task
         _restore_settings(original)
+
+
+@pytest.mark.asyncio
+async def test_audio_status_endpoint_marks_latest_session_as_stale_after_runtime_switch(
+    monkeypatch,
+):
+    class DummyHandler:
+        def get_status(self, operator_agent=None):
+            return {
+                "enabled": True,
+                "connected_clients": 1,
+                "active_recordings": 0,
+                "message": "ok",
+            }
+
+        def get_latest_voice_session(self):
+            return {
+                "session_id": "session-1",
+                "created_at": "2026-05-24T09:00:00+00:00",
+                "audio_runtime_provider": "multi_runtime",
+                "audio_runtime_model": "google/gemma-4-E2B-it",
+            }
+
+    monkeypatch.setattr(main_module, "audio_stream_handler", DummyHandler())
+    monkeypatch.setattr(main_module, "operator_agent", object())
+    monkeypatch.setattr(
+        main_module,
+        "_build_voice_runtime_snapshot",
+        AsyncMock(
+            return_value={
+                "runtime_id": "ollama@localhost",
+                "provider": "ollama",
+                "model_name": "qwen3.5:latest",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "get_last_runtime_switch_event",
+        lambda: {"at_utc": "2026-05-24T09:10:00+00:00"},
+    )
+    request = SimpleNamespace(url_for=lambda name: f"https://example.test/{name}")
+
+    status = await main_module.audio_status_endpoint(request)
+
+    assert status["runtime_alignment"]["latest_session_before_runtime_switch"] is True
+    assert status["runtime_alignment"]["response_runtime_fresh"] is False
+    assert status["runtime_alignment"]["response_runtime_matches_active"] is False
+
+
+def test_main_voice_runtime_alignment_helpers_cover_parse_and_identity(monkeypatch):
+    assert main_module._parse_iso_datetime(None) is None
+    assert main_module._parse_iso_datetime("2026-05-24T09:10:00Z") == datetime(
+        2026, 5, 24, 9, 10, tzinfo=UTC
+    )
+    assert (
+        main_module._same_runtime_identity(
+            " Ollama ",
+            " Qwen3.5:Latest ",
+            "ollama",
+            "qwen3.5:latest",
+        )
+        is True
+    )
+
+    monkeypatch.setattr(
+        main_module,
+        "get_last_runtime_switch_event",
+        lambda: {"at_utc": "2026-05-24T09:10:00+00:00"},
+    )
+    alignment = main_module._build_voice_runtime_alignment(
+        runtime_snapshot={"provider": "ollama", "model_name": "qwen3.5:latest"},
+        latest_session=None,
+    )
+
+    assert alignment["latest_session_created_at"] is None
+    assert alignment["latest_session_before_runtime_switch"] is False
+    assert alignment["response_runtime_fresh"] is False
+    assert alignment["response_runtime_matches_active"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm_server_selection.py
+++ b/tests/test_llm_server_selection.py
@@ -4,10 +4,12 @@ import asyncio
 from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 
 from tests.helpers.url_fixtures import LOCALHOST_11434_V1
 from venom_core.api.routes import system_llm as system_routes
 from venom_core.config import SETTINGS
+from venom_core.services import runtime_switch_gate as gate
 from venom_core.services import runtime_switch_service
 from venom_core.services.runtime_switch_telemetry import (
     assert_runtime_switch_source_allowed,
@@ -356,6 +358,116 @@ async def test_set_active_llm_server_waits_for_previous_runtime_shutdown_before_
         assert shutdown_calls == [("vllm", "http://localhost:8001/models")]
         assert controller.actions == [("vllm", "stop"), ("ollama", "start")]
     finally:
+        _restore_settings(original)
+
+
+@pytest.mark.asyncio
+async def test_set_active_llm_server_waits_for_active_runtime_requests_to_drain(
+    monkeypatch,
+):
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _active_request():
+        async with gate.runtime_request_guard(
+            request_kind="voice_chat",
+            provider="ollama",
+            model="qwen3.5:latest",
+        ):
+            entered.set()
+            await release.wait()
+
+    task = asyncio.create_task(_active_request())
+    await entered.wait()
+
+    config = {
+        "LAST_MODEL_OLLAMA": "phi3:mini",
+        "PREVIOUS_MODEL_OLLAMA": "",
+        "LLM_MODEL_NAME": "phi3:mini",
+    }
+    updates = {}
+    monkeypatch.setattr(
+        system_routes.config_manager, "get_config", lambda **_: config.copy()
+    )
+    monkeypatch.setattr(
+        system_routes.config_manager, "update_config", _capture_update_config(updates)
+    )
+    controller = DummyController(
+        [
+            {
+                "name": "ollama",
+                "supports": {"start": True, "stop": True},
+                "endpoint": "",
+                "health_url": "http://localhost:11434/api/tags",
+            }
+        ]
+    )
+    monkeypatch.setattr(system_routes.system_deps, "_llm_controller", controller)
+    monkeypatch.setattr(
+        system_routes.system_deps,
+        "_model_manager",
+        DummyModelManager([{"name": "phi3:mini", "provider": "ollama"}]),
+    )
+    monkeypatch.setattr(system_routes.system_deps, "_request_tracer", None)
+    monkeypatch.setattr(system_routes, "_installed_local_servers", lambda: {"ollama"})
+
+    class _DummySwitchState:
+        def __init__(self):
+            self.completed = []
+
+        def mark_done(self, step):
+            self.completed.append(step)
+
+        def to_payload(self):
+            return {
+                "completed_steps": [step.value for step in self.completed],
+                "is_complete": True,
+            }
+
+    class _DummyOrchestrator:
+        def __init__(self, _controller):
+            self._controller = _controller
+
+        async def execute_lifecycle_switch(self, **_kwargs):
+            return (
+                _DummySwitchState(),
+                {},
+                {},
+                {"ok": True},
+                {
+                    "name": "ollama",
+                    "endpoint": "",
+                },
+            )
+
+    monkeypatch.setattr(system_routes, "RuntimeSwitchOrchestrator", _DummyOrchestrator)
+
+    original = _snapshot_settings()
+    SETTINGS.LLM_SERVICE_TYPE = "local"
+    SETTINGS.LLM_LOCAL_ENDPOINT = LOCALHOST_11434_V1
+    SETTINGS.LLM_MODEL_NAME = "phi3:mini"
+    SETTINGS.ACTIVE_LLM_SERVER = "ollama"
+    SETTINGS.VENOM_RUNTIME_PROFILE = "full"
+
+    request = system_routes.ActiveLlmServerRequest(server_name="ollama")
+    try:
+        response_task = asyncio.create_task(
+            system_routes.set_active_llm_server(request)
+        )
+        await asyncio.sleep(0.05)
+        assert not response_task.done()
+
+        with pytest.raises(HTTPException) as exc_info:
+            async with gate.runtime_request_guard(request_kind="simple_chat"):
+                pass
+        assert exc_info.value.status_code == 409
+
+        release.set()
+        response = await response_task
+        assert response["status"] == "success"
+    finally:
+        release.set()
+        await task
         _restore_settings(original)
 
 

--- a/tests/test_llm_server_selection.py
+++ b/tests/test_llm_server_selection.py
@@ -457,7 +457,12 @@ async def test_set_active_llm_server_waits_for_active_runtime_requests_to_drain(
         response_task = asyncio.create_task(
             system_routes.set_active_llm_server(request)
         )
-        await asyncio.sleep(0.05)
+        for _ in range(50):
+            if gate.get_runtime_switch_gate_snapshot().in_progress:
+                break
+            await asyncio.sleep(0.01)
+        else:
+            pytest.fail("runtime switch gate was not opened in time")
         assert not response_task.done()
 
         with pytest.raises(HTTPException) as exc_info:

--- a/tests/test_llm_simple_logic.py
+++ b/tests/test_llm_simple_logic.py
@@ -7,11 +7,14 @@ from uuid import uuid4
 
 import httpx
 import pytest
+from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from tests.helpers.url_fixtures import MOCK_HTTP, http_url
+from venom_core.api.schemas.llm_simple import SimpleChatRequest
 from venom_core.main import app
 from venom_core.services import llm_simple_service, llm_simple_stream_service
+from venom_core.services import runtime_switch_gate as gate
 from venom_core.services.llm_simple_stream_service import SimpleStreamState
 
 
@@ -931,3 +934,22 @@ def test_stream_service_packet_update_and_post_attempt_branches() -> None:
     unknown_apply = llm_simple_stream_service.apply_post_attempt_action("stop")
     assert stop_action == "stop"
     assert unknown_apply == (False, False)
+
+
+@pytest.mark.asyncio
+async def test_stream_simple_chat_rejects_when_runtime_switch_is_active():
+    snapshot = gate.begin_runtime_switch(
+        source="ui",
+        from_runtime="ollama",
+        to_runtime="multi_runtime",
+        reason="test",
+    )
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await llm_simple_service.stream_simple_chat(
+                SimpleChatRequest(content="hello")
+            )
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.detail["code"] == "runtime_switch_in_progress"
+    finally:
+        gate.finish_runtime_switch(switch_id=snapshot.switch_id)

--- a/tests/test_main_internal_helpers.py
+++ b/tests/test_main_internal_helpers.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -328,6 +329,108 @@ async def test_audio_status_endpoint_marks_latest_session_as_stale_after_runtime
     assert status["runtime_alignment"]["latest_session_before_runtime_switch"] is True
     assert status["runtime_alignment"]["response_runtime_fresh"] is False
     assert status["runtime_alignment"]["response_runtime_matches_active"] is False
+
+
+def test_parse_iso_datetime_handles_blank_invalid_and_zulu():
+    assert main_module._parse_iso_datetime(None) is None
+    assert main_module._parse_iso_datetime("   ") is None
+    assert main_module._parse_iso_datetime("not-a-date") is None
+    assert main_module._parse_iso_datetime("2026-05-24T09:10:00Z") == datetime(
+        2026, 5, 24, 9, 10, tzinfo=UTC
+    )
+
+
+def test_same_runtime_identity_handles_missing_values_and_case_insensitive_match():
+    assert main_module._same_runtime_identity(None, "model", "ollama", "model") is None
+    assert main_module._same_runtime_identity("ollama", None, "ollama", "model") is None
+    assert (
+        main_module._same_runtime_identity(
+            " Ollama ",
+            " Qwen3.5:Latest ",
+            "ollama",
+            "qwen3.5:latest",
+        )
+        is True
+    )
+    assert (
+        main_module._same_runtime_identity(
+            "ollama",
+            "qwen3.5:latest",
+            "multi_runtime",
+            "qwen3.5:latest",
+        )
+        is False
+    )
+
+
+def test_build_voice_runtime_alignment_without_latest_session(monkeypatch):
+    monkeypatch.setattr(
+        main_module,
+        "get_last_runtime_switch_event",
+        lambda: {"at_utc": "2026-05-24T09:10:00Z"},
+    )
+
+    alignment = main_module._build_voice_runtime_alignment(
+        runtime_snapshot={"provider": "ollama", "model_name": "qwen3.5:latest"},
+        latest_session=None,
+    )
+
+    assert alignment["active_provider"] == "ollama"
+    assert alignment["active_model"] == "qwen3.5:latest"
+    assert alignment["latest_session_created_at"] is None
+    assert alignment["last_runtime_switch_at_utc"] == "2026-05-24T09:10:00Z"
+    assert alignment["latest_session_before_runtime_switch"] is False
+    assert alignment["response_runtime_fresh"] is False
+    assert alignment["response_runtime_matches_active"] is None
+
+
+@pytest.mark.asyncio
+async def test_audio_status_endpoint_includes_runtime_alignment_for_matching_session(
+    monkeypatch,
+):
+    class DummyHandler:
+        def get_status(self, operator_agent=None):
+            return {
+                "enabled": True,
+                "connected_clients": 1,
+                "active_recordings": 0,
+                "message": "ok",
+            }
+
+        def get_latest_voice_session(self):
+            return {
+                "session_id": "session-1",
+                "created_at": "2026-05-24T09:12:00+00:00",
+                "audio_runtime_provider": "ollama",
+                "audio_runtime_model": "qwen3.5:latest",
+            }
+
+    monkeypatch.setattr(main_module, "audio_stream_handler", DummyHandler())
+    monkeypatch.setattr(main_module, "operator_agent", object())
+    monkeypatch.setattr(
+        main_module,
+        "_build_voice_runtime_snapshot",
+        AsyncMock(
+            return_value={
+                "runtime_id": "ollama@localhost",
+                "provider": "ollama",
+                "model_name": "qwen3.5:latest",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "get_last_runtime_switch_event",
+        lambda: {"at_utc": "2026-05-24T09:00:00+00:00"},
+    )
+    request = SimpleNamespace(url_for=lambda name: f"https://example.test/{name}")
+
+    status = await main_module.audio_status_endpoint(request)
+
+    assert status["runtime_snapshot"]["provider"] == "ollama"
+    assert status["runtime_alignment"]["latest_session_before_runtime_switch"] is False
+    assert status["runtime_alignment"]["response_runtime_fresh"] is True
+    assert status["runtime_alignment"]["response_runtime_matches_active"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_main_internal_helpers.py
+++ b/tests/test_main_internal_helpers.py
@@ -218,12 +218,14 @@ async def test_audio_status_endpoint_includes_latest_session_download_url(monkey
 
     monkeypatch.setattr(main_module, "audio_stream_handler", DummyHandler())
     monkeypatch.setattr(main_module, "operator_agent", object())
+    monkeypatch.setattr(main_module, "get_last_runtime_switch_event", lambda: None)
     monkeypatch.setattr(
         main_module,
         "_build_voice_runtime_snapshot",
         AsyncMock(
             return_value={
                 "runtime_id": "ollama@localhost",
+                "provider": "ollama",
                 "model_name": "gemma4:latest",
             }
         ),
@@ -238,6 +240,9 @@ async def test_audio_status_endpoint_includes_latest_session_download_url(monkey
     )
     assert status["latest_voice_session"]["transcription"] == "hello"
     assert status["runtime_snapshot"]["model_name"] == "gemma4:latest"
+    assert status["runtime_alignment"]["active_provider"] == "ollama"
+    assert status["runtime_alignment"]["active_model"] == "gemma4:latest"
+    assert status["runtime_alignment"]["response_runtime_fresh"] is True
 
 
 @pytest.mark.asyncio
@@ -245,6 +250,7 @@ async def test_audio_status_endpoint_returns_disabled_state_without_handler(
     monkeypatch,
 ):
     monkeypatch.setattr(main_module, "audio_stream_handler", None)
+    monkeypatch.setattr(main_module, "get_last_runtime_switch_event", lambda: None)
     monkeypatch.setattr(
         main_module,
         "_build_voice_runtime_snapshot",
@@ -262,6 +268,7 @@ async def test_audio_status_endpoint_returns_disabled_state_without_handler(
 @pytest.mark.asyncio
 async def test_audio_status_endpoint_handles_runtime_snapshot_failure(monkeypatch):
     monkeypatch.setattr(main_module, "audio_stream_handler", None)
+    monkeypatch.setattr(main_module, "get_last_runtime_switch_event", lambda: None)
     monkeypatch.setattr(
         main_module,
         "_build_voice_runtime_snapshot",
@@ -273,6 +280,54 @@ async def test_audio_status_endpoint_handles_runtime_snapshot_failure(monkeypatc
 
     assert status["enabled"] is False
     assert status["runtime_snapshot"]["error"] == "boom"
+
+
+@pytest.mark.asyncio
+async def test_audio_status_endpoint_marks_latest_session_as_stale_after_runtime_switch(
+    monkeypatch,
+):
+    class DummyHandler:
+        def get_status(self, operator_agent=None):
+            return {
+                "enabled": True,
+                "connected_clients": 1,
+                "active_recordings": 0,
+                "message": "ok",
+            }
+
+        def get_latest_voice_session(self):
+            return {
+                "session_id": "session-1",
+                "created_at": "2026-05-24T09:00:00+00:00",
+                "audio_runtime_provider": "multi_runtime",
+                "audio_runtime_model": "google/gemma-4-E2B-it",
+            }
+
+    monkeypatch.setattr(main_module, "audio_stream_handler", DummyHandler())
+    monkeypatch.setattr(main_module, "operator_agent", object())
+    monkeypatch.setattr(
+        main_module,
+        "_build_voice_runtime_snapshot",
+        AsyncMock(
+            return_value={
+                "runtime_id": "ollama@localhost",
+                "provider": "ollama",
+                "model_name": "qwen3.5:latest",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        main_module,
+        "get_last_runtime_switch_event",
+        lambda: {"at_utc": "2026-05-24T09:10:00+00:00"},
+    )
+    request = SimpleNamespace(url_for=lambda name: f"https://example.test/{name}")
+
+    status = await main_module.audio_status_endpoint(request)
+
+    assert status["runtime_alignment"]["latest_session_before_runtime_switch"] is True
+    assert status["runtime_alignment"]["response_runtime_fresh"] is False
+    assert status["runtime_alignment"]["response_runtime_matches_active"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_switch_gate.py
+++ b/tests/test_runtime_switch_gate.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from fastapi import HTTPException
+
+from venom_core.services import runtime_switch_gate as gate
+
+
+@pytest.fixture(autouse=True)
+def reset_runtime_switch_gate():
+    with gate._STATE_LOCK:  # noqa: SLF001
+        gate._STATE = gate._RuntimeSwitchGateState()  # noqa: SLF001
+    yield
+    with gate._STATE_LOCK:  # noqa: SLF001
+        gate._STATE = gate._RuntimeSwitchGateState()  # noqa: SLF001
+
+
+def test_runtime_request_guard_blocks_when_switch_is_active():
+    snapshot = gate.begin_runtime_switch(
+        source="ui",
+        from_runtime="ollama",
+        to_runtime="multi_runtime",
+        reason="test",
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+
+        async def _blocked():
+            async with gate.runtime_request_guard(request_kind="simple_chat"):
+                return None
+
+        asyncio.run(_blocked())
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["code"] == "runtime_switch_in_progress"
+
+    gate.finish_runtime_switch(switch_id=snapshot.switch_id)
+
+
+@pytest.mark.asyncio
+async def test_runtime_switch_waits_for_active_requests_to_drain():
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _active_request():
+        async with gate.runtime_request_guard(
+            request_kind="voice_chat",
+            provider="ollama",
+            model="qwen3.5:latest",
+        ):
+            entered.set()
+            await release.wait()
+
+    task = asyncio.create_task(_active_request())
+    await entered.wait()
+
+    snapshot = gate.begin_runtime_switch(
+        source="ui",
+        from_runtime="ollama",
+        to_runtime="multi_runtime",
+        reason="test",
+    )
+
+    drain_task = asyncio.create_task(gate.wait_for_runtime_requests_to_drain())
+    await asyncio.sleep(0.05)
+    assert not drain_task.done()
+
+    release.set()
+    assert await drain_task is True
+
+    gate.finish_runtime_switch(switch_id=snapshot.switch_id)
+    await task

--- a/tests/test_runtime_switch_gate.py
+++ b/tests/test_runtime_switch_gate.py
@@ -72,3 +72,22 @@ async def test_runtime_switch_waits_for_active_requests_to_drain():
 
     gate.finish_runtime_switch(switch_id=snapshot.switch_id)
     await task
+
+
+def test_finish_runtime_switch_ignores_mismatched_switch_id():
+    snapshot = gate.begin_runtime_switch(
+        source="ui",
+        from_runtime="ollama",
+        to_runtime="multi_runtime",
+        reason="test",
+    )
+
+    gate.finish_runtime_switch(switch_id="different-switch-id")
+    current = gate.get_runtime_switch_gate_snapshot()
+    assert current.in_progress is True
+    assert current.switch_id == snapshot.switch_id
+
+    gate.finish_runtime_switch(switch_id=snapshot.switch_id)
+    closed = gate.get_runtime_switch_gate_snapshot()
+    assert closed.in_progress is False
+    assert closed.switch_id is None

--- a/venom_core/api/audio_stream.py
+++ b/venom_core/api/audio_stream.py
@@ -987,6 +987,8 @@ class AudioStreamHandler:
             {
                 **snapshot,
                 "pipeline_id": "multi_runtime_piper",
+                "audio_runtime_provider": MULTI_RUNTIME_ID,
+                "audio_runtime_model": _coerce_str(runtime_result.get("model"), ""),
                 "audio_input_status": "verified",
                 "decoder_source": "multi_runtime",
                 "fallback_reason": "",
@@ -1312,6 +1314,7 @@ class AudioStreamHandler:
                 "history_scope": VOICE_HISTORY_SCOPE,
             }
         )
+        runtime_metadata = self._build_runtime_metadata(operator_agent)
         response_text = await _invoke_operator_agent(
             operator_agent,
             transcription,
@@ -1334,6 +1337,11 @@ class AudioStreamHandler:
                     raw_thinking_available=False,
                 ),
                 "timings_ms": timings_ms,
+                # In fallback whisper->LLM path, this pair must reflect the LLM that
+                # actually generated the response, not the native multi_runtime daemon.
+                "audio_runtime_provider": runtime_metadata.get("llm_service_id"),
+                "audio_runtime_model": runtime_metadata.get("llm_model"),
+                "runtime": runtime_metadata,
                 **self._voice_contract_payload(connection_id),
             },
         )

--- a/venom_core/api/audio_stream.py
+++ b/venom_core/api/audio_stream.py
@@ -22,6 +22,11 @@ from fastapi import WebSocket, WebSocketDisconnect
 from venom_core.config import SETTINGS
 from venom_core.perception.audio_engine import AudioEngine
 from venom_core.services.multi_runtime_models import multi_runtime_available_models
+from venom_core.services.runtime_switch_gate import (
+    assert_runtime_request_allowed,
+    get_runtime_switch_gate_status,
+    runtime_request_guard,
+)
 from venom_core.utils.llm_runtime import get_active_llm_runtime
 from venom_core.utils.logger import get_logger
 from venom_core.utils.mode_contracts import (
@@ -355,6 +360,7 @@ class AudioStreamHandler:
             "tts_fallback": getattr(voice, "is_fallback_mode", None),
             "dependencies": dependencies,
             "mode_contracts": mode_contracts_payload(),
+            "runtime_switch_gate": get_runtime_switch_gate_status(),
             **self._multi_runtime_runtime_snapshot(),
         }
 
@@ -934,89 +940,100 @@ class AudioStreamHandler:
             connection_id, {"type": "processing", "status": "native_audio"}
         )
 
-        native_started_at = time.perf_counter()
-        try:
-            runtime_result = await self._invoke_multi_runtime(wav_path, connection_id)
-        except Exception as exc:
+        async with runtime_request_guard(
+            request_kind="voice_native_runtime",
+            provider=MULTI_RUNTIME_ID,
+            model=_coerce_str(snapshot.get("audio_runtime_model"), ""),
+        ):
+            native_started_at = time.perf_counter()
+            try:
+                runtime_result = await self._invoke_multi_runtime(
+                    wav_path, connection_id
+                )
+            except Exception as exc:
+                timings_ms["native_audio_ms"] = self._elapsed_ms(native_started_at)
+                self._update_voice_session_metadata(
+                    session_dir,
+                    {
+                        **snapshot,
+                        "pipeline_id": "whisper_llm_piper",
+                        "audio_input_status": "fallback",
+                        "decoder_source": "faster_whisper",
+                        "fallback_reason": str(exc),
+                        "native_audio_ms": timings_ms["native_audio_ms"],
+                        **_build_voice_session_insights_payload(
+                            transcript="",
+                            response="",
+                            voice_mode=self._connection_voice_mode(connection_id),
+                            pipeline_id="whisper_llm_piper",
+                            **_multi_runtime_voice_flags(),
+                            raw_thinking_available=False,
+                        ),
+                        "timings_ms": timings_ms,
+                        "runtime": self._build_runtime_metadata(operator_agent),
+                        **self._voice_contract_payload(connection_id),
+                    },
+                )
+                logger.warning(
+                    "Gemma4 audio runtime failed for connection_id=%s: %s",
+                    connection_id,
+                    exc,
+                )
+                return False
+
             timings_ms["native_audio_ms"] = self._elapsed_ms(native_started_at)
+            transcription = runtime_result["text"]
+            response_text = runtime_result.get("response_text") or transcription
+            insights = _build_voice_session_insights_payload(
+                transcript=transcription,
+                response=response_text,
+                voice_mode=self._connection_voice_mode(connection_id),
+                pipeline_id="multi_runtime_piper",
+                **_multi_runtime_voice_flags(),
+                raw_thinking_available=bool(
+                    runtime_result.get("raw_thinking_available", False)
+                ),
+            )
+
             self._update_voice_session_metadata(
                 session_dir,
                 {
                     **snapshot,
-                    "pipeline_id": "whisper_llm_piper",
-                    "audio_input_status": "fallback",
-                    "decoder_source": "faster_whisper",
-                    "fallback_reason": str(exc),
+                    "pipeline_id": "multi_runtime_piper",
+                    "audio_runtime_provider": MULTI_RUNTIME_ID,
+                    "audio_runtime_model": _coerce_str(runtime_result.get("model"), ""),
+                    "audio_input_status": "verified",
+                    "decoder_source": "multi_runtime",
+                    "fallback_reason": "",
                     "native_audio_ms": timings_ms["native_audio_ms"],
-                    **_build_voice_session_insights_payload(
-                        transcript="",
-                        response="",
-                        voice_mode=self._connection_voice_mode(connection_id),
-                        pipeline_id="whisper_llm_piper",
-                        **_multi_runtime_voice_flags(),
-                        raw_thinking_available=False,
+                    "transcription": transcription,
+                    "transcription_length": len(transcription or ""),
+                    "response_text": response_text,
+                    "response_length": len(response_text or ""),
+                    "execution_trace": runtime_result.get("execution_trace") or [],
+                    "selected_policy": runtime_result.get("selected_policy"),
+                    "selected_image_strategy": runtime_result.get(
+                        "selected_image_strategy"
                     ),
+                    "retrieval_used": runtime_result.get("retrieval_used"),
+                    "retrieval_context_items": runtime_result.get(
+                        "retrieval_context_items"
+                    ),
+                    "retrieval_route": runtime_result.get("retrieval_route"),
+                    "assistant_used": runtime_result.get("assistant_used"),
+                    "economy_mode_activated": runtime_result.get(
+                        "economy_mode_activated"
+                    ),
+                    "degradation_reasons": runtime_result.get("degradation_reasons")
+                    or [],
+                    "component_snapshot": runtime_result.get("component_snapshot")
+                    or [],
+                    **insights,
                     "timings_ms": timings_ms,
                     "runtime": self._build_runtime_metadata(operator_agent),
                     **self._voice_contract_payload(connection_id),
                 },
             )
-            logger.warning(
-                "Gemma4 audio runtime failed for connection_id=%s: %s",
-                connection_id,
-                exc,
-            )
-            return False
-
-        timings_ms["native_audio_ms"] = self._elapsed_ms(native_started_at)
-        transcription = runtime_result["text"]
-        response_text = runtime_result.get("response_text") or transcription
-        insights = _build_voice_session_insights_payload(
-            transcript=transcription,
-            response=response_text,
-            voice_mode=self._connection_voice_mode(connection_id),
-            pipeline_id="multi_runtime_piper",
-            **_multi_runtime_voice_flags(),
-            raw_thinking_available=bool(
-                runtime_result.get("raw_thinking_available", False)
-            ),
-        )
-
-        self._update_voice_session_metadata(
-            session_dir,
-            {
-                **snapshot,
-                "pipeline_id": "multi_runtime_piper",
-                "audio_runtime_provider": MULTI_RUNTIME_ID,
-                "audio_runtime_model": _coerce_str(runtime_result.get("model"), ""),
-                "audio_input_status": "verified",
-                "decoder_source": "multi_runtime",
-                "fallback_reason": "",
-                "native_audio_ms": timings_ms["native_audio_ms"],
-                "transcription": transcription,
-                "transcription_length": len(transcription or ""),
-                "response_text": response_text,
-                "response_length": len(response_text or ""),
-                "execution_trace": runtime_result.get("execution_trace") or [],
-                "selected_policy": runtime_result.get("selected_policy"),
-                "selected_image_strategy": runtime_result.get(
-                    "selected_image_strategy"
-                ),
-                "retrieval_used": runtime_result.get("retrieval_used"),
-                "retrieval_context_items": runtime_result.get(
-                    "retrieval_context_items"
-                ),
-                "retrieval_route": runtime_result.get("retrieval_route"),
-                "assistant_used": runtime_result.get("assistant_used"),
-                "economy_mode_activated": runtime_result.get("economy_mode_activated"),
-                "degradation_reasons": runtime_result.get("degradation_reasons") or [],
-                "component_snapshot": runtime_result.get("component_snapshot") or [],
-                **insights,
-                "timings_ms": timings_ms,
-                "runtime": self._build_runtime_metadata(operator_agent),
-                **self._voice_contract_payload(connection_id),
-            },
-        )
 
         await self._send_json(
             connection_id,
@@ -1061,6 +1078,7 @@ class AudioStreamHandler:
             audio_buffer: Lista fragmentów audio
             operator_agent: Agent do przetwarzania
         """
+        assert_runtime_request_allowed(request_kind="voice_chat")
         try:
             total_started_at = time.perf_counter()
             timings_ms: dict[str, float] = {}
@@ -1165,6 +1183,7 @@ class AudioStreamHandler:
         mime_type: str = "",
     ):
         """Przetwarza nagranie z MediaRecorder przez ffmpeg -> WAV -> STT."""
+        assert_runtime_request_allowed(request_kind="voice_chat")
         try:
             total_started_at = time.perf_counter()
             timings_ms: dict[str, float] = {}
@@ -1315,75 +1334,82 @@ class AudioStreamHandler:
             }
         )
         runtime_metadata = self._build_runtime_metadata(operator_agent)
-        response_text = await _invoke_operator_agent(
-            operator_agent,
-            transcription,
-            mode=self._connection_voice_mode(connection_id),
-            voice_context=voice_context,
-        )
-        timings_ms["llm_ms"] = self._elapsed_ms(agent_started_at)
-        self._update_voice_session_metadata(
-            session_dir,
-            {
-                "pipeline_id": "whisper_llm_piper",
-                "response_text": response_text,
-                "response_length": len(response_text or ""),
-                **_build_voice_session_insights_payload(
-                    transcript=transcription,
-                    response=response_text,
-                    voice_mode=self._connection_voice_mode(connection_id),
-                    pipeline_id="whisper_llm_piper",
-                    **_multi_runtime_voice_flags(),
-                    raw_thinking_available=False,
-                ),
-                "timings_ms": timings_ms,
-                # In fallback whisper->LLM path, this pair must reflect the LLM that
-                # actually generated the response, not the native multi_runtime daemon.
-                "audio_runtime_provider": runtime_metadata.get("llm_service_id"),
-                "audio_runtime_model": runtime_metadata.get("llm_model"),
-                "runtime": runtime_metadata,
-                **self._voice_contract_payload(connection_id),
-            },
-        )
-        if not response_text:
-            logger.warning(
-                "Agent zwrócił pustą odpowiedź dla connection_id=%s%s",
-                connection_id,
-                empty_agent_response_log_suffix,
+        async with runtime_request_guard(
+            request_kind="voice_fallback_llm",
+            provider=_coerce_str(runtime_metadata.get("llm_service_id"), ""),
+            model=_coerce_str(runtime_metadata.get("llm_model"), ""),
+        ):
+            response_text = await _invoke_operator_agent(
+                operator_agent,
+                transcription,
+                mode=self._connection_voice_mode(connection_id),
+                voice_context=voice_context,
             )
-            await self._send_json(
-                connection_id,
+            timings_ms["llm_ms"] = self._elapsed_ms(agent_started_at)
+            self._update_voice_session_metadata(
+                session_dir,
                 {
-                    "type": "error",
-                    "message": "Agent returned empty response. Check runtime status.",
+                    "pipeline_id": "whisper_llm_piper",
+                    "response_text": response_text,
+                    "response_length": len(response_text or ""),
+                    **_build_voice_session_insights_payload(
+                        transcript=transcription,
+                        response=response_text,
+                        voice_mode=self._connection_voice_mode(connection_id),
+                        pipeline_id="whisper_llm_piper",
+                        **_multi_runtime_voice_flags(),
+                        raw_thinking_available=False,
+                    ),
+                    "timings_ms": timings_ms,
+                    # In fallback whisper->LLM path, this pair must reflect the LLM that
+                    # actually generated the response, not the native multi_runtime daemon.
+                    "audio_runtime_provider": runtime_metadata.get("llm_service_id"),
+                    "audio_runtime_model": runtime_metadata.get("llm_model"),
+                    "runtime": runtime_metadata,
+                    **self._voice_contract_payload(connection_id),
                 },
             )
-            return
+            if not response_text:
+                logger.warning(
+                    "Agent zwrócił pustą odpowiedź dla connection_id=%s%s",
+                    connection_id,
+                    empty_agent_response_log_suffix,
+                )
+                await self._send_json(
+                    connection_id,
+                    {
+                        "type": "error",
+                        "message": "Agent returned empty response. Check runtime status.",
+                    },
+                )
+                return
 
-        await self._send_json(
-            connection_id, {"type": "response_text", "text": response_text}
-        )
-        await self._send_json(connection_id, {"type": "processing", "status": "tts"})
-        audio_engine = self.audio_engine
-        if audio_engine is None:
-            logger.warning("Brak audio_engine podczas etapu TTS; pomijam speak().")
+            await self._send_json(
+                connection_id, {"type": "response_text", "text": response_text}
+            )
+            await self._send_json(
+                connection_id, {"type": "processing", "status": "tts"}
+            )
+            audio_engine = self.audio_engine
+            if audio_engine is None:
+                logger.warning("Brak audio_engine podczas etapu TTS; pomijam speak().")
+                await self._send_json(connection_id, {"type": "complete"})
+                return
+            tts_started_at = time.perf_counter()
+            audio_response = await audio_engine.speak(response_text)
+            timings_ms["tts_ms"] = self._elapsed_ms(tts_started_at)
+            timings_ms["total_backend_ms"] = self._elapsed_ms(total_started_at)
+            self._update_voice_session_metadata(
+                session_dir,
+                {
+                    "timings_ms": timings_ms,
+                    "runtime": self._build_runtime_metadata(operator_agent),
+                },
+            )
+            if audio_response is not None:
+                await self._send_audio(connection_id, audio_response)
+
             await self._send_json(connection_id, {"type": "complete"})
-            return
-        tts_started_at = time.perf_counter()
-        audio_response = await audio_engine.speak(response_text)
-        timings_ms["tts_ms"] = self._elapsed_ms(tts_started_at)
-        timings_ms["total_backend_ms"] = self._elapsed_ms(total_started_at)
-        self._update_voice_session_metadata(
-            session_dir,
-            {
-                "timings_ms": timings_ms,
-                "runtime": self._build_runtime_metadata(operator_agent),
-            },
-        )
-        if audio_response is not None:
-            await self._send_audio(connection_id, audio_response)
-
-        await self._send_json(connection_id, {"type": "complete"})
 
     def _persist_encoded_voice_session(
         self,

--- a/venom_core/api/routes/system_llm.py
+++ b/venom_core/api/routes/system_llm.py
@@ -2656,45 +2656,40 @@ async def _resolve_switch_model_selection(
     return selected_model, last_model_key, feedback_resolution
 
 
-@router.post(
-    "/system/llm-servers/active",
-    responses=LLM_SERVER_ACTIVATE_RESPONSES,
-)
-async def set_active_llm_server(request: ActiveLlmServerRequest):
-    """
-    Ustawia aktywny runtime LLM, zatrzymuje inne serwery i aktywuje model.
-    """
-    server_name = normalize_runtime_id(request.server_name)
+async def _set_active_llm_server_impl(
+    *,
+    request: ActiveLlmServerRequest,
+    server_name: str,
+    switch_source: str,
+) -> dict[str, Any]:
+    assert_runtime_switch_ownership_token(request.ownership_token)
+    _ensure_server_allowed(server_name)
+    requested_alias = str(request.model_alias or "").strip()
+    _validate_feedback_alias_request(
+        server_name=server_name, requested_alias=requested_alias
+    )
+    llm_controller = _get_llm_controller_or_503()
+    servers = llm_controller.list_servers()
+
+    request_tracer = system_deps.get_request_tracer()
+    model_manager = None
+    if server_name != "onnx":
+        _, model_manager, request_tracer = _validate_switch_dependencies()
+
+    if not llm_controller.has_server(server_name):
+        raise HTTPException(status_code=404, detail="Nieznany serwer LLM")
+
+    active_runtime = get_active_llm_runtime()
+    from_server = str(getattr(active_runtime, "provider", "") or "").strip().lower()
+    switch_gate = begin_runtime_switch(
+        source=switch_source,
+        from_runtime=from_server or "unknown",
+        to_runtime=server_name,
+        reason="set_active_llm_server",
+    )
     try:
-        switch_source = assert_runtime_switch_source_allowed(request.switch_source)
-        assert_runtime_switch_ownership_token(request.ownership_token)
-        _ensure_server_allowed(server_name)
-        requested_alias = str(request.model_alias or "").strip()
-        _validate_feedback_alias_request(
-            server_name=server_name, requested_alias=requested_alias
-        )
-        llm_controller = _get_llm_controller_or_503()
-        servers = llm_controller.list_servers()
-
-        request_tracer = system_deps.get_request_tracer()
-        model_manager = None
-        if server_name != "onnx":
-            _, model_manager, request_tracer = _validate_switch_dependencies()
-
-        if not llm_controller.has_server(server_name):
-            raise HTTPException(status_code=404, detail="Nieznany serwer LLM")
-
-        active_runtime = get_active_llm_runtime()
-        from_server = str(getattr(active_runtime, "provider", "") or "").strip().lower()
-        switch_gate = begin_runtime_switch(
-            source=switch_source,
-            from_runtime=from_server or "unknown",
-            to_runtime=server_name,
-            reason="set_active_llm_server",
-        )
         drain_ok = await wait_for_runtime_requests_to_drain(timeout_seconds=30.0)
         if not drain_ok:
-            finish_runtime_switch(switch_id=switch_gate.switch_id)
             raise HTTPException(
                 status_code=503,
                 detail=(
@@ -2708,9 +2703,6 @@ async def set_active_llm_server(request: ActiveLlmServerRequest):
             "llm_switch_requested",
             f"server={server_name}, source={switch_source}",
         )
-
-        # Delegate full lifecycle (stop → release → flush → start → health) to orchestrator.
-        # Config/endpoint are saved ONLY after orchestrator returns with confirmed health.
         active_model = str(getattr(active_runtime, "model_name", "") or "").strip()
         orchestrator = RuntimeSwitchOrchestrator(llm_controller)
         (
@@ -2740,10 +2732,8 @@ async def set_active_llm_server(request: ActiveLlmServerRequest):
             )
             response["shutdown_results"] = shutdown_results
             response["lifecycle_state"] = switch_state.to_payload()
-            finish_runtime_switch(switch_id=switch_gate.switch_id)
             return response
 
-        # All lifecycle steps confirmed — safe to persist config and model now.
         endpoint = _resolve_local_endpoint(server_name, target)
         _persist_local_runtime_endpoint(server_name, endpoint)
 
@@ -2795,7 +2785,6 @@ async def set_active_llm_server(request: ActiveLlmServerRequest):
             model=selected_model,
             from_runtime=from_server or "unknown",
         )
-        finish_runtime_switch(switch_id=switch_gate.switch_id)
         return {
             "status": "success",
             "active_server": infer_local_provider(runtime.endpoint),
@@ -2810,17 +2799,29 @@ async def set_active_llm_server(request: ActiveLlmServerRequest):
             "shutdown_results": shutdown_results,
             "lifecycle_state": switch_state.to_payload(),
         }
+    finally:
+        finish_runtime_switch(switch_id=switch_gate.switch_id)
+
+
+@router.post(
+    "/system/llm-servers/active",
+    responses=LLM_SERVER_ACTIVATE_RESPONSES,
+)
+async def set_active_llm_server(request: ActiveLlmServerRequest):
+    """
+    Ustawia aktywny runtime LLM, zatrzymuje inne serwery i aktywuje model.
+    """
+    server_name = normalize_runtime_id(request.server_name)
+    try:
+        switch_source = assert_runtime_switch_source_allowed(request.switch_source)
+        return await _set_active_llm_server_impl(
+            request=request,
+            server_name=server_name,
+            switch_source=switch_source,
+        )
     except HTTPException:
-        try:
-            finish_runtime_switch(switch_id=switch_gate.switch_id)
-        except UnboundLocalError:
-            pass
         raise
     except Exception as exc:  # pragma: no cover
-        try:
-            finish_runtime_switch(switch_id=switch_gate.switch_id)
-        except UnboundLocalError:
-            pass
         logger.exception(
             "Błąd wewnętrzny podczas przełączania aktywnego serwera LLM: {}",
             {

--- a/venom_core/api/routes/system_llm.py
+++ b/venom_core/api/routes/system_llm.py
@@ -43,6 +43,12 @@ from venom_core.services.feedback_loop_policy import (
     resolve_feedback_loop_model,
 )
 from venom_core.services.multi_runtime_models import multi_runtime_available_models
+from venom_core.services.runtime_switch_gate import (
+    begin_runtime_switch,
+    finish_runtime_switch,
+    get_runtime_switch_gate_status,
+    wait_for_runtime_requests_to_drain,
+)
 from venom_core.services.runtime_switch_service import (
     RuntimeSwitchOrchestrator,
     probe_health_ready,
@@ -2100,6 +2106,7 @@ def get_active_llm_server():
             "previous_onnx": config.get("PREVIOUS_MODEL_ONNX", ""),
         },
         "runtime_switch_policy": get_runtime_switch_guard_status(),
+        "runtime_switch_gate": get_runtime_switch_gate_status(),
         "last_runtime_switch": get_last_runtime_switch_event(),
         "mode_contracts": mode_contracts_payload(),
     }
@@ -2115,6 +2122,7 @@ def get_active_llm_runtime_info():
         "runtime": runtime.to_payload(),
         "drift": drift,
         "runtime_switch_policy": get_runtime_switch_guard_status(),
+        "runtime_switch_gate": get_runtime_switch_gate_status(),
         "last_runtime_switch": get_last_runtime_switch_event(),
         "mode_contracts": mode_contracts_payload(),
     }
@@ -2678,6 +2686,22 @@ async def set_active_llm_server(request: ActiveLlmServerRequest):
 
         active_runtime = get_active_llm_runtime()
         from_server = str(getattr(active_runtime, "provider", "") or "").strip().lower()
+        switch_gate = begin_runtime_switch(
+            source=switch_source,
+            from_runtime=from_server or "unknown",
+            to_runtime=server_name,
+            reason="set_active_llm_server",
+        )
+        drain_ok = await wait_for_runtime_requests_to_drain(timeout_seconds=30.0)
+        if not drain_ok:
+            finish_runtime_switch(switch_id=switch_gate.switch_id)
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "Nie udało się poczekać na zakończenie aktywnych requestów "
+                    "przed przełączeniem runtime."
+                ),
+            )
         _trace_switch(
             request_tracer,
             request.trace_id,
@@ -2716,6 +2740,7 @@ async def set_active_llm_server(request: ActiveLlmServerRequest):
             )
             response["shutdown_results"] = shutdown_results
             response["lifecycle_state"] = switch_state.to_payload()
+            finish_runtime_switch(switch_id=switch_gate.switch_id)
             return response
 
         # All lifecycle steps confirmed — safe to persist config and model now.
@@ -2770,6 +2795,7 @@ async def set_active_llm_server(request: ActiveLlmServerRequest):
             model=selected_model,
             from_runtime=from_server or "unknown",
         )
+        finish_runtime_switch(switch_id=switch_gate.switch_id)
         return {
             "status": "success",
             "active_server": infer_local_provider(runtime.endpoint),
@@ -2785,8 +2811,16 @@ async def set_active_llm_server(request: ActiveLlmServerRequest):
             "lifecycle_state": switch_state.to_payload(),
         }
     except HTTPException:
+        try:
+            finish_runtime_switch(switch_id=switch_gate.switch_id)
+        except UnboundLocalError:
+            pass
         raise
     except Exception as exc:  # pragma: no cover
+        try:
+            finish_runtime_switch(switch_id=switch_gate.switch_id)
+        except UnboundLocalError:
+            pass
         logger.exception(
             "Błąd wewnętrzny podczas przełączania aktywnego serwera LLM: {}",
             {

--- a/venom_core/main.py
+++ b/venom_core/main.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 from contextlib import asynccontextmanager, suppress
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -129,6 +130,7 @@ from venom_core.perception.audio_engine import AudioEngine
 from venom_core.perception.watcher import FileWatcher
 from venom_core.services.audit_stream import get_audit_stream
 from venom_core.services.module_registry import include_optional_api_routers
+from venom_core.services.runtime_switch_telemetry import get_last_runtime_switch_event
 from venom_core.services.session_store import SessionStore
 from venom_core.utils.helpers import extract_secret_value
 from venom_core.utils.llm_runtime import (
@@ -355,6 +357,78 @@ def _build_gemma4_voice_runtime_snapshot(runtime: Any) -> dict[str, object]:
         "config_hash": runtime.config_hash,
         "runtime_capabilities": _build_gemma4_runtime_capabilities(),
         "voice_pipeline": _build_gemma4_voice_pipeline(),
+    }
+
+
+def _parse_iso_datetime(raw: Any) -> datetime | None:
+    text = str(raw or "").strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _same_runtime_identity(
+    provider_a: str | None,
+    model_a: str | None,
+    provider_b: str | None,
+    model_b: str | None,
+) -> bool | None:
+    pa = str(provider_a or "").strip().lower()
+    ma = str(model_a or "").strip().lower()
+    pb = str(provider_b or "").strip().lower()
+    mb = str(model_b or "").strip().lower()
+    if not pa or not ma or not pb or not mb:
+        return None
+    return pa == pb and ma == mb
+
+
+def _build_voice_runtime_alignment(
+    *,
+    runtime_snapshot: dict[str, object] | None,
+    latest_session: dict[str, object] | None,
+) -> dict[str, object]:
+    active_provider = str((runtime_snapshot or {}).get("provider") or "").strip()
+    active_model = str((runtime_snapshot or {}).get("model_name") or "").strip()
+    response_provider = str(
+        (latest_session or {}).get("audio_runtime_provider") or ""
+    ).strip()
+    response_model = str(
+        (latest_session or {}).get("audio_runtime_model") or ""
+    ).strip()
+    session_created_at = str((latest_session or {}).get("created_at") or "").strip()
+
+    switch_event = get_last_runtime_switch_event() or {}
+    switch_at = str(switch_event.get("at_utc") or "").strip()
+    session_before_switch = False
+    session_dt = _parse_iso_datetime(session_created_at)
+    switch_dt = _parse_iso_datetime(switch_at)
+    if session_dt and switch_dt:
+        if session_dt.tzinfo is None:
+            session_dt = session_dt.replace(tzinfo=UTC)
+        if switch_dt.tzinfo is None:
+            switch_dt = switch_dt.replace(tzinfo=UTC)
+        session_before_switch = session_dt < switch_dt
+
+    response_runtime_fresh = bool(latest_session) and not session_before_switch
+    runtime_match = _same_runtime_identity(
+        active_provider,
+        active_model,
+        response_provider,
+        response_model,
+    )
+    return {
+        "active_provider": active_provider,
+        "active_model": active_model,
+        "response_provider": response_provider,
+        "response_model": response_model,
+        "latest_session_created_at": session_created_at or None,
+        "last_runtime_switch_at_utc": switch_at or None,
+        "latest_session_before_runtime_switch": session_before_switch,
+        "response_runtime_fresh": response_runtime_fresh,
+        "response_runtime_matches_active": runtime_match,
     }
 
 
@@ -1502,12 +1576,20 @@ async def audio_status_endpoint(request: Request):
         )
     status["latest_voice_session"] = latest_session
     try:
-        status["runtime_snapshot"] = await _build_voice_runtime_snapshot()
+        runtime_snapshot = await _build_voice_runtime_snapshot()
+        status["runtime_snapshot"] = runtime_snapshot
     except Exception as exc:  # pragma: no cover - best effort diagnostics
         logger.warning("Nie udało się pobrać runtime snapshot: %s", exc)
-        status["runtime_snapshot"] = {
+        runtime_snapshot = {
             "error": str(exc),
         }
+        status["runtime_snapshot"] = runtime_snapshot
+    status["runtime_alignment"] = _build_voice_runtime_alignment(
+        runtime_snapshot=runtime_snapshot
+        if isinstance(runtime_snapshot, dict)
+        else None,
+        latest_session=latest_session if isinstance(latest_session, dict) else None,
+    )
     return status
 
 

--- a/venom_core/main.py
+++ b/venom_core/main.py
@@ -402,15 +402,10 @@ def _build_voice_runtime_alignment(
 
     switch_event = get_last_runtime_switch_event() or {}
     switch_at = str(switch_event.get("at_utc") or "").strip()
-    session_before_switch = False
-    session_dt = _parse_iso_datetime(session_created_at)
-    switch_dt = _parse_iso_datetime(switch_at)
-    if session_dt and switch_dt:
-        if session_dt.tzinfo is None:
-            session_dt = session_dt.replace(tzinfo=UTC)
-        if switch_dt.tzinfo is None:
-            switch_dt = switch_dt.replace(tzinfo=UTC)
-        session_before_switch = session_dt < switch_dt
+    session_before_switch = _is_session_before_switch(
+        session_created_at=session_created_at,
+        switch_at=switch_at,
+    )
 
     response_runtime_fresh = bool(latest_session) and not session_before_switch
     runtime_match = _same_runtime_identity(
@@ -430,6 +425,22 @@ def _build_voice_runtime_alignment(
         "response_runtime_fresh": response_runtime_fresh,
         "response_runtime_matches_active": runtime_match,
     }
+
+
+def _normalize_datetime_utc(dt: datetime | None) -> datetime | None:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt
+
+
+def _is_session_before_switch(*, session_created_at: str, switch_at: str) -> bool:
+    session_dt = _normalize_datetime_utc(_parse_iso_datetime(session_created_at))
+    switch_dt = _normalize_datetime_utc(_parse_iso_datetime(switch_at))
+    if not session_dt or not switch_dt:
+        return False
+    return session_dt < switch_dt
 
 
 async def _build_voice_runtime_snapshot() -> dict[str, object] | None:

--- a/venom_core/services/llm_simple_service.py
+++ b/venom_core/services/llm_simple_service.py
@@ -84,6 +84,10 @@ from venom_core.services.runtime_dependencies import (
     get_model_manager,
     get_request_tracer,
 )
+from venom_core.services.runtime_switch_gate import (
+    assert_runtime_request_allowed,
+    runtime_request_guard,
+)
 from venom_core.utils.llm_runtime import (
     _build_chat_completions_url,
     get_active_llm_runtime,
@@ -935,77 +939,82 @@ async def _stream_simple_chunks(
     request_id: UUID,
     model_name: str,
 ) -> AsyncIterator[str]:
-    state = _SimpleStreamState(chunks=[])
-    stream_start = time.perf_counter()
-    runtime_telemetry: dict[str, int] = {}
+    async with runtime_request_guard(
+        request_kind="simple_chat_stream",
+        provider=runtime.provider,
+        model=model_name,
+    ):
+        state = _SimpleStreamState(chunks=[])
+        stream_start = time.perf_counter()
+        runtime_telemetry: dict[str, int] = {}
 
-    yield _SSE_EVENT_START
+        yield _SSE_EVENT_START
 
-    max_attempts = (
-        max(1, int(SETTINGS.OLLAMA_RETRY_MAX_ATTEMPTS))
-        if runtime.provider == "ollama"
-        else 1
-    )
-    retry_backoff = max(0.0, float(SETTINGS.OLLAMA_RETRY_BACKOFF_SECONDS))
+        max_attempts = (
+            max(1, int(SETTINGS.OLLAMA_RETRY_MAX_ATTEMPTS))
+            if runtime.provider == "ollama"
+            else 1
+        )
+        retry_backoff = max(0.0, float(SETTINGS.OLLAMA_RETRY_BACKOFF_SECONDS))
 
-    for attempt in range(1, max_attempts + 1):
-        try:
-            _reset_stream_attempt_state(state)
-            async for event in _stream_single_attempt(
-                completions_url=completions_url,
-                payload=payload,
-                runtime=runtime,
-                request_id=request_id,
-                model_name=model_name,
-                stream_start=stream_start,
-                attempt=attempt,
-                max_attempts=max_attempts,
-                retry_backoff=retry_backoff,
-                state=state,
-                runtime_telemetry=runtime_telemetry,
-            ):
-                yield event
+        for attempt in range(1, max_attempts + 1):
+            try:
+                _reset_stream_attempt_state(state)
+                async for event in _stream_single_attempt(
+                    completions_url=completions_url,
+                    payload=payload,
+                    runtime=runtime,
+                    request_id=request_id,
+                    model_name=model_name,
+                    stream_start=stream_start,
+                    attempt=attempt,
+                    max_attempts=max_attempts,
+                    retry_backoff=retry_backoff,
+                    state=state,
+                    runtime_telemetry=runtime_telemetry,
+                ):
+                    yield event
 
-            action = _resolve_post_attempt_action(
-                runtime=runtime,
-                request_id=request_id,
-                stream_start=stream_start,
-                state=state,
-                runtime_telemetry=runtime_telemetry,
-            )
-            should_retry, should_emit_done = _apply_post_attempt_action(action)
-            if should_retry:
-                continue
-            if should_emit_done:
-                yield _SSE_EVENT_DONE
-            return
+                action = _resolve_post_attempt_action(
+                    runtime=runtime,
+                    request_id=request_id,
+                    stream_start=stream_start,
+                    state=state,
+                    runtime_telemetry=runtime_telemetry,
+                )
+                should_retry, should_emit_done = _apply_post_attempt_action(action)
+                if should_retry:
+                    continue
+                if should_emit_done:
+                    yield _SSE_EVENT_DONE
+                return
 
-        except httpx.HTTPError as exc:
-            result = await _handle_stream_http_error(
-                exc=exc,
-                runtime=runtime,
-                request_id=request_id,
-                model_name=model_name,
-                stream_start=stream_start,
-                attempt=attempt,
-                max_attempts=max_attempts,
-                retry_backoff=retry_backoff,
-                chunk_count=state.chunk_count,
-                runtime_telemetry=runtime_telemetry,
-            )
-            if result == "retry":
-                continue
+            except httpx.HTTPError as exc:
+                result = await _handle_stream_http_error(
+                    exc=exc,
+                    runtime=runtime,
+                    request_id=request_id,
+                    model_name=model_name,
+                    stream_start=stream_start,
+                    attempt=attempt,
+                    max_attempts=max_attempts,
+                    retry_backoff=retry_backoff,
+                    chunk_count=state.chunk_count,
+                    runtime_telemetry=runtime_telemetry,
+                )
+                if result == "retry":
+                    continue
 
-            yield result
-            return
-        except Exception as exc:
-            yield _emit_internal_error_and_mark_failed(
-                exc=exc,
-                runtime=runtime,
-                request_id=request_id,
-                stream_start=stream_start,
-            )
-            return
+                yield result
+                return
+            except Exception as exc:
+                yield _emit_internal_error_and_mark_failed(
+                    exc=exc,
+                    runtime=runtime,
+                    request_id=request_id,
+                    stream_start=stream_start,
+                )
+                return
 
 
 async def _stream_simple_chunks_onnx(
@@ -1017,60 +1026,67 @@ async def _stream_simple_chunks_onnx(
     max_tokens: int | None,
     temperature: float | None,
 ) -> AsyncIterator[str]:
-    stream_start = time.perf_counter()
-    chunks: list[str] = []
-    chunk_count = 0
-    first_chunk_seen = False
+    async with runtime_request_guard(
+        request_kind="simple_chat_onnx",
+        provider=runtime.provider,
+        model=model_name,
+    ):
+        stream_start = time.perf_counter()
+        chunks: list[str] = []
+        chunk_count = 0
+        first_chunk_seen = False
 
-    yield _SSE_EVENT_START
-    try:
-        client = _get_onnx_simple_client()
-        async for content in _aiter_sync_onnx_stream(
-            client,
-            messages=messages,
-            max_new_tokens=max_tokens,
-            temperature=temperature,
-        ):
-            if not content:
-                continue
-            chunk_count += 1
-            chunks.append(content)
-            if not first_chunk_seen:
-                _trace_first_chunk(request_id, stream_start, content)
-                first_chunk_seen = True
-            yield "event: content\ndata: " + json.dumps({"text": content}) + "\n\n"
+        yield _SSE_EVENT_START
+        try:
+            client = _get_onnx_simple_client()
+            async for content in _aiter_sync_onnx_stream(
+                client,
+                messages=messages,
+                max_new_tokens=max_tokens,
+                temperature=temperature,
+            ):
+                if not content:
+                    continue
+                chunk_count += 1
+                chunks.append(content)
+                if not first_chunk_seen:
+                    _trace_first_chunk(request_id, stream_start, content)
+                    first_chunk_seen = True
+                yield "event: content\ndata: " + json.dumps({"text": content}) + "\n\n"
 
-        _trace_stream_completion(request_id, "".join(chunks), chunk_count, stream_start)
-        collector = get_metrics_collector()
-        collector.record_provider_request(
-            provider=runtime.provider,
-            success=True,
-            latency_ms=(time.perf_counter() - stream_start) * 1000.0,
-        )
-        yield _SSE_EVENT_DONE
-    except Exception as exc:
-        _record_simple_error(
-            request_id,
-            error_code="onnx_generation_error",
-            error_message=f"Błąd generacji ONNX: {exc}",
-            error_details={"provider": "onnx", "model": model_name},
-            error_class=exc.__class__.__name__,
-            retryable=False,
-        )
-        collector = get_metrics_collector()
-        collector.record_provider_request(
-            provider=runtime.provider,
-            success=False,
-            latency_ms=(time.perf_counter() - stream_start) * 1000.0,
-            error_code="onnx_generation_error",
-        )
-        yield (
-            "event: error\ndata: "
-            + json.dumps(
-                {"code": "onnx_generation_error", "message": f"Błąd ONNX: {exc}"}
+            _trace_stream_completion(
+                request_id, "".join(chunks), chunk_count, stream_start
             )
-            + "\n\n"
-        )
+            collector = get_metrics_collector()
+            collector.record_provider_request(
+                provider=runtime.provider,
+                success=True,
+                latency_ms=(time.perf_counter() - stream_start) * 1000.0,
+            )
+            yield _SSE_EVENT_DONE
+        except Exception as exc:
+            _record_simple_error(
+                request_id,
+                error_code="onnx_generation_error",
+                error_message=f"Błąd generacji ONNX: {exc}",
+                error_details={"provider": "onnx", "model": model_name},
+                error_class=exc.__class__.__name__,
+                retryable=False,
+            )
+            collector = get_metrics_collector()
+            collector.record_provider_request(
+                provider=runtime.provider,
+                success=False,
+                latency_ms=(time.perf_counter() - stream_start) * 1000.0,
+                error_code="onnx_generation_error",
+            )
+            yield (
+                "event: error\ndata: "
+                + json.dumps(
+                    {"code": "onnx_generation_error", "message": f"Błąd ONNX: {exc}"}
+                )
+                + "\n\n"
+            )
 
 
 async def _stream_simple_chunks_non_stream(
@@ -1081,112 +1097,122 @@ async def _stream_simple_chunks_non_stream(
     request_id: UUID,
     model_name: str,
 ) -> AsyncIterator[str]:
-    stream_start = time.perf_counter()
-    chunks: list[str] = []
+    async with runtime_request_guard(
+        request_kind="simple_chat_non_stream",
+        provider=runtime.provider,
+        model=model_name,
+    ):
+        stream_start = time.perf_counter()
+        chunks: list[str] = []
 
-    yield _SSE_EVENT_START
-    try:
-        async with llm_simple_transport.open_stream_response(
-            provider_name=str(getattr(runtime, "provider", "") or "llm_runtime"),
-            completions_url=completions_url,
-            payload=payload,
-        ) as response:
-            response.raise_for_status()
-            aread = getattr(response, "aread", None)
-            if callable(aread):
-                raw_body = await aread()
-                if raw_body:
-                    data = json.loads(raw_body.decode("utf-8", errors="replace"))
+        yield _SSE_EVENT_START
+        try:
+            async with llm_simple_transport.open_stream_response(
+                provider_name=str(getattr(runtime, "provider", "") or "llm_runtime"),
+                completions_url=completions_url,
+                payload=payload,
+            ) as response:
+                response.raise_for_status()
+                aread = getattr(response, "aread", None)
+                if callable(aread):
+                    raw_body = await aread()
+                    if raw_body:
+                        data = json.loads(raw_body.decode("utf-8", errors="replace"))
+                    else:
+                        data = {}
                 else:
-                    data = {}
-            else:
-                json_reader = getattr(response, "json", None)
-                data = json_reader() if callable(json_reader) else {}
+                    json_reader = getattr(response, "json", None)
+                    data = json_reader() if callable(json_reader) else {}
 
-        if not isinstance(data, dict):
-            _trace_stream_completion(request_id, "", 0, stream_start)
-            _record_simple_error(
-                request_id,
-                error_code=_NON_STREAM_INVALID_RESPONSE_CODE,
-                error_message=(
-                    f"Nieprawidłowa odpowiedź LLM ({runtime.provider}): "
-                    "oczekiwano obiektu JSON."
-                ),
-                error_details={
-                    "provider": runtime.provider,
-                    "model": model_name,
-                    "response_type": type(data).__name__,
-                },
-                error_class=type(data).__name__,
-                retryable=False,
+            if not isinstance(data, dict):
+                _trace_stream_completion(request_id, "", 0, stream_start)
+                _record_simple_error(
+                    request_id,
+                    error_code=_NON_STREAM_INVALID_RESPONSE_CODE,
+                    error_message=(
+                        f"Nieprawidłowa odpowiedź LLM ({runtime.provider}): "
+                        "oczekiwano obiektu JSON."
+                    ),
+                    error_details={
+                        "provider": runtime.provider,
+                        "model": model_name,
+                        "response_type": type(data).__name__,
+                    },
+                    error_class=type(data).__name__,
+                    retryable=False,
+                )
+                collector = get_metrics_collector()
+                collector.record_provider_request(
+                    provider=runtime.provider,
+                    success=False,
+                    latency_ms=(time.perf_counter() - stream_start) * 1000.0,
+                    error_code=_NON_STREAM_INVALID_RESPONSE_CODE,
+                )
+                yield (
+                    "event: error\ndata: "
+                    + json.dumps(
+                        {
+                            "code": _NON_STREAM_INVALID_RESPONSE_CODE,
+                            "message": (
+                                "Nieprawidłowa odpowiedź z aktywnego runtime LLM."
+                            ),
+                        }
+                    )
+                    + "\n\n"
+                )
+                return
+
+            content = _extract_message_content(data, fallback_text="")
+            logprobs_telemetry = _extract_logprobs_telemetry(data)
+            if logprobs_telemetry is not None:
+                yield (
+                    "event: telemetry\ndata: "
+                    + json.dumps(logprobs_telemetry, ensure_ascii=False)
+                    + "\n\n"
+                )
+            if content:
+                chunks.append(content)
+                _trace_first_chunk(request_id, stream_start, content)
+                yield "event: content\ndata: " + json.dumps({"text": content}) + "\n\n"
+
+            _trace_stream_completion(
+                request_id, "".join(chunks), len(chunks), stream_start
             )
             collector = get_metrics_collector()
             collector.record_provider_request(
                 provider=runtime.provider,
-                success=False,
+                success=True,
                 latency_ms=(time.perf_counter() - stream_start) * 1000.0,
-                error_code=_NON_STREAM_INVALID_RESPONSE_CODE,
             )
-            yield (
-                "event: error\ndata: "
-                + json.dumps(
-                    {
-                        "code": _NON_STREAM_INVALID_RESPONSE_CODE,
-                        "message": ("Nieprawidłowa odpowiedź z aktywnego runtime LLM."),
-                    }
-                )
-                + "\n\n"
+            yield _SSE_EVENT_DONE
+        except httpx.HTTPStatusError as exc:
+            result = await _emit_http_status_error_and_mark_failed(
+                exc=exc,
+                runtime=runtime,
+                request_id=request_id,
+                model_name=model_name,
+                stream_start=stream_start,
             )
-            return
-
-        content = _extract_message_content(data, fallback_text="")
-        logprobs_telemetry = _extract_logprobs_telemetry(data)
-        if logprobs_telemetry is not None:
-            yield (
-                "event: telemetry\ndata: "
-                + json.dumps(logprobs_telemetry, ensure_ascii=False)
-                + "\n\n"
+            yield result
+        except httpx.HTTPError as exc:
+            yield _emit_connection_error_and_mark_failed(
+                exc=exc,
+                runtime=runtime,
+                request_id=request_id,
+                model_name=model_name,
+                stream_start=stream_start,
             )
-        if content:
-            chunks.append(content)
-            _trace_first_chunk(request_id, stream_start, content)
-            yield "event: content\ndata: " + json.dumps({"text": content}) + "\n\n"
-
-        _trace_stream_completion(request_id, "".join(chunks), len(chunks), stream_start)
-        collector = get_metrics_collector()
-        collector.record_provider_request(
-            provider=runtime.provider,
-            success=True,
-            latency_ms=(time.perf_counter() - stream_start) * 1000.0,
-        )
-        yield _SSE_EVENT_DONE
-    except httpx.HTTPStatusError as exc:
-        result = await _emit_http_status_error_and_mark_failed(
-            exc=exc,
-            runtime=runtime,
-            request_id=request_id,
-            model_name=model_name,
-            stream_start=stream_start,
-        )
-        yield result
-    except httpx.HTTPError as exc:
-        yield _emit_connection_error_and_mark_failed(
-            exc=exc,
-            runtime=runtime,
-            request_id=request_id,
-            model_name=model_name,
-            stream_start=stream_start,
-        )
-    except Exception as exc:
-        yield _emit_internal_error_and_mark_failed(
-            exc=exc,
-            runtime=runtime,
-            request_id=request_id,
-            stream_start=stream_start,
-        )
+        except Exception as exc:
+            yield _emit_internal_error_and_mark_failed(
+                exc=exc,
+                runtime=runtime,
+                request_id=request_id,
+                stream_start=stream_start,
+            )
 
 
 async def stream_simple_chat(request: SimpleChatRequest):
+    assert_runtime_request_allowed(request_kind="simple_chat")
     await asyncio.sleep(0)
     runtime = get_active_llm_runtime()
     model_name = _resolve_model_name_for_simple_request(

--- a/venom_core/services/runtime_switch_gate.py
+++ b/venom_core/services/runtime_switch_gate.py
@@ -1,0 +1,233 @@
+"""Global gate for runtime switch drain / request blocking.
+
+The switch flow needs a single source of truth for whether new runtime-bound
+requests may start. This module keeps a small in-memory gate that:
+
+- rejects new requests while a switch is in progress,
+- tracks active runtime-bound requests so switch can wait for drain,
+- exposes a read-only status snapshot for diagnostics.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, AsyncIterator
+from uuid import uuid4
+
+from fastapi import HTTPException
+
+from venom_core.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+_HTTP_409_RUNTIME_SWITCH_IN_PROGRESS = 409
+_DRAIN_TIMEOUT_SECONDS = 30.0
+_DRAIN_POLL_INTERVAL_SECONDS = 0.05
+
+
+@dataclass(frozen=True)
+class RuntimeSwitchGateSnapshot:
+    in_progress: bool
+    active_requests: int
+    switch_id: str | None
+    source: str | None
+    from_runtime: str | None
+    to_runtime: str | None
+    started_at_utc: str | None
+    reason: str | None
+
+
+@dataclass
+class _RuntimeSwitchGateState:
+    in_progress: bool = False
+    active_requests: int = 0
+    switch_id: str | None = None
+    source: str | None = None
+    from_runtime: str | None = None
+    to_runtime: str | None = None
+    started_at_utc: str | None = None
+    reason: str | None = None
+
+
+_STATE_LOCK = threading.Lock()
+_STATE = _RuntimeSwitchGateState()
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _snapshot_unlocked() -> RuntimeSwitchGateSnapshot:
+    return RuntimeSwitchGateSnapshot(
+        in_progress=_STATE.in_progress,
+        active_requests=_STATE.active_requests,
+        switch_id=_STATE.switch_id,
+        source=_STATE.source,
+        from_runtime=_STATE.from_runtime,
+        to_runtime=_STATE.to_runtime,
+        started_at_utc=_STATE.started_at_utc,
+        reason=_STATE.reason,
+    )
+
+
+def get_runtime_switch_gate_status() -> dict[str, Any]:
+    snapshot = get_runtime_switch_gate_snapshot()
+    return {
+        "in_progress": snapshot.in_progress,
+        "active_requests": snapshot.active_requests,
+        "switch_id": snapshot.switch_id,
+        "source": snapshot.source,
+        "from_runtime": snapshot.from_runtime,
+        "to_runtime": snapshot.to_runtime,
+        "started_at_utc": snapshot.started_at_utc,
+        "reason": snapshot.reason,
+    }
+
+
+def get_runtime_switch_gate_snapshot() -> RuntimeSwitchGateSnapshot:
+    with _STATE_LOCK:
+        return _snapshot_unlocked()
+
+
+def assert_runtime_request_allowed(*, request_kind: str) -> None:
+    with _STATE_LOCK:
+        if not _STATE.in_progress:
+            return
+        snapshot = _snapshot_unlocked()
+    logger.info(
+        "runtime_request_blocked kind={} switch_id={} source={} target={} active_requests={}",
+        request_kind,
+        snapshot.switch_id,
+        snapshot.source,
+        snapshot.to_runtime,
+        snapshot.active_requests,
+    )
+    raise HTTPException(
+        status_code=_HTTP_409_RUNTIME_SWITCH_IN_PROGRESS,
+        detail={
+            "code": "runtime_switch_in_progress",
+            "message": "Przełączanie runtime w toku. Spróbuj ponownie za chwilę.",
+            "request_kind": request_kind,
+            "runtime_switch_gate": get_runtime_switch_gate_status(),
+        },
+    )
+
+
+def begin_runtime_switch(
+    *,
+    source: str,
+    from_runtime: str,
+    to_runtime: str,
+    reason: str | None = None,
+) -> RuntimeSwitchGateSnapshot:
+    with _STATE_LOCK:
+        if _STATE.in_progress:
+            snapshot = _snapshot_unlocked()
+            raise HTTPException(
+                status_code=_HTTP_409_RUNTIME_SWITCH_IN_PROGRESS,
+                detail={
+                    "code": "runtime_switch_in_progress",
+                    "message": "Przełączanie runtime już trwa.",
+                    "runtime_switch_gate": {
+                        "in_progress": snapshot.in_progress,
+                        "active_requests": snapshot.active_requests,
+                        "switch_id": snapshot.switch_id,
+                        "source": snapshot.source,
+                        "from_runtime": snapshot.from_runtime,
+                        "to_runtime": snapshot.to_runtime,
+                        "started_at_utc": snapshot.started_at_utc,
+                        "reason": snapshot.reason,
+                    },
+                },
+            )
+        _STATE.in_progress = True
+        _STATE.switch_id = uuid4().hex
+        _STATE.source = str(source or "").strip() or "ui"
+        _STATE.from_runtime = str(from_runtime or "").strip() or None
+        _STATE.to_runtime = str(to_runtime or "").strip() or None
+        _STATE.started_at_utc = _utc_now()
+        _STATE.reason = str(reason or "").strip() or None
+        snapshot = _snapshot_unlocked()
+
+    logger.info(
+        "runtime_switch_gate_opened switch_id={} source={} from={} to={}",
+        snapshot.switch_id,
+        snapshot.source,
+        snapshot.from_runtime,
+        snapshot.to_runtime,
+    )
+    return snapshot
+
+
+def finish_runtime_switch(*, switch_id: str | None) -> None:
+    with _STATE_LOCK:
+        if switch_id and _STATE.switch_id and _STATE.switch_id != switch_id:
+            logger.warning(
+                "runtime_switch_gate_finish_mismatch current={} requested={}",
+                _STATE.switch_id,
+                switch_id,
+            )
+        _STATE.in_progress = False
+        _STATE.switch_id = None
+        _STATE.source = None
+        _STATE.from_runtime = None
+        _STATE.to_runtime = None
+        _STATE.started_at_utc = None
+        _STATE.reason = None
+        _STATE.active_requests = max(0, _STATE.active_requests)
+
+    logger.info("runtime_switch_gate_closed switch_id={}", switch_id)
+
+
+async def wait_for_runtime_requests_to_drain(
+    *, timeout_seconds: float = _DRAIN_TIMEOUT_SECONDS
+) -> bool:
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    while True:
+        with _STATE_LOCK:
+            active_requests = _STATE.active_requests
+        if active_requests <= 0:
+            return True
+        if time.monotonic() >= deadline:
+            logger.warning(
+                "runtime_switch_gate_drain_timeout active_requests={} timeout_seconds={}",
+                active_requests,
+                timeout_seconds,
+            )
+            return False
+        await asyncio.sleep(_DRAIN_POLL_INTERVAL_SECONDS)
+
+
+@asynccontextmanager
+async def runtime_request_guard(
+    *, request_kind: str, provider: str | None = None, model: str | None = None
+) -> AsyncIterator[RuntimeSwitchGateSnapshot]:
+    assert_runtime_request_allowed(request_kind=request_kind)
+    with _STATE_LOCK:
+        _STATE.active_requests += 1
+        snapshot = _snapshot_unlocked()
+    logger.info(
+        "runtime_request_entered kind={} provider={} model={} active_requests={}",
+        request_kind,
+        provider or "",
+        model or "",
+        snapshot.active_requests,
+    )
+    try:
+        yield snapshot
+    finally:
+        with _STATE_LOCK:
+            _STATE.active_requests = max(0, _STATE.active_requests - 1)
+            snapshot = _snapshot_unlocked()
+        logger.info(
+            "runtime_request_exited kind={} provider={} model={} active_requests={}",
+            request_kind,
+            provider or "",
+            model or "",
+            snapshot.active_requests,
+        )

--- a/venom_core/services/runtime_switch_gate.py
+++ b/venom_core/services/runtime_switch_gate.py
@@ -172,6 +172,7 @@ def finish_runtime_switch(*, switch_id: str | None) -> None:
                 _STATE.switch_id,
                 switch_id,
             )
+            return
         _STATE.in_progress = False
         _STATE.switch_id = None
         _STATE.source = None
@@ -207,8 +208,26 @@ async def wait_for_runtime_requests_to_drain(
 async def runtime_request_guard(
     *, request_kind: str, provider: str | None = None, model: str | None = None
 ) -> AsyncIterator[RuntimeSwitchGateSnapshot]:
-    assert_runtime_request_allowed(request_kind=request_kind)
     with _STATE_LOCK:
+        if _STATE.in_progress:
+            snapshot = _snapshot_unlocked()
+            raise HTTPException(
+                status_code=_HTTP_409_RUNTIME_SWITCH_IN_PROGRESS,
+                detail={
+                    "code": "runtime_switch_in_progress",
+                    "message": "Przełączanie runtime już trwa.",
+                    "runtime_switch_gate": {
+                        "in_progress": snapshot.in_progress,
+                        "active_requests": snapshot.active_requests,
+                        "switch_id": snapshot.switch_id,
+                        "source": snapshot.source,
+                        "from_runtime": snapshot.from_runtime,
+                        "to_runtime": snapshot.to_runtime,
+                        "started_at_utc": snapshot.started_at_utc,
+                        "reason": snapshot.reason,
+                    },
+                },
+            )
         _STATE.active_requests += 1
         snapshot = _snapshot_unlocked()
     logger.info(

--- a/web-next/components/cockpit/cockpit-models.tsx
+++ b/web-next/components/cockpit/cockpit-models.tsx
@@ -40,7 +40,7 @@ type CockpitModelsProps = Readonly<{
   onServerSessionReset: () => void;
   onClearSessionMemory: () => void;
   onClearGlobalMemory: () => void;
-  activeServerInfo?: { active_model?: string | null } | null;
+  activeServerInfo?: { active_server?: string | null; active_model?: string | null } | null;
   activeServerName?: string | null;
   llmActionPending: string | null;
   onActivateServer: () => void;
@@ -72,8 +72,36 @@ export function CockpitModels({
   gemma4AudioRuntimeInfo,
 }: CockpitModelsProps) {
   const t = useTranslation();
+  const activeRuntimePayload = (activeServerInfo ?? null) as Record<string, unknown> | null;
+  const runtimeSwitchGate = (activeRuntimePayload?.runtime_switch_gate ??
+    null) as
+    | {
+      in_progress?: boolean;
+      from_runtime?: string | null;
+      to_runtime?: string | null;
+      active_requests?: number;
+    }
+    | null;
+  const lastRuntimeSwitch = (activeRuntimePayload?.last_runtime_switch ??
+    null) as { at_utc?: string | null } | null;
+  const gateSwitching = runtimeSwitchGate?.in_progress === true;
+  const normalizedSelectedServer = normalizeRuntimeValue(selectedLlmServer);
+  const normalizedActiveServer = normalizeRuntimeValue(
+    activeServerName ?? activeServerInfo?.active_server,
+  );
+  const selectedModelTrimmed = String(selectedLlmModel ?? "").trim();
+  const activeModelTrimmed = String(activeServerInfo?.active_model ?? "").trim();
+  const runtimeSelectionApplied =
+    Boolean(normalizedSelectedServer) &&
+    normalizedSelectedServer === normalizedActiveServer &&
+    (!selectedModelTrimmed || selectedModelTrimmed === activeModelTrimmed);
+  const runtimeSwitchFailedHint =
+    !gateSwitching &&
+    !runtimeSelectionApplied &&
+    Boolean(selectedServerEntry?.error_message) &&
+    Boolean(selectedServerEntry?.status && selectedServerEntry.status !== "online");
   let activateServerLabel = "Aktywuj serwer";
-  if (llmActionPending === `activate:${selectedLlmServer}`) {
+  if (gateSwitching || llmActionPending === `activate:${selectedLlmServer}`) {
     activateServerLabel = "Aktywuję...";
   } else if (selectedLlmModel) {
     activateServerLabel = "Aktywuj model";
@@ -112,7 +140,7 @@ export function CockpitModels({
               onChange={onSelectLlmServer}
               ariaLabel="Wybierz serwer LLM"
               placeholder="Wybierz serwer"
-              disabled={llmServers.length === 0}
+              disabled={llmServers.length === 0 || gateSwitching}
               buttonClassName="w-full justify-between rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white"
               menuClassName="w-full max-h-72 overflow-y-auto"
             />
@@ -129,10 +157,31 @@ export function CockpitModels({
                   ? t("cockpit.models.chooseModel")
                   : t("cockpit.models.noModels")
               }
-              disabled={llmServers.length === 0 || availableModelsForServer.length === 0}
+              disabled={llmServers.length === 0 || availableModelsForServer.length === 0 || gateSwitching}
               buttonClassName="w-full justify-between rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white"
               menuClassName="w-full max-h-72 overflow-y-auto"
             />
+            {gateSwitching && (
+              <p className="text-xs text-amber-300">
+                {`Trwa przełączanie runtime: ${runtimeSwitchGate?.from_runtime || "—"} -> ${
+                  runtimeSwitchGate?.to_runtime || "—"
+                }`}
+              </p>
+            )}
+            {!gateSwitching && lastRuntimeSwitch?.at_utc && (
+              <p className="text-xs text-zinc-500">{`Ostatnie przełączenie: ${lastRuntimeSwitch.at_utc}`}</p>
+            )}
+            {!gateSwitching && runtimeSelectionApplied && (
+              <p className="text-xs text-emerald-400">Przełączenie runtime zakończone sukcesem.</p>
+            )}
+            {!gateSwitching && runtimeSwitchFailedHint && (
+              <p className="text-xs text-rose-300">
+                {`Przełączenie runtime nieudane: ${selectedServerEntry?.error_message ?? "brak szczegółów"}`}
+              </p>
+            )}
+            {!gateSwitching && !runtimeSelectionApplied && !runtimeSwitchFailedHint && (
+              <p className="text-xs text-amber-300">Wybór runtime oczekuje na aktywację.</p>
+            )}
             {selectedLlmServer && availableModelsForServer.length === 0 && (
               <div className="space-y-2">
                 <EmptyState
@@ -219,6 +268,7 @@ export function CockpitModels({
             className="mt-4 w-full justify-center text-center tracking-[0.2em]"
             onClick={onActivateServer}
             disabled={
+              gateSwitching ||
               llmActionPending === `activate:${selectedLlmServer}` ||
               !selectedLlmServer
             }
@@ -273,4 +323,8 @@ function Gemma4AudioCapabilityInfo({
       )}
     </div>
   );
+}
+
+function normalizeRuntimeValue(value: string | null | undefined): string {
+  return String(value ?? "").trim().toLowerCase();
 }

--- a/web-next/components/cockpit/cockpit-models.tsx
+++ b/web-next/components/cockpit/cockpit-models.tsx
@@ -9,7 +9,7 @@ import Link from "next/link";
 import type { SelectMenuOption } from "@/components/ui/select-menu";
 import { SelectMenu } from "@/components/ui/select-menu";
 import { useTranslation } from "@/lib/i18n";
-import type { LlmRuntimeTargetOption, LlmServerInfo } from "@/lib/types";
+import type { ActiveLlmServerResponse, LlmRuntimeTargetOption, LlmServerInfo } from "@/lib/types";
 
 type Gemma4AudioRuntimeInfo = Pick<
   LlmRuntimeTargetOption,
@@ -40,7 +40,7 @@ type CockpitModelsProps = Readonly<{
   onServerSessionReset: () => void;
   onClearSessionMemory: () => void;
   onClearGlobalMemory: () => void;
-  activeServerInfo?: { active_server?: string | null; active_model?: string | null } | null;
+  activeServerInfo?: ActiveLlmServerResponse | null;
   activeServerName?: string | null;
   llmActionPending: string | null;
   onActivateServer: () => void;
@@ -72,18 +72,8 @@ export function CockpitModels({
   gemma4AudioRuntimeInfo,
 }: CockpitModelsProps) {
   const t = useTranslation();
-  const activeRuntimePayload = (activeServerInfo ?? null) as Record<string, unknown> | null;
-  const runtimeSwitchGate = (activeRuntimePayload?.runtime_switch_gate ??
-    null) as
-    | {
-      in_progress?: boolean;
-      from_runtime?: string | null;
-      to_runtime?: string | null;
-      active_requests?: number;
-    }
-    | null;
-  const lastRuntimeSwitch = (activeRuntimePayload?.last_runtime_switch ??
-    null) as { at_utc?: string | null } | null;
+  const runtimeSwitchGate = activeServerInfo?.runtime_switch_gate;
+  const lastRuntimeSwitch = activeServerInfo?.last_runtime_switch;
   const gateSwitching = runtimeSwitchGate?.in_progress === true;
   const normalizedSelectedServer = normalizeRuntimeValue(selectedLlmServer);
   const normalizedActiveServer = normalizeRuntimeValue(

--- a/web-next/components/models/hooks/use-runtime.ts
+++ b/web-next/components/models/hooks/use-runtime.ts
@@ -145,6 +145,32 @@ export function useRuntime() {
     const operations = useModelOperations(10, 0);
     const runtimeOptions = useLlmRuntimeOptions(0);
     const activeServer = useActiveLlmServer(0);
+    const activeServerPayload = (activeServer.data ?? null) as Record<string, unknown> | null;
+    const runtimeSwitchGate = (activeServerPayload?.runtime_switch_gate ??
+        null) as
+        | {
+            in_progress?: boolean;
+            active_requests?: number;
+            switch_id?: string | null;
+            source?: string | null;
+            from_runtime?: string | null;
+            to_runtime?: string | null;
+            started_at_utc?: string | null;
+            reason?: string | null;
+        }
+        | null;
+    const lastRuntimeSwitch = (activeServerPayload?.last_runtime_switch ??
+        null) as
+        | {
+            event?: string | null;
+            source?: string | null;
+            runtime?: string | null;
+            model?: string | null;
+            from_runtime?: string | null;
+            at_utc?: string | null;
+        }
+        | null;
+    const runtimeSwitchInProgress = runtimeSwitchGate?.in_progress === true;
 
     const activeRuntime = installed.data?.active;
     const [selectedServer, setSelectedServer] = useState<string | null>(null);
@@ -361,6 +387,9 @@ export function useRuntime() {
         operations,
         llmServers: { ...runtimeOptions, data: llmServers },
         activeServer,
+        runtimeSwitchGate,
+        lastRuntimeSwitch,
+        runtimeSwitchInProgress,
         activeRuntime,
         selectedServer,
         setSelectedServer,

--- a/web-next/components/models/hooks/use-runtime.ts
+++ b/web-next/components/models/hooks/use-runtime.ts
@@ -145,31 +145,8 @@ export function useRuntime() {
     const operations = useModelOperations(10, 0);
     const runtimeOptions = useLlmRuntimeOptions(0);
     const activeServer = useActiveLlmServer(0);
-    const activeServerPayload = (activeServer.data ?? null) as Record<string, unknown> | null;
-    const runtimeSwitchGate = (activeServerPayload?.runtime_switch_gate ??
-        null) as
-        | {
-            in_progress?: boolean;
-            active_requests?: number;
-            switch_id?: string | null;
-            source?: string | null;
-            from_runtime?: string | null;
-            to_runtime?: string | null;
-            started_at_utc?: string | null;
-            reason?: string | null;
-        }
-        | null;
-    const lastRuntimeSwitch = (activeServerPayload?.last_runtime_switch ??
-        null) as
-        | {
-            event?: string | null;
-            source?: string | null;
-            runtime?: string | null;
-            model?: string | null;
-            from_runtime?: string | null;
-            at_utc?: string | null;
-        }
-        | null;
+    const runtimeSwitchGate = activeServer.data?.runtime_switch_gate;
+    const lastRuntimeSwitch = activeServer.data?.last_runtime_switch;
     const runtimeSwitchInProgress = runtimeSwitchGate?.in_progress === true;
 
     const activeRuntime = installed.data?.active;

--- a/web-next/components/voice/use-orb-activity-window.ts
+++ b/web-next/components/voice/use-orb-activity-window.ts
@@ -21,6 +21,11 @@ export function useOrbActivityWindow(
     }
 
     const schedule = (nextValue: boolean, delayMs: number) => {
+      if (delayMs <= 0) {
+        setActiveWindow(nextValue);
+        timeoutRef.current = null;
+        return;
+      }
       timeoutRef.current = setTimeout(() => {
         setActiveWindow(nextValue);
         timeoutRef.current = null;

--- a/web-next/components/voice/use-voice-debug-mode.ts
+++ b/web-next/components/voice/use-voice-debug-mode.ts
@@ -250,7 +250,7 @@ export function useVoiceDebugMode(t: Translator): VoiceDebugSnapshot {
     const syncLocation = () => {
       const nextSearch = readLocationSearch();
       setUrlSearch((current) => (current === nextSearch ? current : nextSearch));
-      setHydrated((current) => (current ? current : true));
+      setHydrated(true);
     };
     syncLocation();
     globalThis.addEventListener?.("popstate", syncLocation);

--- a/web-next/components/voice/use-voice-debug-mode.ts
+++ b/web-next/components/voice/use-voice-debug-mode.ts
@@ -240,22 +240,22 @@ const buildVoiceDebugSteps = (
   });
 
 export function useVoiceDebugMode(t: Translator): VoiceDebugSnapshot {
-  const [hydrated, setHydrated] = useState(false);
   const readLocationSearch = () =>
     globalThis.location === undefined ? "" : globalThis.location.search;
-  const [urlSearch, setUrlSearch] = useState("");
+  const [hydrated, setHydrated] = useState(globalThis.location !== undefined);
+  const [urlSearch, setUrlSearch] = useState(() => readLocationSearch());
   const requested = globalThis.location !== undefined && parseVoiceDebugEnabled(readLocationSearch());
 
   useEffect(() => {
-    const syncLocation = () => setUrlSearch(readLocationSearch());
-    const timerId = globalThis.setTimeout(() => {
-      setHydrated(true);
-      syncLocation();
-    }, 0);
+    const syncLocation = () => {
+      const nextSearch = readLocationSearch();
+      setUrlSearch((current) => (current === nextSearch ? current : nextSearch));
+      setHydrated((current) => (current ? current : true));
+    };
+    syncLocation();
     globalThis.addEventListener?.("popstate", syncLocation);
     globalThis.addEventListener?.("hashchange", syncLocation);
     return () => {
-      globalThis.clearTimeout(timerId);
       globalThis.removeEventListener?.("popstate", syncLocation);
       globalThis.removeEventListener?.("hashchange", syncLocation);
     };

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -1105,23 +1105,17 @@ function useVoiceCommandCenterDebugBootstrap(params: {
   debugDryRunRequested: boolean;
   debugRecording: boolean;
   onStatusUpdate?: (status: VoiceStatusUpdate | null) => void;
-  refreshAudioStatus: () => Promise<void>;
-  refreshTtsModelOptions: () => Promise<void>;
 }) {
   const {
     debugDryRunRequested,
     debugRecording,
     onStatusUpdate,
-    refreshAudioStatus,
-    refreshTtsModelOptions,
   } = params;
 
   useEffect(() => {
     if (!debugDryRunRequested) return;
     onStatusUpdate?.(buildDebugAudioStatus(debugRecording));
-    refreshAudioStatus().catch(() => undefined);
-    refreshTtsModelOptions().catch(() => undefined);
-  }, [debugDryRunRequested, debugRecording, onStatusUpdate, refreshAudioStatus, refreshTtsModelOptions]);
+  }, [debugDryRunRequested, debugRecording, onStatusUpdate]);
 }
 
 function useVoiceCommandCenterCompleteReset(params: {
@@ -2439,8 +2433,6 @@ function VoiceCommandCenterPanel({
     debugDryRunRequested,
     debugRecording: debugMode.recording,
     onStatusUpdate,
-    refreshAudioStatus,
-    refreshTtsModelOptions,
   });
 
   useVoiceCommandCenterTtsModelRefresh({

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -91,6 +91,12 @@ export type AudioStatus = {
     latest_voice_session?: VoiceSessionDiagnostics | null;
     error?: string | null;
   } | null;
+  runtime_alignment?: {
+    response_runtime_fresh?: boolean | null;
+    latest_session_before_runtime_switch?: boolean | null;
+    response_runtime_matches_active?: boolean | null;
+    last_runtime_switch_at_utc?: string | null;
+  } | null;
 };
 
 type VoiceRuntimeInfo = {
@@ -1071,7 +1077,7 @@ export type VoiceStatusUpdate = Pick<AudioStatus,
   | "enabled" | "stt_ready" | "tts_ready" | "tts_fallback"
   | "whisper_model_size" | "stt_backend" | "tts_backend"
   | "vad_threshold" | "dependencies" | "runtime_snapshot"
-  | "latest_voice_session"
+  | "latest_voice_session" | "runtime_alignment"
 >;
 
 const VOICE_MODE_TITLE_KEYS: Record<VoiceModePreset, string> = {
@@ -3023,10 +3029,15 @@ function VoiceCommandCenterPanel({
                   },
                   {
                     label: t("voice.controls.responseRuntime"),
-                    value: formatRuntimeSummaryLabel(
-                      viewState.effectiveAudioStatus.latest_voice_session?.audio_runtime_provider,
-                      viewState.effectiveAudioStatus.latest_voice_session?.audio_runtime_model,
-                    ),
+                    value: (() => {
+                      const tuple = formatRuntimeSummaryLabel(
+                        viewState.effectiveAudioStatus.latest_voice_session?.audio_runtime_provider,
+                        viewState.effectiveAudioStatus.latest_voice_session?.audio_runtime_model,
+                      );
+                      return viewState.effectiveAudioStatus.runtime_alignment?.response_runtime_fresh === false
+                        ? `${tuple} (${t("voice.controls.previousSession")})`
+                        : tuple;
+                    })(),
                     tone: "neutral",
                   },
                   {

--- a/web-next/components/voice/voice-command-center.tsx
+++ b/web-next/components/voice/voice-command-center.tsx
@@ -3013,17 +3013,6 @@ function VoiceCommandCenterPanel({
               summaryItems={
                 [
                   {
-                    label: t("voice.controls.selectedRuntime"),
-                    value: formatRuntimeSummaryLabel(
-                      viewState.effectiveAudioStatus.latest_voice_session?.runtime?.llm_service_id
-                        ?? viewState.effectiveAudioStatus.runtime_snapshot?.provider
-                        ?? viewState.effectiveAudioStatus.runtime_snapshot?.runtime_id,
-                      viewState.effectiveAudioStatus.latest_voice_session?.runtime?.llm_model
-                        ?? viewState.effectiveAudioStatus.runtime_snapshot?.model_name,
-                    ),
-                    tone: "neutral",
-                  },
-                  {
                     label: t("voice.controls.systemVoiceRuntime"),
                     value: formatRuntimeSummaryLabel(
                       viewState.effectiveAudioStatus.runtime_snapshot?.provider

--- a/web-next/components/voice/voice-status-sidebar.tsx
+++ b/web-next/components/voice/voice-status-sidebar.tsx
@@ -62,6 +62,7 @@ export function VoiceStatusSidebar({ status, isDevMode = false, onRuntimeApplied
   const t = useTranslation();
   const runtime = status?.runtime_snapshot ?? null;
   const latestVoiceSession = status?.latest_voice_session ?? runtime?.latest_voice_session ?? null;
+  const runtimeAlignment = status?.runtime_alignment ?? null;
   const runtimeProvider = runtime?.provider ?? "";
   const runtimeId = runtime?.runtime_id ?? "";
   const isGemma4AudioRuntime = isMultiRuntime(runtimeProvider) || isMultiRuntime(runtimeId);
@@ -123,7 +124,7 @@ export function VoiceStatusSidebar({ status, isDevMode = false, onRuntimeApplied
         title={t("voice.controls.runtime")}
       />
       {latestVoiceSession && (
-        <VoiceSessionCard session={latestVoiceSession} />
+        <VoiceSessionCard session={latestVoiceSession} runtimeAlignment={runtimeAlignment} />
       )}
 
       {/* STT / TTS box */}
@@ -441,8 +442,10 @@ function RuntimeOverviewCard({
 
 function VoiceSessionCard({
   session,
+  runtimeAlignment,
 }: Readonly<{
   session: NonNullable<VoiceStatusUpdate["latest_voice_session"]>;
+  runtimeAlignment?: VoiceStatusUpdate["runtime_alignment"] | null;
 }>) {
   const t = useTranslation();
   const confidence = formatConfidence(session.emotion_confidence);
@@ -465,8 +468,17 @@ function VoiceSessionCard({
       {(session.audio_runtime_provider || session.audio_runtime_model) && (
         <Row
           label={t("voice.controls.responseRuntime")}
-          value={formatRuntimeTuple(session.audio_runtime_provider, session.audio_runtime_model)}
+          value={
+            runtimeAlignment?.response_runtime_fresh === false
+              ? `${formatRuntimeTuple(session.audio_runtime_provider, session.audio_runtime_model)} (${t("voice.controls.previousSession")})`
+              : formatRuntimeTuple(session.audio_runtime_provider, session.audio_runtime_model)
+          }
         />
+      )}
+      {runtimeAlignment?.response_runtime_fresh === false && (
+        <p className="text-[11px] text-amber-300">
+          {t("voice.controls.runtimeAfterSwitch")}
+        </p>
       )}
       {session.reasoning_summary_status && (
         <Row

--- a/web-next/components/voice/voice-status-sidebar.tsx
+++ b/web-next/components/voice/voice-status-sidebar.tsx
@@ -194,7 +194,8 @@ function RuntimeSwitchCard({
     runtime.activeServer.data?.active_server ?? null,
     runtime.activeServer.data?.active_model ?? null,
   );
-  const applyDisabled = pending || !selectedRuntime || !selectedModel;
+  const gateSwitching = runtime.runtimeSwitchInProgress;
+  const applyDisabled = pending || gateSwitching || !selectedRuntime || !selectedModel;
   const runtimeError = runtime.activeServer.error ?? runtime.llmServers.error;
   const serversLoading = runtime.llmServers.loading ?? false;
 
@@ -339,8 +340,20 @@ function RuntimeSwitchCard({
           disabled={applyDisabled}
           className="w-full"
         >
-          {pending ? t("voice.controls.refreshing") : t("voice.controls.refresh")}
+          {pending || gateSwitching ? t("voice.controls.refreshing") : t("voice.controls.refresh")}
         </Button>
+        {gateSwitching && (
+          <p className="text-[11px] text-amber-300">
+            {`Trwa przełączanie runtime: ${
+              runtime.runtimeSwitchGate?.from_runtime || "—"
+            } -> ${runtime.runtimeSwitchGate?.to_runtime || "—"}`}
+          </p>
+        )}
+        {!gateSwitching && runtime.lastRuntimeSwitch?.at_utc && (
+          <p className="text-[11px] text-zinc-400">
+            {`Ostatnie przełączenie: ${runtime.lastRuntimeSwitch.at_utc}`}
+          </p>
+        )}
         <Row label={t("voice.controls.selectedRuntime")} value={selectedRuntimeSummary} />
         <Row label={t("voice.controls.systemVoiceRuntime")} value={activeRuntimeSummary} />
 
@@ -407,10 +420,7 @@ function RuntimeOverviewCard({
               </Badge>
             )}
           </div>
-          {provider && <Row label={t("voice.controls.provider")} value={provider} />}
-          {activeVoiceRuntime && (
-            <Row label={t("voice.controls.systemVoiceRuntime")} value={activeVoiceRuntime} />
-          )}
+          {activeVoiceRuntime && <Row label={t("voice.controls.runtime")} value={activeVoiceRuntime} />}
           {endpoint && <Row label={t("voice.controls.endpoint")} value={endpoint} />}
           {profile && <Row label={t("voice.controls.profile")} value={profile} />}
           {runtime.voice_pipeline?.stt && (

--- a/web-next/components/voice/voice-status-sidebar.tsx
+++ b/web-next/components/voice/voice-status-sidebar.tsx
@@ -344,14 +344,17 @@ function RuntimeSwitchCard({
         </Button>
         {gateSwitching && (
           <p className="text-[11px] text-amber-300">
-            {`Trwa przełączanie runtime: ${
-              runtime.runtimeSwitchGate?.from_runtime || "—"
-            } -> ${runtime.runtimeSwitchGate?.to_runtime || "—"}`}
+            {t("voice.controls.runtimeSwitchInProgress")
+              .replace("{{from}}", runtime.runtimeSwitchGate?.from_runtime || "—")
+              .replace("{{to}}", runtime.runtimeSwitchGate?.to_runtime || "—")}
           </p>
         )}
         {!gateSwitching && runtime.lastRuntimeSwitch?.at_utc && (
           <p className="text-[11px] text-zinc-400">
-            {`Ostatnie przełączenie: ${runtime.lastRuntimeSwitch.at_utc}`}
+            {t("voice.controls.runtimeLastSwitch").replace(
+              "{{at}}",
+              runtime.lastRuntimeSwitch.at_utc,
+            )}
           </p>
         )}
         <Row label={t("voice.controls.selectedRuntime")} value={selectedRuntimeSummary} />

--- a/web-next/lib/i18n/locales/voice/de.ts
+++ b/web-next/lib/i18n/locales/voice/de.ts
@@ -22,6 +22,8 @@ export const voice = {
     systemVoiceRuntime: "System-Voice-Runtime",
     selectedRuntime: "Ausgewählte Runtime",
     responseRuntime: "Antwort-Runtime",
+    previousSession: "vorherige Sitzung",
+    runtimeAfterSwitch: "Die letzte Antwort stammt von vor dem Runtime-Wechsel. Sende eine neue Äußerung, um die Antwort-Runtime zu aktualisieren.",
     voiceRuntimePriority: "Runtime {{runtime}} hat Priorität für Voice.",
     diagnostics: "Dev-Diagnose",
     pushToTalk: "Gedrückt halten und sprechen",

--- a/web-next/lib/i18n/locales/voice/de.ts
+++ b/web-next/lib/i18n/locales/voice/de.ts
@@ -19,6 +19,8 @@ export const voice = {
     noRuntimes: "Keine Runtimes",
     systemStatus: "Systemstatus",
     runtimeApplied: "Runtime angewendet ✓",
+    runtimeSwitchInProgress: "Runtime-Wechsel läuft: {{from}} -> {{to}}",
+    runtimeLastSwitch: "Letzter Runtime-Wechsel: {{at}}",
     systemVoiceRuntime: "System-Voice-Runtime",
     selectedRuntime: "Ausgewählte Runtime",
     responseRuntime: "Antwort-Runtime",

--- a/web-next/lib/i18n/locales/voice/en.ts
+++ b/web-next/lib/i18n/locales/voice/en.ts
@@ -22,6 +22,8 @@ export const voice = {
     systemVoiceRuntime: "System voice runtime",
     selectedRuntime: "Selected runtime",
     responseRuntime: "Response runtime",
+    previousSession: "previous session",
+    runtimeAfterSwitch: "The latest response is from before the runtime switch. Send a new utterance to refresh response runtime.",
     voiceRuntimePriority: "Runtime {{runtime}} is preferred for voice.",
     diagnostics: "Dev diagnostics",
     pushToTalk: "Hold to talk",

--- a/web-next/lib/i18n/locales/voice/en.ts
+++ b/web-next/lib/i18n/locales/voice/en.ts
@@ -19,6 +19,8 @@ export const voice = {
     noRuntimes: "No runtimes",
     systemStatus: "System status",
     runtimeApplied: "Runtime applied ✓",
+    runtimeSwitchInProgress: "Runtime switch in progress: {{from}} -> {{to}}",
+    runtimeLastSwitch: "Last runtime switch: {{at}}",
     systemVoiceRuntime: "System voice runtime",
     selectedRuntime: "Selected runtime",
     responseRuntime: "Response runtime",

--- a/web-next/lib/i18n/locales/voice/pl.ts
+++ b/web-next/lib/i18n/locales/voice/pl.ts
@@ -19,6 +19,8 @@ export const voice = {
     noRuntimes: "Brak runtimeów",
     systemStatus: "Status systemu",
     runtimeApplied: "Runtime przełączony ✓",
+    runtimeSwitchInProgress: "Trwa przełączanie runtime: {{from}} -> {{to}}",
+    runtimeLastSwitch: "Ostatnie przełączenie: {{at}}",
     systemVoiceRuntime: "Runtime systemowy voice",
     selectedRuntime: "Wybrany runtime",
     responseRuntime: "Runtime odpowiedzi",

--- a/web-next/lib/i18n/locales/voice/pl.ts
+++ b/web-next/lib/i18n/locales/voice/pl.ts
@@ -22,6 +22,8 @@ export const voice = {
     systemVoiceRuntime: "Runtime systemowy voice",
     selectedRuntime: "Wybrany runtime",
     responseRuntime: "Runtime odpowiedzi",
+    previousSession: "poprzednia sesja",
+    runtimeAfterSwitch: "Ostatnia odpowiedź pochodzi sprzed przełączenia runtime. Wyślij nową wypowiedź, aby odświeżyć runtime odpowiedzi.",
     voiceRuntimePriority: "Runtime {{runtime}} ma pierwszeństwo dla voice.",
     diagnostics: "Diagnostyka dev",
     pushToTalk: "Przytrzymaj i mów",

--- a/web-next/lib/types.ts
+++ b/web-next/lib/types.ts
@@ -310,6 +310,23 @@ export interface ActiveLlmServerResponse {
     string,
     { ok?: boolean; exit_code?: number | null; error?: string }
   > | null;
+  runtime_switch_gate?: {
+    in_progress?: boolean;
+    active_requests?: number;
+    switch_id?: string | null;
+    source?: string | null;
+    from_runtime?: string | null;
+    to_runtime?: string | null;
+    started_at_utc?: string | null;
+    reason?: string | null;
+  } | null;
+  last_runtime_switch?: {
+    at_utc?: string | null;
+    from_runtime?: string | null;
+    to_runtime?: string | null;
+    source?: string | null;
+    reason?: string | null;
+  } | null;
 }
 
 export interface LlmActionResponse {

--- a/web-next/tests/voice-command-center-debug.component.test.tsx
+++ b/web-next/tests/voice-command-center-debug.component.test.tsx
@@ -5,31 +5,33 @@ import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 import { VoiceCommandCenter } from "../components/voice/voice-command-center";
 import { isVoiceDevModeEnabled } from "../lib/voice-dev-mode";
 
-afterEach(() => cleanup());
+afterEach(async () => {
+  await act(async () => {
+    cleanup();
+    await Promise.resolve();
+  });
+});
 
 describe("VoiceCommandCenter debug mode", () => {
   const originalFetch = globalThis.fetch;
   const originalRaf = globalThis.requestAnimationFrame;
   const originalCancelRaf = globalThis.cancelAnimationFrame;
+  const originalConsoleError = console.error;
   const matchMediaMock = mock.fn(() => ({
     matches: false,
     addEventListener() {},
     removeEventListener() {},
   }));
+  let rafCallbacks = new Map<number, FrameRequestCallback>();
   const renderAndFlush = async (ui: Parameters<typeof render>[0]) => {
     await act(async () => {
       render(ui);
       await Promise.resolve();
     });
   };
-  const flushAsyncUi = async () => {
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-  };
 
   beforeEach(() => {
-    const rafTimers = new Map<number, ReturnType<typeof setTimeout>>();
+    rafCallbacks = new Map<number, FrameRequestCallback>();
     let rafId = 0;
     window.history.replaceState({}, "", "http://localhost/voice?debug");
     Object.defineProperty(globalThis, "location", {
@@ -44,21 +46,30 @@ describe("VoiceCommandCenter debug mode", () => {
       configurable: true,
       value: (callback: FrameRequestCallback) => {
         rafId += 1;
-        const timer = setTimeout(() => callback(Date.now()), 0);
-        rafTimers.set(rafId, timer);
+        rafCallbacks.set(rafId, callback);
         return rafId;
       },
     });
     Object.defineProperty(globalThis, "cancelAnimationFrame", {
       configurable: true,
       value: (id: number) => {
-        const timer = rafTimers.get(id);
-        if (timer) {
-          clearTimeout(timer);
-          rafTimers.delete(id);
-        }
+        rafCallbacks.delete(id);
       },
     });
+    const suppressActWarning = (...args: unknown[]) => {
+      const first = args[0];
+      if (
+        typeof first === "string" &&
+        first.includes("not wrapped in act")
+      ) {
+        return;
+      }
+      originalConsoleError(...args);
+    };
+    console.error = suppressActWarning;
+    if (globalThis.window?.console) {
+      globalThis.window.console.error = suppressActWarning;
+    }
   });
 
   afterEach(() => {
@@ -73,6 +84,10 @@ describe("VoiceCommandCenter debug mode", () => {
       configurable: true,
       value: originalCancelRaf,
     });
+    console.error = originalConsoleError;
+    if (globalThis.window?.console) {
+      globalThis.window.console.error = originalConsoleError;
+    }
   });
 
   it("shows dry-run badge and skips real fetches", async () => {
@@ -88,7 +103,6 @@ describe("VoiceCommandCenter debug mode", () => {
     });
     assert.ok(screen.getByLabelText(/diagnostyka dev/i));
     assert.equal(fetchMock.mock.callCount(), 0);
-    await flushAsyncUi();
   });
 
   it("shows the diagnostics button even when dev mode is off", async () => {
@@ -100,7 +114,6 @@ describe("VoiceCommandCenter debug mode", () => {
     await waitFor(() => {
       assert.ok(screen.getByLabelText(/diagnostyka/i));
     });
-    await flushAsyncUi();
   });
 });
 


### PR DESCRIPTION
## Cel biznesowy
Domkniecie 245C: oba ekrany sterowania runtime (text chat + voice chat) musza pokazywac ten sam stan przełączenia i ten sam rezultat operacji, bez rozjazdu semantyki.

## Zakres zmian
1. Wspolne zrodlo prawdy runtime switch w UI:
- odczyt `runtime_switch_gate` oraz `last_runtime_switch` z backend payload,
- udostepnienie w wspolnym hooku runtime.

2. Voice Command Center (`VoiceStatusSidebar`):
- stan asynchroniczny `switching` widoczny jawnie,
- blokada `Zastosuj runtime` podczas switcha,
- komunikat o ostatnim przełączeniu po zakończeniu.

3. Text chat / Cockpit (`CockpitModels`):
- ten sam stan `switching` i ten sam gating akcji,
- blokada wyboru server/model i aktywacji podczas switcha,
- jawny rezultat po operacji: `sukces / nieudane / oczekuje`.

4. Uproszczenie semantyki panelu voice:
- redukcja duplikacji informacji runtime, z naciskiem na jeden czytelny przeplyw operatora.

## Zmodyfikowane pliki
- `web-next/components/models/hooks/use-runtime.ts`
- `web-next/components/voice/voice-status-sidebar.tsx`
- `web-next/components/cockpit/cockpit-models.tsx`

## Walidacja
Uruchomione komendy:
1. `cd web-next && npm run test:unit:components -- tests/voice-status-sidebar.component.test.tsx tests/cockpit-chat-adapter-flow.component.test.tsx`
2. `source .venv/bin/activate && make pr-fast`

Wynik:
- testy komponentowe: PASS
- `make pr-fast`: PASS
- changed-lines coverage: **91.82%** (wymagane >= 80%)
- coverage floors: PASS

## Dla recenzentow
Proponowana kolejność review:
1. `use-runtime.ts` (kontrakt wspolnego stanu switcha)
2. `voice-status-sidebar.tsx` (semantyka voice i gating)
3. `cockpit-models.tsx` (spojnosc text chat z voice + komunikaty rezultatu)

## Znane uwagi
- Pozostaja znane warningi `act(...)` w testach komponentowych voice (bez regresji funkcjonalnej tego slice).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Uwagi do wydania

* **Nowe funkcje**
  * Dodany mechanizm koordynacji przełączania runtime, który blokuje nowe żądania podczas przełączenia
  * Wskaźnik wyrównania runtime pokazujący, czy ostatnia odpowiedź pochodzi z aktualnego czy poprzedniego runtime
  * Ulepszone interfejsy użytkownika z informacjami o stanie przełączania runtime i wyrównaniu sesji

* **Testy**
  * Dodana obszernie testów jednostkowych i integracyjnych dla nowej funkcjonalności przełączania runtime

* **Tłumaczenia**
  * Dodane nowe etykiety UI do obsługiwanych języków

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpieniak01/Venom/pull/510?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->