### PR TITLE
feat(voice): PR248A interactive orb effects + EN/PL docs sync

### DIFF
--- a/docs/FRONTEND_NEXT_GUIDE.md
+++ b/docs/FRONTEND_NEXT_GUIDE.md
@@ -120,17 +120,22 @@ From repository root, you can use:
 - UI language (PL/EN/DE) is sent as `preferred_language` in `/api/v1/tasks` and backend translates response if different language detected.
 - Calculation results (e.g. JSON/arrays) are formatted in chat to tables/lists; when formulas detected we render KaTeX.
 
-### 0.6 Voice screen and `react-three` orb stack
-- `web-next/components/voice/*` is the dedicated voice surface for `/voice`: `VoiceCommandCenter`, `OrbZone`, `VoiceOrb`, `VoiceOrb3D`, dialog windows, metrics hooks, and orb-specific overlays.
-- The orb now has a `react-three` rendering path (`VoiceOrb3D` with `@react-three/fiber`, `@react-three/drei`, `@react-three/postprocessing`) plus a CSS fallback when WebGL or 3D mode is unavailable.
+### 0.6 Voice screen and low-GPU orb stack
+- `web-next/components/voice/*` is the dedicated voice surface for `/voice`: `VoiceCommandCenter`, `OrbZone`, `VoiceOrb`, dialog windows, metrics hooks, and orb-specific overlays.
+- After PR 215, the orb is rendered by a 2D CSS/HTML/SVG stack (Calm Idle baseline) instead of `react-three`.
+- PR 248A adds low-GPU interactive effects behind `OrbEffectsConfig`: `parallaxTilt`, `interactiveGlow`, and `clickShockwave`.
+- The new effects can be toggled via `NEXT_PUBLIC_ORB_PARALLAX_TILT`, `NEXT_PUBLIC_ORB_INTERACTIVE_GLOW`, and `NEXT_PUBLIC_ORB_CLICK_SHOCKWAVE`.
+- Interactive effects are active only in operational states (`ready`, `recording`, `thinking`, `tts`, `complete`) and are disabled in `offline`/`error`.
+- `reducedMotion` disables mouse-driven interactions and shockwave animations to keep a static fallback.
 - The `/voice` status panels should make the active audio route explicit: `whisper_llm_piper` for the stable text-only path and `multi_runtime_piper` for the Gemma4 native-audio path, including the fallback reason when the native route is not used.
 - Runtime truth on `/voice` should come from `runtime_state` (`selected`, `active`, `response`, `switch`) and not from ad-hoc field mixing between local component states.
 - `web-next/tests/voice-orb.spec.ts` covers `/voice` layout stability and orb visibility in smoke-style Playwright checks.
+- `web-next/tests/voice-orb.component.test.tsx` covers PR248A interaction behavior (CSS variables on mouse move, offline guardrails, spotlight gating, click shockwave).
 - Frontend helper scripts that matter for this stack live in `web-next/scripts/`:
   - `run-e2e.mjs`
   - `e2e-quality-gate.mjs`
   - `check-dev-turbo.mjs`
-- When adding new voice visuals, document them as part of the orb stack first; treat CSS-only variants as fallback, not as the primary architecture.
+- When adding new voice visuals, document them as part of the primary 2D orb stack and keep GPU-heavy paths optional and explicitly guarded.
 
 ### 0.7 Inspector / Model Introspection
 - Route: `/inspector/model-introspection`.

--- a/docs/PL/FRONTEND_NEXT_GUIDE.md
+++ b/docs/PL/FRONTEND_NEXT_GUIDE.md
@@ -120,17 +120,22 @@ Z poziomu roota repo możesz użyć:
 - Język UI (PL/EN/DE) jest przesyłany jako `preferred_language` w `/api/v1/tasks` i backend tłumaczy odpowiedź, jeśli wykryje inny język.
 - Wyniki obliczeń (np. JSON/tablice) są formatowane w czacie do tabel/list; przy wykryciu formuł renderujemy KaTeX.
 
-### 0.6 Ekran voice i stos orba `react-three`
-- `web-next/components/voice/*` to dedykowany ekran voice dla `/voice`: `VoiceCommandCenter`, `OrbZone`, `VoiceOrb`, `VoiceOrb3D`, okna dialogowe, hooki metryk i overlaye orba.
-- Orb ma już ścieżkę renderowania w `react-three` (`VoiceOrb3D` z `@react-three/fiber`, `@react-three/drei`, `@react-three/postprocessing`) oraz fallback CSS, gdy WebGL lub tryb 3D są niedostępne.
+### 0.6 Ekran voice i niskokosztowy stos orba
+- `web-next/components/voice/*` to dedykowany ekran voice dla `/voice`: `VoiceCommandCenter`, `OrbZone`, `VoiceOrb`, okna dialogowe, hooki metryk i overlaye orba.
+- Po PR 215 orb jest renderowany przez stos 2D CSS/HTML/SVG (baseline Calm Idle), a nie przez `react-three`.
+- PR 248A dodaje interaktywne efekty low-GPU sterowane przez `OrbEffectsConfig`: `parallaxTilt`, `interactiveGlow`, `clickShockwave`.
+- Nowe efekty można przełączać przez `NEXT_PUBLIC_ORB_PARALLAX_TILT`, `NEXT_PUBLIC_ORB_INTERACTIVE_GLOW` i `NEXT_PUBLIC_ORB_CLICK_SHOCKWAVE`.
+- Interaktywne efekty są aktywne tylko w stanach operacyjnych (`ready`, `recording`, `thinking`, `tts`, `complete`) i są wyłączone w `offline`/`error`.
+- `reducedMotion` wyłącza interakcje myszą i animacje shockwave, utrzymując statyczny fallback.
 - Panele statusowe `/voice` powinny jasno pokazywać aktywny tor audio: `whisper_llm_piper` dla stabilnej ścieżki tekstowej oraz `multi_runtime_piper` dla natywnej ścieżki Gemma4, razem z powodem fallbacku, gdy tor natywny nie jest użyty.
 - Kanoniczna prawda runtime na `/voice` powinna pochodzić z `runtime_state` (`selected`, `active`, `response`, `switch`), a nie z mieszania lokalnych stanów komponentów.
 - `web-next/tests/voice-orb.spec.ts` pokrywa stabilność layoutu `/voice` i widoczność orba w smoke testach Playwright.
+- `web-next/tests/voice-orb.component.test.tsx` pokrywa zachowanie interakcji z PR248A (CSS variables po ruchu myszy, guardy offline, spotlight, click shockwave).
 - Ważne skrypty frontendowe dla tego stosu znajdują się w `web-next/scripts/`:
   - `run-e2e.mjs`
   - `e2e-quality-gate.mjs`
   - `check-dev-turbo.mjs`
-- Przy dodawaniu nowych efektów voice dokumentuj je najpierw jako część stosu orba; wariant CSS traktuj jako fallback, nie jako główną architekturę.
+- Przy dodawaniu nowych efektów voice dokumentuj je najpierw jako część głównego stosu 2D orba, a ścieżki GPU-heavy trzymaj jako opcjonalne i jawnie ograniczane.
 
 ### 0.7 Inspector / Model Introspection
 - Route: `/inspector/model-introspection`.

--- a/docs/PL/VOICE_RUNTIME_CAPABILITIES.md
+++ b/docs/PL/VOICE_RUNTIME_CAPABILITIES.md
@@ -39,9 +39,11 @@ Aktualny kontrakt runtime dla `/api/v1/audio/status`:
 Ta gałąź traktuje też orb voice jako osobny stos UI, a nie luźny widget:
 
 1. `VoiceCommandCenter` zarządza stanem ekranu `/voice` i podpina orb do reszty strony,
-2. `VoiceOrb3D` to ścieżka renderowania `react-three` dla orba, gdy włączone są wizualizacje 3D,
-3. CSS orb pozostaje bezpiecznym fallbackiem, gdy WebGL jest niedostępny albo 3D jest wyłączone,
-4. smoke coverage dla voice siedzi w `web-next/tests/voice-orb.spec.ts`.
+2. po PR 215 `VoiceOrb` używa niskokosztowego stosu 2D CSS/HTML/SVG (baseline Calm Idle) jako domyślnej architektury renderowania,
+3. PR 248A dodaje opcjonalne efekty interaktywne (`parallaxTilt`, `interactiveGlow`, `clickShockwave`) sterowane configiem i stanem runtime,
+4. efekty interaktywne działają tylko w `ready`, `recording`, `thinking`, `tts`, `complete` i są wyłączone w `offline` oraz `error`,
+5. `reducedMotion` wyłącza efekty interakcji myszą i utrzymuje orb w stanie statycznym,
+6. pokrycie testowe voice obejmuje teraz `web-next/tests/voice-orb.spec.ts` (smoke) i `web-next/tests/voice-orb.component.test.tsx` (zachowanie interakcji).
 
 ### Aktualny baseline STT
 

--- a/docs/VOICE_RUNTIME_CAPABILITIES.md
+++ b/docs/VOICE_RUNTIME_CAPABILITIES.md
@@ -39,9 +39,11 @@ Current runtime contract for `/api/v1/audio/status`:
 The current branch also treats the voice orb as a dedicated UI stack, not a loose widget:
 
 1. `VoiceCommandCenter` owns the `/voice` screen state and wires the orb into the rest of the page,
-2. `VoiceOrb3D` is the `react-three` rendering path for the orb when 3D visuals are enabled,
-3. the CSS orb remains the safe fallback when WebGL is unavailable or 3D is disabled,
-4. voice-specific smoke coverage lives in `web-next/tests/voice-orb.spec.ts`.
+2. after PR 215, `VoiceOrb` uses a low-GPU 2D CSS/HTML/SVG stack (Calm Idle baseline) as the default rendering architecture,
+3. PR 248A adds optional interactive effects (`parallaxTilt`, `interactiveGlow`, `clickShockwave`) gated by config and runtime state,
+4. interactive effects are active only in `ready`, `recording`, `thinking`, `tts`, `complete` and are disabled in `offline` and `error`,
+5. `reducedMotion` disables mouse-driven interaction effects and keeps the orb static,
+6. voice-specific coverage now includes `web-next/tests/voice-orb.spec.ts` (smoke) and `web-next/tests/voice-orb.component.test.tsx` (interaction behavior).
 
 ### Current STT baseline
 

--- a/web-next/app/globals.css
+++ b/web-next/app/globals.css
@@ -930,3 +930,27 @@ html[data-theme="venom-light"] body::after {
   from { transform: translateY(40px); opacity: 0; }
   to   { transform: translateY(0);    opacity: 1; }
 }
+
+/* Ergonomic Orb enhancements (To-Be plan in PR 248) */
+@keyframes orb-breath {
+  0%, 100% { opacity: 0.16; transform: scale(0.96); }
+  50% { opacity: 0.32; transform: scale(1.04); }
+}
+.animate-orb-breath { animation: orb-breath 6.5s ease-in-out infinite; }
+
+@keyframes orb-fluid-idle {
+  0%, 100% { border-radius: 50%; }
+  33% { border-radius: 52% 48% 51% 49% / 49% 51% 52% 48%; }
+  66% { border-radius: 49% 51% 48% 52% / 51% 49% 52% 48%; }
+}
+.animate-orb-fluid-idle { animation: orb-fluid-idle 8s ease-in-out infinite; }
+
+@keyframes orb-plasma-gradient {
+  0%, 100% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+}
+.animate-orb-plasma-gradient {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.14) 0%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0.08) 100%);
+  background-size: 200% 200%;
+  animation: orb-plasma-gradient 6s ease infinite;
+}

--- a/web-next/app/globals.css
+++ b/web-next/app/globals.css
@@ -953,4 +953,8 @@ html[data-theme="venom-light"] body::after {
   background: linear-gradient(135deg, rgba(255, 255, 255, 0.14) 0%, rgba(255, 255, 255, 0) 50%, rgba(255, 255, 255, 0.08) 100%);
   background-size: 200% 200%;
   animation: orb-plasma-gradient 6s ease infinite;
+  transition: animation-duration 0.4s ease, opacity 0.4s ease;
+}
+.group:hover .animate-orb-plasma-gradient {
+  animation-duration: 2.5s;
 }

--- a/web-next/components/voice/use-orb-effects-config.ts
+++ b/web-next/components/voice/use-orb-effects-config.ts
@@ -14,6 +14,10 @@ export type OrbEffectsConfig = {
   stateLabel: boolean;
   // PR 208B — live system metrics bars radiating from orb center
   orbMetricsBars: boolean;
+  // PR 248A — interactive hover/click low-GPU effects
+  parallaxTilt: boolean;
+  interactiveGlow: boolean;
+  clickShockwave: boolean;
 };
 
 const ALL_OFF: OrbEffectsConfig = {
@@ -26,6 +30,9 @@ const ALL_OFF: OrbEffectsConfig = {
   particles: false,
   stateLabel: false,
   orbMetricsBars: false,
+  parallaxTilt: false,
+  interactiveGlow: false,
+  clickShockwave: false,
 };
 
 const MINIMAL_PROFILE: OrbEffectsConfig = {
@@ -38,6 +45,9 @@ const MINIMAL_PROFILE: OrbEffectsConfig = {
   particles: false,
   stateLabel: true,
   orbMetricsBars: false,
+  parallaxTilt: false,
+  interactiveGlow: false,
+  clickShockwave: false,
 };
 
 // Next.js replaces NEXT_PUBLIC_* vars at build time only when referenced by
@@ -61,6 +71,10 @@ export function useOrbEffectsConfig(): OrbEffectsConfig {
       stateLabel:          !isOff(process.env.NEXT_PUBLIC_ORB_STATE_LABEL),
       // PR 208B — metrics bars default to false (opt-in)
       orbMetricsBars:      process.env.NEXT_PUBLIC_ORB_METRICS_BARS === "true",
+      // PR 248A — interactive effects
+      parallaxTilt:        !isOff(process.env.NEXT_PUBLIC_ORB_PARALLAX_TILT),
+      interactiveGlow:     !isOff(process.env.NEXT_PUBLIC_ORB_INTERACTIVE_GLOW),
+      clickShockwave:      !isOff(process.env.NEXT_PUBLIC_ORB_CLICK_SHOCKWAVE),
     };
     const profile = (process.env.NEXT_PUBLIC_ORB_EFFECT_PROFILE ?? "balanced").toLowerCase();
     if (profile === "minimal") {

--- a/web-next/components/voice/use-voice-debug-mode.ts
+++ b/web-next/components/voice/use-voice-debug-mode.ts
@@ -242,7 +242,8 @@ const buildVoiceDebugSteps = (
 export function useVoiceDebugMode(t: Translator): VoiceDebugSnapshot {
   const readLocationSearch = () =>
     globalThis.location === undefined ? "" : globalThis.location.search;
-  const [hydrated, setHydrated] = useState(globalThis.location !== undefined);
+  // Keep the first client render aligned with SSR output; enable debug mode after mount sync.
+  const [hydrated, setHydrated] = useState(false);
   const [urlSearch, setUrlSearch] = useState(() => readLocationSearch());
   const requested = globalThis.location !== undefined && parseVoiceDebugEnabled(readLocationSearch());
 

--- a/web-next/components/voice/voice-orb.tsx
+++ b/web-next/components/voice/voice-orb.tsx
@@ -64,6 +64,7 @@ const PARTICLE_COLORS: Partial<Record<VoiceOrbState, string>> = {
 };
 
 const ORB_PARTICLE_COUNT = 6;
+const INTERACTIVE_STATES: readonly VoiceOrbState[] = ["ready", "recording", "thinking", "tts", "complete"];
 
 const ORB_SIZE = 160;
 const CORE_SIZE = 96;
@@ -471,6 +472,119 @@ type VoiceOrbProps = Readonly<{
   metricsRef?: RefObject<OrbMetrics>;
 }>;
 
+type OrbShockwave = Readonly<{ id: number; x: number; y: number }>;
+
+type OrbInteractions = Readonly<{
+  shouldInteract: boolean;
+  shouldApplyTilt: boolean;
+  shouldApplyInteractiveGlow: boolean;
+  shockwaves: readonly OrbShockwave[];
+  handleMouseMove: (e: React.MouseEvent<HTMLDivElement>) => void;
+  handleMouseLeave: () => void;
+  handleClick: (e: React.MouseEvent<HTMLDivElement>) => void;
+  handleKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+  handleTouchStart: (e: React.TouchEvent<HTMLDivElement>) => void;
+  handleShockwaveAnimationEnd: (e: React.AnimationEvent<HTMLDivElement>) => void;
+}>;
+
+function isInteractiveOrbState(state: VoiceOrbState): boolean {
+  return INTERACTIVE_STATES.includes(state);
+}
+
+function useOrbInteractions(
+  state: VoiceOrbState,
+  cfg: OrbEffectsConfig,
+  noAnim: boolean,
+  containerRef: RefObject<HTMLDivElement>,
+): OrbInteractions {
+  const [shockwaves, setShockwaves] = useState<readonly OrbShockwave[]>([]);
+  const shockwaveIdRef = useRef(0);
+
+  const shouldInteract = !noAnim && isInteractiveOrbState(state);
+  const shouldApplyTilt = shouldInteract && cfg.parallaxTilt;
+  const shouldApplyInteractiveGlow = shouldInteract && cfg.interactiveGlow;
+
+  const spawnShockwave = (
+    container: HTMLDivElement,
+    clientX: number | undefined,
+    clientY: number | undefined,
+  ) => {
+    if (!shouldInteract || !cfg.clickShockwave) return;
+
+    const rect = container.getBoundingClientRect();
+    const x = typeof clientX === "number" ? clientX - rect.left : rect.width / 2;
+    const y = typeof clientY === "number" ? clientY - rect.top : rect.height / 2;
+
+    const id = shockwaveIdRef.current++;
+    setShockwaves((current) => [...current, { id, x, y }]);
+  };
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!shouldInteract || !containerRef.current) return;
+    if (!cfg.parallaxTilt && !cfg.interactiveGlow) return;
+
+    const rect = containerRef.current.getBoundingClientRect();
+    const width = rect.width || ORB_SIZE;
+    const height = rect.height || ORB_SIZE;
+    const centerX = rect.left + width / 2;
+    const centerY = rect.top + height / 2;
+
+    const x = (e.clientX - centerX) / (width / 2);
+    const y = (e.clientY - centerY) / (height / 2);
+
+    const clampedX = Math.max(-1, Math.min(1, x));
+    const clampedY = Math.max(-1, Math.min(1, y));
+
+    containerRef.current.style.setProperty("--mouse-x", clampedX.toFixed(3));
+    containerRef.current.style.setProperty("--mouse-y", clampedY.toFixed(3));
+  };
+
+  const handleMouseLeave = () => {
+    if (!containerRef.current) return;
+    containerRef.current.style.setProperty("--mouse-x", "0");
+    containerRef.current.style.setProperty("--mouse-y", "0");
+  };
+
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    spawnShockwave(e.currentTarget, e.clientX, e.clientY);
+  };
+
+  const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+    const touch = e.touches[0];
+    if (!touch) return;
+    spawnShockwave(e.currentTarget, touch.clientX, touch.clientY);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== "Enter" && e.key !== " ") return;
+    e.preventDefault();
+    spawnShockwave(e.currentTarget, undefined, undefined);
+  };
+
+  const handleShockwaveAnimationEnd = (e: React.AnimationEvent<HTMLDivElement>) => {
+    const rawId = e.currentTarget.dataset.shockwaveId;
+    if (!rawId) return;
+
+    const id = Number(rawId);
+    if (!Number.isFinite(id)) return;
+
+    setShockwaves((current) => current.filter((sw) => sw.id !== id));
+  };
+
+  return {
+    shouldInteract,
+    shouldApplyTilt,
+    shouldApplyInteractiveGlow,
+    shockwaves,
+    handleMouseMove,
+    handleMouseLeave,
+    handleClick,
+    handleKeyDown,
+    handleTouchStart,
+    handleShockwaveAnimationEnd,
+  };
+}
+
 export function VoiceOrb({
   state,
   inputLevel: inputLevelProp,
@@ -500,54 +614,9 @@ export function VoiceOrb({
     interactiveGlow: true,
     clickShockwave: true,
   };
-
   const containerRef = useRef<HTMLDivElement>(null);
-  const [shockwaves, setShockwaves] = useState<readonly { id: number; x: number; y: number }[]>([]);
-  const shockwaveIdRef = useRef(0);
 
-  const isInteractiveState = !["offline", "error"].includes(effectiveState);
-  const shouldInteract = !noAnim && isInteractiveState;
-  const shouldApplyTilt = shouldInteract && cfg.parallaxTilt;
-  const shouldApplyInteractiveGlow = shouldInteract && cfg.interactiveGlow;
-
-  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (!shouldInteract || !containerRef.current) return;
-    if (!cfg.parallaxTilt && !cfg.interactiveGlow) return;
-
-    const rect = containerRef.current.getBoundingClientRect();
-    const centerX = rect.left + rect.width / 2;
-    const centerY = rect.top + rect.height / 2;
-
-    const x = (e.clientX - centerX) / (rect.width / 2);
-    const y = (e.clientY - centerY) / (rect.height / 2);
-
-    const clampedX = Math.max(-1, Math.min(1, x));
-    const clampedY = Math.max(-1, Math.min(1, y));
-
-    containerRef.current.style.setProperty("--mouse-x", clampedX.toFixed(3));
-    containerRef.current.style.setProperty("--mouse-y", clampedY.toFixed(3));
-  };
-
-  const handleMouseLeave = () => {
-    if (!containerRef.current) return;
-    containerRef.current.style.setProperty("--mouse-x", "0");
-    containerRef.current.style.setProperty("--mouse-y", "0");
-  };
-
-  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (!shouldInteract || !cfg.clickShockwave) return;
-
-    const rect = e.currentTarget.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
-
-    const id = shockwaveIdRef.current++;
-    setShockwaves((current) => [...current, { id, x, y }]);
-
-    setTimeout(() => {
-      setShockwaves((current) => current.filter((sw) => sw.id !== id));
-    }, 600);
-  };
+  const interactions = useOrbInteractions(effectiveState, cfg, noAnim, containerRef);
 
   // Audio level is computed here so the parent does not re-render at 60fps.
   const fallbackRef = useRef<AnalyserNode | null>(null);
@@ -591,9 +660,15 @@ export function VoiceOrb({
     >
       <div
         ref={containerRef}
-        onMouseMove={handleMouseMove}
-        onMouseLeave={handleMouseLeave}
-        onClick={handleClick}
+        onMouseMove={interactions.handleMouseMove}
+        onMouseLeave={interactions.handleMouseLeave}
+        onClick={interactions.handleClick}
+        onKeyDown={interactions.handleKeyDown}
+        onTouchStart={interactions.handleTouchStart}
+        role="button"
+        tabIndex={cfg.clickShockwave && interactions.shouldInteract ? 0 : -1}
+        aria-disabled={!cfg.clickShockwave || !interactions.shouldInteract}
+        aria-label="Trigger voice orb effect"
         className="relative flex items-center justify-center group"
         style={{
           width: ORB_SIZE,
@@ -601,14 +676,16 @@ export function VoiceOrb({
           borderRadius: "50%",
           boxShadow: glowShadow,
           transition: noAnim ? "box-shadow 220ms ease" : "box-shadow 220ms ease, transform 150ms ease-out",
-          transform: shouldApplyTilt ? "perspective(600px) rotateX(calc(var(--mouse-y, 0) * -8deg)) rotateY(calc(var(--mouse-x, 0) * 8deg)) translate3d(calc(var(--mouse-x, 0) * 6px), calc(var(--mouse-y, 0) * 6px), 0)" : undefined,
-          willChange: shouldApplyTilt ? "transform" : undefined,
+          transform: interactions.shouldApplyTilt ? "perspective(600px) rotateX(calc(var(--mouse-y, 0) * -8deg)) rotateY(calc(var(--mouse-x, 0) * 8deg)) translate3d(calc(var(--mouse-x, 0) * 6px), calc(var(--mouse-y, 0) * 6px), 0)" : undefined,
+          willChange: interactions.shouldApplyTilt ? "transform" : undefined,
         }}
       >
-        {cfg.clickShockwave &&
-          shockwaves.map((sw) => (
+        {cfg.clickShockwave && interactions.shouldInteract &&
+          interactions.shockwaves.map((sw) => (
             <div
               key={sw.id}
+              data-shockwave-id={sw.id}
+              onAnimationEnd={interactions.handleShockwaveAnimationEnd}
               className="absolute rounded-full border border-white/40 animate-orb-shockwave pointer-events-none"
               style={{
                 left: sw.x - 24,
@@ -681,7 +758,7 @@ export function VoiceOrb({
             />
           )}
 
-          {cfg.coreTexture && shouldApplyInteractiveGlow && (
+          {cfg.coreTexture && interactions.shouldApplyInteractiveGlow && (
             <div
               className="pointer-events-none absolute inset-0 transition-transform duration-150 ease-out"
               style={{
@@ -693,7 +770,7 @@ export function VoiceOrb({
             />
           )}
 
-          {cfg.coreTexture && effectiveState === "thinking" && (
+          {cfg.coreTexture && !noAnim && effectiveState === "thinking" && (
             <div className="absolute inset-0 animate-orb-plasma-gradient pointer-events-none" />
           )}
 

--- a/web-next/components/voice/voice-orb.tsx
+++ b/web-next/components/voice/voice-orb.tsx
@@ -27,7 +27,7 @@ type OrbVisual = {
 
 const ORB_VISUALS: Record<VoiceOrbState, OrbVisual> = {
   offline: { coreColor: "bg-zinc-700", glowColor: "bg-zinc-600/20", ringAnimation: "", coreAnimation: "" },
-  ready: { coreColor: "bg-indigo-600", glowColor: "bg-indigo-500/12", ringAnimation: "", coreAnimation: "" },
+  ready: { coreColor: "bg-indigo-600", glowColor: "bg-indigo-500/12", ringAnimation: "animate-orb-breath", coreAnimation: "animate-orb-fluid-idle" },
   recording: { coreColor: "bg-emerald-500", glowColor: "bg-emerald-400/30", ringAnimation: "", coreAnimation: "" },
   stt: { coreColor: "bg-amber-500", glowColor: "bg-amber-400/25", ringAnimation: "animate-spin", coreAnimation: "animate-pulse" },
   thinking: { coreColor: "bg-violet-600", glowColor: "bg-violet-500/25", ringAnimation: "animate-orb-thinking", coreAnimation: "" },
@@ -519,7 +519,10 @@ export function VoiceOrb({
   const coreScale = noAnim ? 1 : 1 + Math.min(1, audioLevel) * 0.35;
   const hasMotion = coreScale !== 1;
   const glowShadow = getOrbGlowShadow(cfg.glow, noAnim, effectiveState, audioLevel);
-  const ringAnimation = showAmbientMotion ? getMotionClass(noAnim, visual.ringAnimation) : "";
+  const ringAnimation =
+    !noAnim && (effectiveState === "ready" || showAmbientMotion)
+      ? getMotionClass(noAnim, visual.ringAnimation)
+      : "";
   const coreAnimation = getMotionClass(noAnim, visual.coreAnimation);
   const blobClass = showBlob ? "animate-orb-blob" : "";
   const rippleColors = RIPPLE_COLORS[effectiveState];
@@ -572,6 +575,19 @@ export function VoiceOrb({
           />
         )}
 
+        {effectiveState === "recording" && (
+          <div
+            className={`absolute -inset-2 rounded-full border border-emerald-400/20 ${
+              noAnim ? "" : "transition-all duration-300"
+            } ${
+              audioLevel > 0.05 && !noAnim
+                ? "border-emerald-400/60 scale-[1.04] shadow-[0_0_12px_rgba(52,211,153,0.3)]"
+                : "scale-100"
+            }`}
+            style={{ pointerEvents: "none" }}
+          />
+        )}
+
         <div
           data-testid="voice-orb-core"
           className={`relative overflow-hidden rounded-full shadow-lg transition-colors duration-300 ${visual.coreColor} ${coreAnimation} ${blobClass} ${flashClass}`}
@@ -592,6 +608,10 @@ export function VoiceOrb({
                 background: "radial-gradient(circle at 33% 28%, rgba(255,255,255,0.22) 0%, transparent 58%)",
               }}
             />
+          )}
+
+          {cfg.coreTexture && effectiveState === "thinking" && (
+            <div className="absolute inset-0 animate-orb-plasma-gradient pointer-events-none" />
           )}
 
           {cfg.coreTexture && showAmbientMotion && (

--- a/web-next/components/voice/voice-orb.tsx
+++ b/web-next/components/voice/voice-orb.tsx
@@ -496,6 +496,57 @@ export function VoiceOrb({
     particles: true,
     stateLabel: true,
     orbMetricsBars: false,
+    parallaxTilt: true,
+    interactiveGlow: true,
+    clickShockwave: true,
+  };
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [shockwaves, setShockwaves] = useState<readonly { id: number; x: number; y: number }[]>([]);
+  const shockwaveIdRef = useRef(0);
+
+  const isInteractiveState = !["offline", "error"].includes(effectiveState);
+  const shouldInteract = !noAnim && isInteractiveState;
+  const shouldApplyTilt = shouldInteract && cfg.parallaxTilt;
+  const shouldApplyInteractiveGlow = shouldInteract && cfg.interactiveGlow;
+
+  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!shouldInteract || !containerRef.current) return;
+    if (!cfg.parallaxTilt && !cfg.interactiveGlow) return;
+
+    const rect = containerRef.current.getBoundingClientRect();
+    const centerX = rect.left + rect.width / 2;
+    const centerY = rect.top + rect.height / 2;
+
+    const x = (e.clientX - centerX) / (rect.width / 2);
+    const y = (e.clientY - centerY) / (rect.height / 2);
+
+    const clampedX = Math.max(-1, Math.min(1, x));
+    const clampedY = Math.max(-1, Math.min(1, y));
+
+    containerRef.current.style.setProperty("--mouse-x", clampedX.toFixed(3));
+    containerRef.current.style.setProperty("--mouse-y", clampedY.toFixed(3));
+  };
+
+  const handleMouseLeave = () => {
+    if (!containerRef.current) return;
+    containerRef.current.style.setProperty("--mouse-x", "0");
+    containerRef.current.style.setProperty("--mouse-y", "0");
+  };
+
+  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!shouldInteract || !cfg.clickShockwave) return;
+
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+
+    const id = shockwaveIdRef.current++;
+    setShockwaves((current) => [...current, { id, x, y }]);
+
+    setTimeout(() => {
+      setShockwaves((current) => current.filter((sw) => sw.id !== id));
+    }, 600);
   };
 
   // Audio level is computed here so the parent does not re-render at 60fps.
@@ -539,15 +590,35 @@ export function VoiceOrb({
       style={{ minHeight: "220px" }}
     >
       <div
-        className="relative flex items-center justify-center"
+        ref={containerRef}
+        onMouseMove={handleMouseMove}
+        onMouseLeave={handleMouseLeave}
+        onClick={handleClick}
+        className="relative flex items-center justify-center group"
         style={{
           width: ORB_SIZE,
           height: ORB_SIZE,
           borderRadius: "50%",
           boxShadow: glowShadow,
-          transition: "box-shadow 220ms ease",
+          transition: noAnim ? "box-shadow 220ms ease" : "box-shadow 220ms ease, transform 150ms ease-out",
+          transform: shouldApplyTilt ? "perspective(600px) rotateX(calc(var(--mouse-y, 0) * -8deg)) rotateY(calc(var(--mouse-x, 0) * 8deg)) translate3d(calc(var(--mouse-x, 0) * 6px), calc(var(--mouse-y, 0) * 6px), 0)" : undefined,
+          willChange: shouldApplyTilt ? "transform" : undefined,
         }}
       >
+        {cfg.clickShockwave &&
+          shockwaves.map((sw) => (
+            <div
+              key={sw.id}
+              className="absolute rounded-full border border-white/40 animate-orb-shockwave pointer-events-none"
+              style={{
+                left: sw.x - 24,
+                top: sw.y - 24,
+                width: 48,
+                height: 48,
+              }}
+            />
+          ))}
+
         {showRipple && rippleColors && (
           <>
             <div className={`absolute inset-0 rounded-full ${rippleColors[0]} animate-orb-ripple`} style={{ animationDelay: "0s" }} />
@@ -606,6 +677,18 @@ export function VoiceOrb({
               className="pointer-events-none absolute inset-0"
               style={{
                 background: "radial-gradient(circle at 33% 28%, rgba(255,255,255,0.22) 0%, transparent 58%)",
+              }}
+            />
+          )}
+
+          {cfg.coreTexture && shouldApplyInteractiveGlow && (
+            <div
+              className="pointer-events-none absolute inset-0 transition-transform duration-150 ease-out"
+              style={{
+                background: "radial-gradient(circle at center, rgba(255,255,255,0.18) 0%, transparent 60%)",
+                mixBlendMode: "overlay",
+                transform: "translate3d(calc(var(--mouse-x, 0) * 16px), calc(var(--mouse-y, 0) * 16px), 0)",
+                willChange: "transform",
               }}
             />
           )}

--- a/web-next/components/voice/voice-orb.tsx
+++ b/web-next/components/voice/voice-orb.tsx
@@ -64,7 +64,7 @@ const PARTICLE_COLORS: Partial<Record<VoiceOrbState, string>> = {
 };
 
 const ORB_PARTICLE_COUNT = 6;
-const INTERACTIVE_STATES: readonly VoiceOrbState[] = ["ready", "recording", "thinking", "tts", "complete"];
+const INTERACTIVE_STATES: ReadonlySet<VoiceOrbState> = new Set(["ready", "recording", "thinking", "tts", "complete"]);
 
 const ORB_SIZE = 160;
 const CORE_SIZE = 96;
@@ -479,23 +479,23 @@ type OrbInteractions = Readonly<{
   shouldApplyTilt: boolean;
   shouldApplyInteractiveGlow: boolean;
   shockwaves: readonly OrbShockwave[];
-  handleMouseMove: (e: React.MouseEvent<HTMLDivElement>) => void;
+  handleMouseMove: (e: React.MouseEvent<HTMLButtonElement>) => void;
   handleMouseLeave: () => void;
-  handleClick: (e: React.MouseEvent<HTMLDivElement>) => void;
-  handleKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
-  handleTouchStart: (e: React.TouchEvent<HTMLDivElement>) => void;
+  handleClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  handleKeyDown: (e: React.KeyboardEvent<HTMLButtonElement>) => void;
+  handleTouchStart: (e: React.TouchEvent<HTMLButtonElement>) => void;
   handleShockwaveAnimationEnd: (e: React.AnimationEvent<HTMLDivElement>) => void;
 }>;
 
 function isInteractiveOrbState(state: VoiceOrbState): boolean {
-  return INTERACTIVE_STATES.includes(state);
+  return INTERACTIVE_STATES.has(state);
 }
 
 function useOrbInteractions(
   state: VoiceOrbState,
   cfg: OrbEffectsConfig,
   noAnim: boolean,
-  containerRef: RefObject<HTMLDivElement>,
+  containerRef: RefObject<HTMLButtonElement>,
 ): OrbInteractions {
   const [shockwaves, setShockwaves] = useState<readonly OrbShockwave[]>([]);
   const shockwaveIdRef = useRef(0);
@@ -505,7 +505,7 @@ function useOrbInteractions(
   const shouldApplyInteractiveGlow = shouldInteract && cfg.interactiveGlow;
 
   const spawnShockwave = (
-    container: HTMLDivElement,
+    container: HTMLButtonElement,
     clientX: number | undefined,
     clientY: number | undefined,
   ) => {
@@ -519,7 +519,7 @@ function useOrbInteractions(
     setShockwaves((current) => [...current, { id, x, y }]);
   };
 
-  const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+  const handleMouseMove = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (!shouldInteract || !containerRef.current) return;
     if (!cfg.parallaxTilt && !cfg.interactiveGlow) return;
 
@@ -545,17 +545,17 @@ function useOrbInteractions(
     containerRef.current.style.setProperty("--mouse-y", "0");
   };
 
-  const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     spawnShockwave(e.currentTarget, e.clientX, e.clientY);
   };
 
-  const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
+  const handleTouchStart = (e: React.TouchEvent<HTMLButtonElement>) => {
     const touch = e.touches[0];
     if (!touch) return;
     spawnShockwave(e.currentTarget, touch.clientX, touch.clientY);
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
     if (e.key !== "Enter" && e.key !== " ") return;
     e.preventDefault();
     spawnShockwave(e.currentTarget, undefined, undefined);
@@ -583,6 +583,238 @@ function useOrbInteractions(
     handleTouchStart,
     handleShockwaveAnimationEnd,
   };
+}
+
+type VoiceOrbSceneProps = Readonly<{
+  visual: OrbVisual;
+  cfg: OrbEffectsConfig;
+  noAnim: boolean;
+  effectiveState: VoiceOrbState;
+  containerRef: RefObject<HTMLButtonElement>;
+  interactions: OrbInteractions;
+  glowShadow: string | undefined;
+  ringAnimation: string;
+  glowClassName: string;
+  showRipple: boolean;
+  rippleColors: [string, string, string] | undefined;
+  showFreqRing: boolean;
+  activeAnalyser: RefObject<AnalyserNode | null> | undefined;
+  fftColor: string;
+  showBurst: boolean;
+  burstKey: number;
+  audioLevel: number;
+  coreScale: number;
+  hasMotion: boolean;
+  coreAnimation: string;
+  blobClass: string;
+  flashClass: string;
+  showAmbientMotion: boolean;
+  showParticles: boolean;
+  particles: ReturnType<typeof useOrbParticles>;
+  particleColor: string;
+  showMetricsBars: boolean;
+  metricsRef: RefObject<OrbMetrics> | undefined;
+}>;
+
+function VoiceOrbScene({
+  visual,
+  cfg,
+  noAnim,
+  effectiveState,
+  containerRef,
+  interactions,
+  glowShadow,
+  ringAnimation,
+  glowClassName,
+  showRipple,
+  rippleColors,
+  showFreqRing,
+  activeAnalyser,
+  fftColor,
+  showBurst,
+  burstKey,
+  audioLevel,
+  coreScale,
+  hasMotion,
+  coreAnimation,
+  blobClass,
+  flashClass,
+  showAmbientMotion,
+  showParticles,
+  particles,
+  particleColor,
+  showMetricsBars,
+  metricsRef,
+}: VoiceOrbSceneProps) {
+  return (
+    <button
+      ref={containerRef}
+      type="button"
+      onMouseMove={interactions.handleMouseMove}
+      onMouseLeave={interactions.handleMouseLeave}
+      onClick={interactions.handleClick}
+      onKeyDown={interactions.handleKeyDown}
+      onTouchStart={interactions.handleTouchStart}
+      tabIndex={cfg.clickShockwave && interactions.shouldInteract ? 0 : -1}
+      aria-disabled={!cfg.clickShockwave || !interactions.shouldInteract}
+      aria-label="Trigger voice orb effect"
+      className="group relative flex appearance-none items-center justify-center border-0 bg-transparent p-0 text-inherit"
+      style={{
+        width: ORB_SIZE,
+        height: ORB_SIZE,
+        borderRadius: "50%",
+        boxShadow: glowShadow,
+        transition: noAnim ? "box-shadow 220ms ease" : "box-shadow 220ms ease, transform 150ms ease-out",
+        transform: interactions.shouldApplyTilt ? "perspective(600px) rotateX(calc(var(--mouse-y, 0) * -8deg)) rotateY(calc(var(--mouse-x, 0) * 8deg)) translate3d(calc(var(--mouse-x, 0) * 6px), calc(var(--mouse-y, 0) * 6px), 0)" : undefined,
+        willChange: interactions.shouldApplyTilt ? "transform" : undefined,
+      }}
+    >
+      {cfg.clickShockwave && interactions.shouldInteract &&
+        interactions.shockwaves.map((sw) => (
+          <div
+            key={sw.id}
+            data-shockwave-id={sw.id}
+            onAnimationEnd={interactions.handleShockwaveAnimationEnd}
+            className="pointer-events-none absolute rounded-full border border-white/40 animate-orb-shockwave"
+            style={{
+              left: sw.x - 24,
+              top: sw.y - 24,
+              width: 48,
+              height: 48,
+            }}
+          />
+        ))}
+
+      {showRipple && rippleColors && (
+        <>
+          <div className={`absolute inset-0 rounded-full ${rippleColors[0]} animate-orb-ripple`} style={{ animationDelay: "0s" }} />
+          <div className={`absolute inset-1 rounded-full ${rippleColors[1]} animate-orb-ripple`} style={{ animationDelay: "0.44s" }} />
+        </>
+      )}
+
+      {cfg.glow && (
+        <div className={`absolute inset-0 rounded-full ${glowClassName} transition-colors duration-500 ${visual.glowColor} ${ringAnimation}`} />
+      )}
+
+      {showFreqRing && activeAnalyser && (
+        <OrbFrequencyRing analyserRef={activeAnalyser} active={showFreqRing} color={fftColor} size={ORB_SIZE} />
+      )}
+
+      {effectiveState === "stt" && !noAnim && (
+        <div className="absolute inset-4 rounded-full border-2 border-amber-400/40 border-t-amber-400 animate-spin" />
+      )}
+
+      {showBurst && (
+        <div
+          key={burstKey}
+          className="pointer-events-none absolute inset-0 rounded-full border-2 border-teal-400/70 animate-orb-burst"
+        />
+      )}
+
+      {effectiveState === "recording" && (
+        <div
+          className={`absolute -inset-2 rounded-full border border-emerald-400/20 ${
+            noAnim ? "" : "transition-all duration-300"
+          } ${
+            audioLevel > 0.05 && !noAnim
+              ? "border-emerald-400/60 scale-[1.04] shadow-[0_0_12px_rgba(52,211,153,0.3)]"
+              : "scale-100"
+          }`}
+          style={{ pointerEvents: "none" }}
+        />
+      )}
+
+      <div
+        data-testid="voice-orb-core"
+        className={`relative overflow-hidden rounded-full shadow-lg transition-colors duration-300 ${visual.coreColor} ${coreAnimation} ${blobClass} ${flashClass}`}
+        style={{
+          width: CORE_SIZE,
+          height: CORE_SIZE,
+          transform: `scale(${formatCoreScale(coreScale)})`,
+          willChange: hasMotion ? "transform" : undefined,
+          transition: noAnim
+            ? "background-color 300ms, border-radius 400ms"
+            : "transform 80ms linear, background-color 300ms, border-radius 400ms ease-in-out",
+        }}
+      >
+        {cfg.coreTexture && (
+          <div
+            className="pointer-events-none absolute inset-0"
+            style={{
+              background: "radial-gradient(circle at 33% 28%, rgba(255,255,255,0.22) 0%, transparent 58%)",
+            }}
+          />
+        )}
+
+        {cfg.coreTexture && interactions.shouldApplyInteractiveGlow && (
+          <div
+            className="pointer-events-none absolute inset-0 transition-transform duration-150 ease-out"
+            style={{
+              background: "radial-gradient(circle at center, rgba(255,255,255,0.18) 0%, transparent 60%)",
+              mixBlendMode: "overlay",
+              transform: "translate3d(calc(var(--mouse-x, 0) * 16px), calc(var(--mouse-y, 0) * 16px), 0)",
+              willChange: "transform",
+            }}
+          />
+        )}
+
+        {cfg.coreTexture && !noAnim && effectiveState === "thinking" && (
+          <div className="pointer-events-none absolute inset-0 animate-orb-plasma-gradient" />
+        )}
+
+        {cfg.coreTexture && showAmbientMotion && (
+          <>
+            <div
+              className="pointer-events-none absolute rounded-full opacity-[0.18] animate-orb-plasma-slow"
+              style={{
+                width: "58%",
+                height: "58%",
+                top: "21%",
+                left: "21%",
+                border: "1px solid rgba(255,255,255,0.5)",
+              }}
+            />
+            <div
+              className="pointer-events-none absolute rounded-full opacity-[0.13] animate-orb-plasma-fast"
+              style={{
+                width: "80%",
+                height: "80%",
+                top: "10%",
+                left: "10%",
+                border: "1px solid rgba(255,255,255,0.3)",
+              }}
+            />
+          </>
+        )}
+      </div>
+
+      {showParticles &&
+        particles.map((particle) => {
+          const rad = (particle.angle * Math.PI) / 180;
+          const x = ORB_SIZE / 2 + particle.offset * Math.cos(rad);
+          const y = ORB_SIZE / 2 + particle.offset * Math.sin(rad);
+          return (
+            <div
+              key={particle.id}
+              className="pointer-events-none absolute rounded-full animate-orb-particle-rise"
+              style={{
+                width: particle.size,
+                height: particle.size,
+                left: x - particle.size / 2,
+                top: y - particle.size / 2,
+                backgroundColor: particleColor,
+                animationDuration: `${particle.duration.toFixed(2)}s`,
+                animationDelay: `${particle.delay.toFixed(2)}s`,
+              }}
+            />
+          );
+        })}
+
+      {showMetricsBars && (
+        <OrbMetricsBars2D metricsRef={metricsRef} orbSize={ORB_SIZE} colorMode />
+      )}
+    </button>
+  );
 }
 
 export function VoiceOrb({
@@ -614,7 +846,7 @@ export function VoiceOrb({
     interactiveGlow: true,
     clickShockwave: true,
   };
-  const containerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLButtonElement>(null);
 
   const interactions = useOrbInteractions(effectiveState, cfg, noAnim, containerRef);
 
@@ -658,174 +890,36 @@ export function VoiceOrb({
       className="flex flex-col items-center gap-3 py-2"
       style={{ minHeight: "220px" }}
     >
-      <div
-        ref={containerRef}
-        onMouseMove={interactions.handleMouseMove}
-        onMouseLeave={interactions.handleMouseLeave}
-        onClick={interactions.handleClick}
-        onKeyDown={interactions.handleKeyDown}
-        onTouchStart={interactions.handleTouchStart}
-        role="button"
-        tabIndex={cfg.clickShockwave && interactions.shouldInteract ? 0 : -1}
-        aria-disabled={!cfg.clickShockwave || !interactions.shouldInteract}
-        aria-label="Trigger voice orb effect"
-        className="relative flex items-center justify-center group"
-        style={{
-          width: ORB_SIZE,
-          height: ORB_SIZE,
-          borderRadius: "50%",
-          boxShadow: glowShadow,
-          transition: noAnim ? "box-shadow 220ms ease" : "box-shadow 220ms ease, transform 150ms ease-out",
-          transform: interactions.shouldApplyTilt ? "perspective(600px) rotateX(calc(var(--mouse-y, 0) * -8deg)) rotateY(calc(var(--mouse-x, 0) * 8deg)) translate3d(calc(var(--mouse-x, 0) * 6px), calc(var(--mouse-y, 0) * 6px), 0)" : undefined,
-          willChange: interactions.shouldApplyTilt ? "transform" : undefined,
-        }}
-      >
-        {cfg.clickShockwave && interactions.shouldInteract &&
-          interactions.shockwaves.map((sw) => (
-            <div
-              key={sw.id}
-              data-shockwave-id={sw.id}
-              onAnimationEnd={interactions.handleShockwaveAnimationEnd}
-              className="absolute rounded-full border border-white/40 animate-orb-shockwave pointer-events-none"
-              style={{
-                left: sw.x - 24,
-                top: sw.y - 24,
-                width: 48,
-                height: 48,
-              }}
-            />
-          ))}
-
-        {showRipple && rippleColors && (
-          <>
-            <div className={`absolute inset-0 rounded-full ${rippleColors[0]} animate-orb-ripple`} style={{ animationDelay: "0s" }} />
-            <div className={`absolute inset-1 rounded-full ${rippleColors[1]} animate-orb-ripple`} style={{ animationDelay: "0.44s" }} />
-          </>
-        )}
-
-        {cfg.glow && (
-          <div className={`absolute inset-0 rounded-full ${glowClassName} transition-colors duration-500 ${visual.glowColor} ${ringAnimation}`} />
-        )}
-
-        {showFreqRing && activeAnalyser && (
-          <OrbFrequencyRing analyserRef={activeAnalyser} active={showFreqRing} color={fftColor} size={ORB_SIZE} />
-        )}
-
-        {effectiveState === "stt" && !noAnim && (
-          <div className="absolute inset-4 rounded-full border-2 border-amber-400/40 border-t-amber-400 animate-spin" />
-        )}
-
-        {showBurst && (
-          <div
-            key={burstKey}
-            className="absolute inset-0 rounded-full border-2 border-teal-400/70 animate-orb-burst"
-            style={{ pointerEvents: "none" }}
-          />
-        )}
-
-        {effectiveState === "recording" && (
-          <div
-            className={`absolute -inset-2 rounded-full border border-emerald-400/20 ${
-              noAnim ? "" : "transition-all duration-300"
-            } ${
-              audioLevel > 0.05 && !noAnim
-                ? "border-emerald-400/60 scale-[1.04] shadow-[0_0_12px_rgba(52,211,153,0.3)]"
-                : "scale-100"
-            }`}
-            style={{ pointerEvents: "none" }}
-          />
-        )}
-
-        <div
-          data-testid="voice-orb-core"
-          className={`relative overflow-hidden rounded-full shadow-lg transition-colors duration-300 ${visual.coreColor} ${coreAnimation} ${blobClass} ${flashClass}`}
-          style={{
-            width: CORE_SIZE,
-            height: CORE_SIZE,
-            transform: `scale(${formatCoreScale(coreScale)})`,
-            willChange: hasMotion ? "transform" : undefined,
-            transition: noAnim
-              ? "background-color 300ms, border-radius 400ms"
-              : "transform 80ms linear, background-color 300ms, border-radius 400ms ease-in-out",
-          }}
-        >
-          {cfg.coreTexture && (
-            <div
-              className="pointer-events-none absolute inset-0"
-              style={{
-                background: "radial-gradient(circle at 33% 28%, rgba(255,255,255,0.22) 0%, transparent 58%)",
-              }}
-            />
-          )}
-
-          {cfg.coreTexture && interactions.shouldApplyInteractiveGlow && (
-            <div
-              className="pointer-events-none absolute inset-0 transition-transform duration-150 ease-out"
-              style={{
-                background: "radial-gradient(circle at center, rgba(255,255,255,0.18) 0%, transparent 60%)",
-                mixBlendMode: "overlay",
-                transform: "translate3d(calc(var(--mouse-x, 0) * 16px), calc(var(--mouse-y, 0) * 16px), 0)",
-                willChange: "transform",
-              }}
-            />
-          )}
-
-          {cfg.coreTexture && !noAnim && effectiveState === "thinking" && (
-            <div className="absolute inset-0 animate-orb-plasma-gradient pointer-events-none" />
-          )}
-
-          {cfg.coreTexture && showAmbientMotion && (
-            <>
-              <div
-                className="animate-orb-plasma-slow pointer-events-none absolute rounded-full opacity-[0.18]"
-                style={{
-                  width: "58%",
-                  height: "58%",
-                  top: "21%",
-                  left: "21%",
-                  border: "1px solid rgba(255,255,255,0.5)",
-                }}
-              />
-              <div
-                className="animate-orb-plasma-fast pointer-events-none absolute rounded-full opacity-[0.13]"
-                style={{
-                  width: "80%",
-                  height: "80%",
-                  top: "10%",
-                  left: "10%",
-                  border: "1px solid rgba(255,255,255,0.3)",
-                }}
-              />
-            </>
-          )}
-        </div>
-
-        {showParticles &&
-          particles.map((particle) => {
-            const rad = (particle.angle * Math.PI) / 180;
-            const x = ORB_SIZE / 2 + particle.offset * Math.cos(rad);
-            const y = ORB_SIZE / 2 + particle.offset * Math.sin(rad);
-            return (
-              <div
-                key={particle.id}
-                className="pointer-events-none absolute rounded-full animate-orb-particle-rise"
-                style={{
-                  width: particle.size,
-                  height: particle.size,
-                  left: x - particle.size / 2,
-                  top: y - particle.size / 2,
-                  backgroundColor: particleColor,
-                  animationDuration: `${particle.duration.toFixed(2)}s`,
-                  animationDelay: `${particle.delay.toFixed(2)}s`,
-                }}
-              />
-            );
-          })}
-
-        {showMetricsBars && (
-          <OrbMetricsBars2D metricsRef={metricsRef} orbSize={ORB_SIZE} colorMode />
-        )}
-      </div>
+      <VoiceOrbScene
+        visual={visual}
+        cfg={cfg}
+        noAnim={noAnim}
+        effectiveState={effectiveState}
+        containerRef={containerRef}
+        interactions={interactions}
+        glowShadow={glowShadow}
+        ringAnimation={ringAnimation}
+        glowClassName={glowClassName}
+        showRipple={showRipple}
+        rippleColors={rippleColors}
+        showFreqRing={showFreqRing}
+        activeAnalyser={activeAnalyser}
+        fftColor={fftColor}
+        showBurst={showBurst}
+        burstKey={burstKey}
+        audioLevel={audioLevel}
+        coreScale={coreScale}
+        hasMotion={hasMotion}
+        coreAnimation={coreAnimation}
+        blobClass={blobClass}
+        flashClass={flashClass}
+        showAmbientMotion={showAmbientMotion}
+        showParticles={showParticles}
+        particles={particles}
+        particleColor={particleColor}
+        showMetricsBars={showMetricsBars}
+        metricsRef={metricsRef}
+      />
 
       {cfg.stateLabel && (
         <p

--- a/web-next/tailwind.config.ts
+++ b/web-next/tailwind.config.ts
@@ -62,6 +62,10 @@ const config: Config = {
           "0%": { transform: "scale(1)", opacity: "0.75" },
           "100%": { transform: "scale(2.4)", opacity: "0" },
         },
+        "orb-shockwave": {
+          "0%": { transform: "scale(1)", opacity: "0.75" },
+          "100%": { transform: "scale(2.2)", opacity: "0" },
+        },
         "accordion-down": {
           from: { height: "0" },
           to: { height: "var(--radix-accordion-content-height)" },
@@ -78,6 +82,7 @@ const config: Config = {
         "orb-blob": "orb-blob 3.2s ease-in-out infinite",
         "orb-flash": "orb-flash 0.32s ease-out forwards",
         "orb-burst": "orb-burst 0.58s ease-out forwards",
+        "orb-shockwave": "orb-shockwave 0.6s ease-out forwards",
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
       },

--- a/web-next/tests/voice-orb.component.test.tsx
+++ b/web-next/tests/voice-orb.component.test.tsx
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { afterEach, describe, it } from "node:test";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, render, fireEvent } from "@testing-library/react";
 import type { OrbEffectsConfig } from "../components/voice/use-orb-effects-config";
 import { VoiceOrb, type VoiceOrbState } from "../components/voice/voice-orb";
 
@@ -27,6 +27,9 @@ const METRICS_ENABLED_CONFIG: OrbEffectsConfig = {
   particles: false,
   stateLabel: false,
   orbMetricsBars: true,
+  parallaxTilt: false,
+  interactiveGlow: false,
+  clickShockwave: false,
 };
 
 const NO_GLOW_CONFIG: OrbEffectsConfig = {
@@ -39,6 +42,9 @@ const NO_GLOW_CONFIG: OrbEffectsConfig = {
   particles: false,
   stateLabel: true,
   orbMetricsBars: false,
+  parallaxTilt: false,
+  interactiveGlow: false,
+  clickShockwave: false,
 };
 
 const BLOB_ENABLED_CONFIG: OrbEffectsConfig = {
@@ -51,6 +57,9 @@ const BLOB_ENABLED_CONFIG: OrbEffectsConfig = {
   particles: false,
   stateLabel: false,
   orbMetricsBars: false,
+  parallaxTilt: false,
+  interactiveGlow: false,
+  clickShockwave: false,
 };
 
 const PARTICLES_ENABLED_CONFIG: OrbEffectsConfig = {
@@ -63,6 +72,9 @@ const PARTICLES_ENABLED_CONFIG: OrbEffectsConfig = {
   particles: true,
   stateLabel: false,
   orbMetricsBars: false,
+  parallaxTilt: false,
+  interactiveGlow: false,
+  clickShockwave: false,
 };
 
 describe("VoiceOrb", () => {
@@ -313,6 +325,84 @@ describe("VoiceOrb", () => {
       );
       assert.ok(!container.innerHTML.includes("animate-orb-breath"), "should disable breath animation");
       assert.ok(!container.innerHTML.includes("animate-orb-fluid-idle"), "should disable fluid idle animation");
+    });
+  });
+
+  describe("PR248A — interactive effects", () => {
+    it("registers mouse move and updates CSS variables for tilt when enabled", () => {
+      const { getByRole } = render(
+        <VoiceOrb state="ready" inputLevel={0} outputLevel={0} />
+      );
+      const orb = getByRole("img");
+      const wrapper = orb.firstChild as HTMLElement;
+
+      // Initially --mouse-x and --mouse-y are not set on style
+      assert.equal(wrapper.style.getPropertyValue("--mouse-x"), "");
+
+      // Trigger mousemove
+      fireEvent.mouseMove(wrapper, { clientX: 100, clientY: 100 });
+
+      // Should have set CSS variables (non-empty string)
+      const mx = wrapper.style.getPropertyValue("--mouse-x");
+      const my = wrapper.style.getPropertyValue("--mouse-y");
+      assert.ok(mx !== "", "should set --mouse-x");
+      assert.ok(my !== "", "should set --mouse-y");
+
+      // Trigger mouseleave
+      fireEvent.mouseLeave(wrapper);
+      assert.equal(wrapper.style.getPropertyValue("--mouse-x"), "0");
+      assert.equal(wrapper.style.getPropertyValue("--mouse-y"), "0");
+    });
+
+    it("does not track mouse or apply transform in offline state", () => {
+      const { getByRole } = render(
+        <VoiceOrb state="offline" inputLevel={0} outputLevel={0} />
+      );
+      const orb = getByRole("img");
+      const wrapper = orb.firstChild as HTMLElement;
+
+      fireEvent.mouseMove(wrapper, { clientX: 100, clientY: 100 });
+      assert.equal(wrapper.style.getPropertyValue("--mouse-x"), "");
+      assert.ok(!wrapper.style.transform.includes("perspective"), "should not have 3D perspective transform");
+    });
+
+    it("renders spotlight only when interactiveGlow is enabled and state is not offline", () => {
+      const glowConfigEnabled: OrbEffectsConfig = {
+        ripple: false, blob: false, glow: false, transitions: false,
+        frequencyRing: false, coreTexture: true, particles: false,
+        stateLabel: false, orbMetricsBars: false,
+        parallaxTilt: false, interactiveGlow: true, clickShockwave: false
+      };
+      const { container, unmount } = render(
+        <VoiceOrb state="ready" inputLevel={0} outputLevel={0} effectsConfig={glowConfigEnabled} />
+      );
+      assert.ok(container.innerHTML.includes("mix-blend-mode: overlay"), "should render spotlight");
+      unmount();
+
+      const offline = render(
+        <VoiceOrb state="offline" inputLevel={0} outputLevel={0} effectsConfig={glowConfigEnabled} />
+      );
+      assert.ok(!offline.container.innerHTML.includes("mix-blend-mode: overlay"), "should not render spotlight in offline");
+      offline.unmount();
+    });
+
+    it("spawns shockwave on click when clickShockwave is enabled", () => {
+      const clickConfigEnabled: OrbEffectsConfig = {
+        ripple: false, blob: false, glow: false, transitions: false,
+        frequencyRing: false, coreTexture: false, particles: false,
+        stateLabel: false, orbMetricsBars: false,
+        parallaxTilt: false, interactiveGlow: false, clickShockwave: true
+      };
+      const { container, getByRole } = render(
+        <VoiceOrb state="ready" inputLevel={0} outputLevel={0} effectsConfig={clickConfigEnabled} />
+      );
+      const orb = getByRole("img");
+      const wrapper = orb.firstChild as HTMLElement;
+
+      assert.ok(!container.innerHTML.includes("animate-orb-shockwave"), "no shockwave initially");
+
+      fireEvent.click(wrapper, { clientX: 50, clientY: 50 });
+      assert.ok(container.innerHTML.includes("animate-orb-shockwave"), "shockwave rendered after click");
     });
   });
 });

--- a/web-next/tests/voice-orb.component.test.tsx
+++ b/web-next/tests/voice-orb.component.test.tsx
@@ -326,6 +326,13 @@ describe("VoiceOrb", () => {
       assert.ok(!container.innerHTML.includes("animate-orb-breath"), "should disable breath animation");
       assert.ok(!container.innerHTML.includes("animate-orb-fluid-idle"), "should disable fluid idle animation");
     });
+
+    it("respects reducedMotion by disabling thinking plasma gradient animation", () => {
+      const { container } = render(
+        <VoiceOrb state="thinking" inputLevel={0} outputLevel={0} reducedMotion />,
+      );
+      assert.ok(!container.innerHTML.includes("animate-orb-plasma-gradient"));
+    });
   });
 
   describe("PR248A — interactive effects", () => {
@@ -366,6 +373,48 @@ describe("VoiceOrb", () => {
       assert.ok(!wrapper.style.transform.includes("perspective"), "should not have 3D perspective transform");
     });
 
+    it("does not track mouse or apply transform in stt state", () => {
+      const { getByRole } = render(
+        <VoiceOrb state="stt" inputLevel={0} outputLevel={0} />
+      );
+      const orb = getByRole("img");
+      const wrapper = orb.firstChild as HTMLElement;
+
+      fireEvent.mouseMove(wrapper, { clientX: 100, clientY: 100 });
+      assert.equal(wrapper.style.getPropertyValue("--mouse-x"), "");
+      assert.ok(!wrapper.style.transform.includes("perspective"), "should not have 3D perspective transform");
+    });
+
+    it("falls back to ORB_SIZE when bounding rect dimensions are zero", () => {
+      const { getByRole } = render(
+        <VoiceOrb state="ready" inputLevel={0} outputLevel={0} />
+      );
+      const orb = getByRole("img");
+      const wrapper = orb.firstChild as HTMLElement;
+      const originalGetBoundingClientRect = wrapper.getBoundingClientRect.bind(wrapper);
+
+      wrapper.getBoundingClientRect = () =>
+        ({
+          x: 0,
+          y: 0,
+          width: 0,
+          height: 0,
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+          toJSON: () => ({}),
+        }) as DOMRect;
+
+      fireEvent.mouseMove(wrapper, { clientX: 10, clientY: 10 });
+      const mx = wrapper.style.getPropertyValue("--mouse-x");
+      const my = wrapper.style.getPropertyValue("--mouse-y");
+      assert.ok(mx !== "NaN", "should not set --mouse-x to NaN");
+      assert.ok(my !== "NaN", "should not set --mouse-y to NaN");
+
+      wrapper.getBoundingClientRect = originalGetBoundingClientRect;
+    });
+
     it("renders spotlight only when interactiveGlow is enabled and state is not offline", () => {
       const glowConfigEnabled: OrbEffectsConfig = {
         ripple: false, blob: false, glow: false, transitions: false,
@@ -403,6 +452,26 @@ describe("VoiceOrb", () => {
 
       fireEvent.click(wrapper, { clientX: 50, clientY: 50 });
       assert.ok(container.innerHTML.includes("animate-orb-shockwave"), "shockwave rendered after click");
+    });
+
+    it("hides queued shockwaves when state becomes non-interactive", () => {
+      const clickConfigEnabled: OrbEffectsConfig = {
+        ripple: false, blob: false, glow: false, transitions: false,
+        frequencyRing: false, coreTexture: false, particles: false,
+        stateLabel: false, orbMetricsBars: false,
+        parallaxTilt: false, interactiveGlow: false, clickShockwave: true
+      };
+      const { container, getByRole, rerender } = render(
+        <VoiceOrb state="ready" inputLevel={0} outputLevel={0} effectsConfig={clickConfigEnabled} />
+      );
+      const orb = getByRole("img");
+      const wrapper = orb.firstChild as HTMLElement;
+
+      fireEvent.click(wrapper, { clientX: 50, clientY: 50 });
+      assert.ok(container.innerHTML.includes("animate-orb-shockwave"), "shockwave rendered after click");
+
+      rerender(<VoiceOrb state="offline" inputLevel={0} outputLevel={0} effectsConfig={clickConfigEnabled} />);
+      assert.ok(!container.innerHTML.includes("animate-orb-shockwave"), "shockwave hidden in non-interactive state");
     });
   });
 });

--- a/web-next/tests/voice-orb.component.test.tsx
+++ b/web-next/tests/voice-orb.component.test.tsx
@@ -274,4 +274,45 @@ describe("VoiceOrb", () => {
       );
     });
   });
+
+  describe("ergonomic enhancements", () => {
+    it("applies ambient breath and fluid idle animations in ready state", () => {
+      const { container } = render(
+        <VoiceOrb state="ready" inputLevel={0} outputLevel={0} />,
+      );
+      assert.ok(container.innerHTML.includes("animate-orb-breath"), "should include animate-orb-breath");
+      assert.ok(container.innerHTML.includes("animate-orb-fluid-idle"), "should include animate-orb-fluid-idle");
+    });
+
+    it("applies inner plasma gradient in thinking state", () => {
+      const { container } = render(
+        <VoiceOrb state="thinking" inputLevel={0} outputLevel={0} />,
+      );
+      assert.ok(container.innerHTML.includes("animate-orb-plasma-gradient"), "should include animate-orb-plasma-gradient");
+    });
+
+    it("applies dynamic VAD ring scaling during recording state based on input level", () => {
+      const active = render(
+        <VoiceOrb state="recording" inputLevel={0.15} outputLevel={0} />,
+      );
+      assert.ok(active.container.innerHTML.includes("border-emerald-400/60"), "should include border active class");
+      assert.ok(active.container.innerHTML.includes("scale-[1.04]"), "should scale VAD ring");
+      active.unmount();
+
+      const quiet = render(
+        <VoiceOrb state="recording" inputLevel={0} outputLevel={0} />,
+      );
+      assert.ok(!quiet.container.innerHTML.includes("border-emerald-400/60"), "should not include border active class when quiet");
+      assert.ok(quiet.container.innerHTML.includes("scale-100"), "should scale to 100 when quiet");
+      quiet.unmount();
+    });
+
+    it("respects reducedMotion by disabling ready state animations", () => {
+      const { container } = render(
+        <VoiceOrb state="ready" inputLevel={0} outputLevel={0} reducedMotion />,
+      );
+      assert.ok(!container.innerHTML.includes("animate-orb-breath"), "should disable breath animation");
+      assert.ok(!container.innerHTML.includes("animate-orb-fluid-idle"), "should disable fluid idle animation");
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- implement PR248A low-GPU interactive orb effects in `/voice`
- add feature flags in `OrbEffectsConfig` for:
  - `parallaxTilt`
  - `interactiveGlow`
  - `clickShockwave`
- add Tailwind `orb-shockwave` keyframes/animation
- add state-aware interaction guardrails (`offline`/`error` disabled, `reducedMotion` safe path)
- expand `VoiceOrb` component tests for interaction paths
- sync EN/PL docs to reflect the current 2D orb architecture and PR248A behavior

## Validation
- `make pr-fast` ✅
- `node --import tsx --import ./tests/component-test-setup.ts --test --test-concurrency=1 --test-reporter=spec tests/voice-orb.component.test.tsx` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nowe funkcje**
  * Interaktywne efekty dla ekranu voice: parallax tilt, interaktywny glow i click shockwave; respektują stany runtime i ustawienie reducedMotion.
  * Nowe animacje orbu: breath, fluid idle i plasma gradient; dynamiczne warstwy wizualne dla stanów (np. recording, thinking).

* **Testy**
  * Dodano testy stabilności układu i zachowania interakcji dla orba.

* **Dokumentacja**
  * Zaktualizowano przewodnik i opis runtime voice, zasady aktywacji efektów i wymagania dokumentacyjne.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mpieniak01/Venom/pull/515?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->